### PR TITLE
fix: support uppercase file extensions in import dialog

### DIFF
--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -33,7 +33,7 @@ export function HomePage() {
       const selected = await open({
         multiple: true,
         filters: [
-          { name: "Books", extensions: ["epub", "pdf", "mobi", "azw", "azw3", "fb2", "fbz", "txt"] },
+          { name: "Books", extensions: ["epub", "EPUB", "pdf", "PDF", "mobi", "MOBI", "azw", "AZW", "azw3", "AZW3", "fb2", "FB2", "fbz", "FBZ", "txt", "TXT"] },
         ],
       } as const);
       if (selected) {


### PR DESCRIPTION
## Problem

The file picker dialog filters only lowercase extensions (`epub`, `pdf`, etc.). On Linux (GTK file chooser) and case-sensitive file systems, files with uppercase extensions such as `.PDF`, `.EPUB`, `.MOBI` are hidden and cannot be selected through the dialog.

## Root Cause

`HomePage.tsx` passes a fixed lowercase extension list to the Tauri `open()` dialog:

```ts
// Before
extensions: ["epub", "pdf", "mobi", "azw", "azw3", "fb2", "fbz", "txt"]
```

Note that drag-and-drop in `ImportDropZone.tsx` already handles this correctly via `.toLowerCase()`, so the behavior was inconsistent between the two import methods.

## Fix

Add uppercase variants to the dialog filter:

```ts
// After
extensions: ["epub", "EPUB", "pdf", "PDF", "mobi", "MOBI", "azw", "AZW", "azw3", "AZW3", "fb2", "FB2", "fbz", "FBZ", "txt", "TXT"]
```

## Test

- Files with uppercase extensions (`.PDF`, `.EPUB`) now appear in the import dialog on Linux
- Drag-and-drop behavior unchanged