### PR TITLE
feat(reader): polish mobile reader experience

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -32,6 +32,39 @@
       width: 100%;
       height: 100%;
       position: relative;
+      overflow: hidden;
+    }
+
+    #pull-bookmark-indicator {
+      position: absolute;
+      left: 50%;
+      top: 0;
+      transform: translate(-50%, -12px) scale(0.96);
+      opacity: 0;
+      pointer-events: none;
+      z-index: 30;
+      transition: opacity 140ms ease, transform 180ms ease;
+    }
+
+    #pull-bookmark-indicator .pill {
+      min-width: 164px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: rgba(28, 28, 30, 0.88);
+      color: #f5f5f7;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      text-align: center;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+
+    #pull-bookmark-indicator[data-armed="true"] .pill {
+      background: rgba(59, 130, 246, 0.92);
+      color: white;
     }
 
     #loading {
@@ -89,6 +122,9 @@
 
 <body>
   <div id="reader-container">
+    <div id="pull-bookmark-indicator" aria-hidden="true" data-armed="false">
+      <div class="pill" id="pull-bookmark-indicator-text"></div>
+    </div>
     <div id="loading">
       <div class="spinner"></div>
       <div id="loading-text">Loading...</div>
@@ -117,9 +153,83 @@
     let currentThemeColors = { bg: '#1c1c1e', fg: '#e8e8ed', muted: '#7c7c82', primary: '#3b82f6' };
     let lastRendererStyles = '';
     let tapNavigationInFlight = false;
+    let tapNavigationResetTimer = null;
+    let readerElement = null;
+    let bookmarkPullGestureActive = false;
+    let pullBookmarkResetTimer = null;
+    let bookmarkPullStateMeta = {
+      bookmarked: false,
+      pullToAdd: '下滑添加书签',
+      releaseToAdd: '松手添加书签',
+      pullToRemove: '下滑删除书签',
+      releaseToRemove: '松手删除书签',
+    };
 
     // Store user annotations for re-rendering on page change
     const userAnnotations = new Map();
+
+    function clearTapNavigationLock() {
+      tapNavigationInFlight = false;
+      if (tapNavigationResetTimer) {
+        clearTimeout(tapNavigationResetTimer);
+        tapNavigationResetTimer = null;
+      }
+    }
+
+    function armTapNavigationLock() {
+      tapNavigationInFlight = true;
+      if (tapNavigationResetTimer) clearTimeout(tapNavigationResetTimer);
+      tapNavigationResetTimer = setTimeout(() => {
+        clearTapNavigationLock();
+      }, 220);
+    }
+
+    function getPullBookmarkElements() {
+      return {
+        indicator: document.getElementById('pull-bookmark-indicator'),
+        text: document.getElementById('pull-bookmark-indicator-text'),
+      };
+    }
+
+    function getPullBookmarkLabel(armed) {
+      if (bookmarkPullStateMeta.bookmarked) {
+        return armed ? bookmarkPullStateMeta.releaseToRemove : bookmarkPullStateMeta.pullToRemove;
+      }
+      return armed ? bookmarkPullStateMeta.releaseToAdd : bookmarkPullStateMeta.pullToAdd;
+    }
+
+    function setReaderTranslateY(offset, animated) {
+      return;
+    }
+
+    function updatePullBookmarkUI(offset, armed) {
+      const { indicator, text } = getPullBookmarkElements();
+      const pullOffset = Math.max(0, Math.min(offset, 72));
+      const easedOffset = Math.round(Math.min(58, pullOffset * 0.78));
+      bookmarkPullGestureActive = pullOffset > 0;
+      if (text) text.textContent = getPullBookmarkLabel(armed);
+      if (indicator) {
+        indicator.dataset.armed = armed ? 'true' : 'false';
+        indicator.style.opacity = String(Math.min(1, pullOffset / 18));
+        indicator.style.transform =
+          `translate(-50%, ${Math.min(24, -12 + easedOffset * 0.68)}px) scale(${0.96 + Math.min(0.08, pullOffset / 360)})`;
+      }
+      setReaderTranslateY(easedOffset, false);
+      postToRN('bookmarkPull', { offset: easedOffset, armed, active: pullOffset > 0 });
+    }
+
+    function resetPullBookmarkUI(animated) {
+      const { indicator, text } = getPullBookmarkElements();
+      bookmarkPullGestureActive = false;
+      if (text) text.textContent = getPullBookmarkLabel(false);
+      if (indicator) {
+        indicator.dataset.armed = 'false';
+        indicator.style.opacity = '0';
+        indicator.style.transform = 'translate(-50%, -12px) scale(0.96)';
+      }
+      setReaderTranslateY(0, animated !== false);
+      postToRN('bookmarkPull', { offset: 0, armed: false, active: false });
+    }
 
     // Note tooltip registry: per-doc WeakMap of cfi -> { range, note }
     const docNoteRegistries = new WeakMap();
@@ -328,14 +438,17 @@
         currentBook = book;
 
         const el = document.createElement('foliate-view');
+        readerElement = el;
         el.style.width = '100%';
         el.style.height = '100%';
+        resetPullBookmarkUI(false);
 
         el.addEventListener('load', (e) => {
           const { doc, index } = e.detail;
           loading.classList.add('hidden');
           applyDocStyles(doc);
           attachTapListener(doc);
+          attachPullBookmarkListener(doc);
           attachSelectionListener(doc);
           attachNoteLongPress(doc);
           attachContinuousScrollListener(doc);
@@ -354,7 +467,7 @@
           const detail = e.detail;
           if (tapNavigationInFlight) {
             setTimeout(() => {
-              tapNavigationInFlight = false;
+              clearTapNavigationLock();
             }, 80);
           }
           if (detail.section != null) {
@@ -677,6 +790,10 @@ a { color: ${primary} !important; }
       let tapState = null;
 
       doc.addEventListener('touchstart', (e) => {
+        if (bookmarkPullGestureActive) {
+          tapState = null;
+          return;
+        }
         if (e.touches.length !== 1) {
           tapState = null;
           return;
@@ -693,6 +810,10 @@ a { color: ${primary} !important; }
 
       doc.addEventListener('touchmove', (e) => {
         if (!tapState || e.touches.length !== 1) return;
+        if (bookmarkPullGestureActive) {
+          tapState = null;
+          return;
+        }
         const touch = e.touches[0];
         if (
           Math.abs(touch.clientX - tapState.startX) > MOVE_THRESHOLD ||
@@ -707,7 +828,7 @@ a { color: ${primary} !important; }
       }, { passive: true });
 
       doc.addEventListener('touchend', (e) => {
-        if (tapNavigationInFlight) {
+        if (bookmarkPullGestureActive || tapNavigationInFlight) {
           tapState = null;
           return;
         }
@@ -743,7 +864,7 @@ a { color: ${primary} !important; }
           return;
         }
 
-        tapNavigationInFlight = true;
+        armTapNavigationLock();
         e.preventDefault();
         e.stopPropagation();
         const dir = currentBook && currentBook.dir === 'rtl' ? 'rtl' : 'ltr';
@@ -760,6 +881,119 @@ a { color: ${primary} !important; }
           }
         }
       }, { passive: false, capture: true });
+    }
+
+    function attachPullBookmarkListener(doc) {
+      if (doc.__readany_pullBookmark) return;
+      doc.__readany_pullBookmark = true;
+
+      const ACTIVATE_DISTANCE = 10;
+      const INTENT_THRESHOLD = 14;
+      const VERTICAL_INTENT_RATIO = 1.35;
+      const HORIZONTAL_CANCEL_RATIO = 1.05;
+      const PULL_THRESHOLD = 60;
+      const MAX_PULL_DISTANCE = 92;
+      const COOLDOWN_MS = 700;
+      let pullState = null;
+      let lastTriggeredAt = 0;
+
+      doc.addEventListener('touchstart', (e) => {
+        if (!view || e.touches.length !== 1) {
+          pullState = null;
+          return;
+        }
+
+        const target = e.target;
+        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) {
+          pullState = null;
+          return;
+        }
+
+        const sel = doc.getSelection();
+        if (sel && !sel.isCollapsed && sel.toString().trim().length > 0) {
+          pullState = null;
+          return;
+        }
+
+        const touch = e.touches[0];
+        pullState = {
+          startX: touch.clientX,
+          startY: touch.clientY,
+          active: false,
+          armed: false,
+          cancelled: false,
+        };
+      }, { passive: true, capture: true });
+
+      doc.addEventListener('touchmove', (e) => {
+        if (!pullState || e.touches.length !== 1) return;
+        const touch = e.touches[0];
+        const deltaX = touch.clientX - pullState.startX;
+        const deltaY = touch.clientY - pullState.startY;
+        const absX = Math.abs(deltaX);
+        const absY = Math.abs(deltaY);
+
+        if (pullState.cancelled) return;
+
+        if (!pullState.active) {
+          if (absX < INTENT_THRESHOLD && absY < INTENT_THRESHOLD) return;
+
+          if (
+            absX >= Math.max(INTENT_THRESHOLD, absY * HORIZONTAL_CANCEL_RATIO) ||
+            deltaY < -INTENT_THRESHOLD / 2
+          ) {
+            pullState.cancelled = true;
+            resetPullBookmarkUI(false);
+            return;
+          }
+
+          if (deltaY < ACTIVATE_DISTANCE) return;
+          if (absY < Math.max(INTENT_THRESHOLD, absX * VERTICAL_INTENT_RATIO)) return;
+
+          pullState.active = true;
+        }
+
+        if (deltaY <= 0) {
+          resetPullBookmarkUI(false);
+          return;
+        }
+
+        const armed = deltaY >= PULL_THRESHOLD;
+        pullState.armed = armed;
+        e.preventDefault();
+        e.stopPropagation();
+        updatePullBookmarkUI(Math.min(MAX_PULL_DISTANCE, deltaY), armed);
+      }, { passive: false, capture: true });
+
+      doc.addEventListener('touchend', (e) => {
+        const state = pullState;
+        pullState = null;
+        if (!state) return;
+
+        if (state.active) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+
+        const shouldToggle =
+          !!state.active &&
+          !!state.armed &&
+          !state.cancelled &&
+          e.changedTouches.length === 1 &&
+          Date.now() - lastTriggeredAt >= COOLDOWN_MS;
+
+        resetPullBookmarkUI(true);
+
+        if (shouldToggle) {
+          lastTriggeredAt = Date.now();
+          postToRN('toggleBookmark', {});
+        }
+      }, { passive: false, capture: true });
+
+      doc.addEventListener('touchcancel', () => {
+        pullState = null;
+        resetPullBookmarkUI(true);
+      }, { passive: true, capture: true });
     }
 
     // ─── Selection detection ───
@@ -1132,6 +1366,14 @@ a { color: ${primary} !important; }
     window.requestPageSnippet = function () {
       var snippet = getVisibleTextSnippet(80);
       postToRN('bookmarkSnippet', { textSnippet: snippet || '' });
+    };
+    window.setBookmarkPullState = function (params) {
+      bookmarkPullStateMeta = {
+        ...bookmarkPullStateMeta,
+        ...(params || {}),
+      };
+      const { text } = getPullBookmarkElements();
+      if (text) text.textContent = getPullBookmarkLabel(false);
     };
     window.getVisibleText = function () {
       var result = doGetVisibleText();

--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -152,6 +152,7 @@
     let totalSections = 0;
     let currentThemeColors = { bg: '#1c1c1e', fg: '#e8e8ed', muted: '#7c7c82', primary: '#3b82f6' };
     let lastRendererStyles = '';
+    let currentViewMode = 'paginated';
     let tapNavigationInFlight = false;
     let tapNavigationResetTimer = null;
     let readerElement = null;
@@ -706,6 +707,7 @@
       }
 
       if (settings.viewMode) {
+        currentViewMode = settings.viewMode;
         if (settings.viewMode === 'scroll') {
           renderer.setAttribute('flow', 'scrolled');
           renderer.setAttribute('max-inline-size', '9999px');
@@ -898,7 +900,7 @@ a { color: ${primary} !important; }
       let lastTriggeredAt = 0;
 
       doc.addEventListener('touchstart', (e) => {
-        if (!view || e.touches.length !== 1) {
+        if (!view || e.touches.length !== 1 || currentViewMode === 'scroll') {
           pullState = null;
           return;
         }

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -32,6 +32,39 @@
       width: 100%;
       height: 100%;
       position: relative;
+      overflow: hidden;
+    }
+
+    #pull-bookmark-indicator {
+      position: absolute;
+      left: 50%;
+      top: 0;
+      transform: translate(-50%, -12px) scale(0.96);
+      opacity: 0;
+      pointer-events: none;
+      z-index: 30;
+      transition: opacity 140ms ease, transform 180ms ease;
+    }
+
+    #pull-bookmark-indicator .pill {
+      min-width: 164px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: rgba(28, 28, 30, 0.88);
+      color: #f5f5f7;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      text-align: center;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+
+    #pull-bookmark-indicator[data-armed="true"] .pill {
+      background: rgba(59, 130, 246, 0.92);
+      color: white;
     }
 
     #loading {
@@ -89,6 +122,9 @@
 
 <body>
   <div id="reader-container">
+    <div id="pull-bookmark-indicator" aria-hidden="true" data-armed="false">
+      <div class="pill" id="pull-bookmark-indicator-text"></div>
+    </div>
     <div id="loading">
       <div class="spinner"></div>
       <div id="loading-text">Loading...</div>
@@ -117,9 +153,83 @@
     let currentThemeColors = { bg: '#1c1c1e', fg: '#e8e8ed', muted: '#7c7c82', primary: '#3b82f6' };
     let lastRendererStyles = '';
     let tapNavigationInFlight = false;
+    let tapNavigationResetTimer = null;
+    let readerElement = null;
+    let bookmarkPullGestureActive = false;
+    let pullBookmarkResetTimer = null;
+    let bookmarkPullStateMeta = {
+      bookmarked: false,
+      pullToAdd: '下滑添加书签',
+      releaseToAdd: '松手添加书签',
+      pullToRemove: '下滑删除书签',
+      releaseToRemove: '松手删除书签',
+    };
 
     // Store user annotations for re-rendering on page change
     const userAnnotations = new Map();
+
+    function clearTapNavigationLock() {
+      tapNavigationInFlight = false;
+      if (tapNavigationResetTimer) {
+        clearTimeout(tapNavigationResetTimer);
+        tapNavigationResetTimer = null;
+      }
+    }
+
+    function armTapNavigationLock() {
+      tapNavigationInFlight = true;
+      if (tapNavigationResetTimer) clearTimeout(tapNavigationResetTimer);
+      tapNavigationResetTimer = setTimeout(() => {
+        clearTapNavigationLock();
+      }, 220);
+    }
+
+    function getPullBookmarkElements() {
+      return {
+        indicator: document.getElementById('pull-bookmark-indicator'),
+        text: document.getElementById('pull-bookmark-indicator-text'),
+      };
+    }
+
+    function getPullBookmarkLabel(armed) {
+      if (bookmarkPullStateMeta.bookmarked) {
+        return armed ? bookmarkPullStateMeta.releaseToRemove : bookmarkPullStateMeta.pullToRemove;
+      }
+      return armed ? bookmarkPullStateMeta.releaseToAdd : bookmarkPullStateMeta.pullToAdd;
+    }
+
+    function setReaderTranslateY(offset, animated) {
+      return;
+    }
+
+    function updatePullBookmarkUI(offset, armed) {
+      const { indicator, text } = getPullBookmarkElements();
+      const pullOffset = Math.max(0, Math.min(offset, 72));
+      const easedOffset = Math.round(Math.min(58, pullOffset * 0.78));
+      bookmarkPullGestureActive = pullOffset > 0;
+      if (text) text.textContent = getPullBookmarkLabel(armed);
+      if (indicator) {
+        indicator.dataset.armed = armed ? 'true' : 'false';
+        indicator.style.opacity = String(Math.min(1, pullOffset / 18));
+        indicator.style.transform =
+          `translate(-50%, ${Math.min(24, -12 + easedOffset * 0.68)}px) scale(${0.96 + Math.min(0.08, pullOffset / 360)})`;
+      }
+      setReaderTranslateY(easedOffset, false);
+      postToRN('bookmarkPull', { offset: easedOffset, armed, active: pullOffset > 0 });
+    }
+
+    function resetPullBookmarkUI(animated) {
+      const { indicator, text } = getPullBookmarkElements();
+      bookmarkPullGestureActive = false;
+      if (text) text.textContent = getPullBookmarkLabel(false);
+      if (indicator) {
+        indicator.dataset.armed = 'false';
+        indicator.style.opacity = '0';
+        indicator.style.transform = 'translate(-50%, -12px) scale(0.96)';
+      }
+      setReaderTranslateY(0, animated !== false);
+      postToRN('bookmarkPull', { offset: 0, armed: false, active: false });
+    }
 
     // Note tooltip registry: per-doc WeakMap of cfi -> { range, note }
     const docNoteRegistries = new WeakMap();
@@ -328,14 +438,17 @@
         currentBook = book;
 
         const el = document.createElement('foliate-view');
+        readerElement = el;
         el.style.width = '100%';
         el.style.height = '100%';
+        resetPullBookmarkUI(false);
 
         el.addEventListener('load', (e) => {
           const { doc, index } = e.detail;
           loading.classList.add('hidden');
           applyDocStyles(doc);
           attachTapListener(doc);
+          attachPullBookmarkListener(doc);
           attachSelectionListener(doc);
           attachNoteLongPress(doc);
           attachContinuousScrollListener(doc);
@@ -354,7 +467,7 @@
           const detail = e.detail;
           if (tapNavigationInFlight) {
             setTimeout(() => {
-              tapNavigationInFlight = false;
+              clearTapNavigationLock();
             }, 80);
           }
           if (detail.section != null) {
@@ -677,6 +790,10 @@ a { color: ${primary} !important; }
       let tapState = null;
 
       doc.addEventListener('touchstart', (e) => {
+        if (bookmarkPullGestureActive) {
+          tapState = null;
+          return;
+        }
         if (e.touches.length !== 1) {
           tapState = null;
           return;
@@ -693,6 +810,10 @@ a { color: ${primary} !important; }
 
       doc.addEventListener('touchmove', (e) => {
         if (!tapState || e.touches.length !== 1) return;
+        if (bookmarkPullGestureActive) {
+          tapState = null;
+          return;
+        }
         const touch = e.touches[0];
         if (
           Math.abs(touch.clientX - tapState.startX) > MOVE_THRESHOLD ||
@@ -707,7 +828,7 @@ a { color: ${primary} !important; }
       }, { passive: true });
 
       doc.addEventListener('touchend', (e) => {
-        if (tapNavigationInFlight) {
+        if (bookmarkPullGestureActive || tapNavigationInFlight) {
           tapState = null;
           return;
         }
@@ -743,7 +864,7 @@ a { color: ${primary} !important; }
           return;
         }
 
-        tapNavigationInFlight = true;
+        armTapNavigationLock();
         e.preventDefault();
         e.stopPropagation();
         const dir = currentBook && currentBook.dir === 'rtl' ? 'rtl' : 'ltr';
@@ -760,6 +881,119 @@ a { color: ${primary} !important; }
           }
         }
       }, { passive: false, capture: true });
+    }
+
+    function attachPullBookmarkListener(doc) {
+      if (doc.__readany_pullBookmark) return;
+      doc.__readany_pullBookmark = true;
+
+      const ACTIVATE_DISTANCE = 10;
+      const INTENT_THRESHOLD = 14;
+      const VERTICAL_INTENT_RATIO = 1.35;
+      const HORIZONTAL_CANCEL_RATIO = 1.05;
+      const PULL_THRESHOLD = 60;
+      const MAX_PULL_DISTANCE = 92;
+      const COOLDOWN_MS = 700;
+      let pullState = null;
+      let lastTriggeredAt = 0;
+
+      doc.addEventListener('touchstart', (e) => {
+        if (!view || e.touches.length !== 1) {
+          pullState = null;
+          return;
+        }
+
+        const target = e.target;
+        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) {
+          pullState = null;
+          return;
+        }
+
+        const sel = doc.getSelection();
+        if (sel && !sel.isCollapsed && sel.toString().trim().length > 0) {
+          pullState = null;
+          return;
+        }
+
+        const touch = e.touches[0];
+        pullState = {
+          startX: touch.clientX,
+          startY: touch.clientY,
+          active: false,
+          armed: false,
+          cancelled: false,
+        };
+      }, { passive: true, capture: true });
+
+      doc.addEventListener('touchmove', (e) => {
+        if (!pullState || e.touches.length !== 1) return;
+        const touch = e.touches[0];
+        const deltaX = touch.clientX - pullState.startX;
+        const deltaY = touch.clientY - pullState.startY;
+        const absX = Math.abs(deltaX);
+        const absY = Math.abs(deltaY);
+
+        if (pullState.cancelled) return;
+
+        if (!pullState.active) {
+          if (absX < INTENT_THRESHOLD && absY < INTENT_THRESHOLD) return;
+
+          if (
+            absX >= Math.max(INTENT_THRESHOLD, absY * HORIZONTAL_CANCEL_RATIO) ||
+            deltaY < -INTENT_THRESHOLD / 2
+          ) {
+            pullState.cancelled = true;
+            resetPullBookmarkUI(false);
+            return;
+          }
+
+          if (deltaY < ACTIVATE_DISTANCE) return;
+          if (absY < Math.max(INTENT_THRESHOLD, absX * VERTICAL_INTENT_RATIO)) return;
+
+          pullState.active = true;
+        }
+
+        if (deltaY <= 0) {
+          resetPullBookmarkUI(false);
+          return;
+        }
+
+        const armed = deltaY >= PULL_THRESHOLD;
+        pullState.armed = armed;
+        e.preventDefault();
+        e.stopPropagation();
+        updatePullBookmarkUI(Math.min(MAX_PULL_DISTANCE, deltaY), armed);
+      }, { passive: false, capture: true });
+
+      doc.addEventListener('touchend', (e) => {
+        const state = pullState;
+        pullState = null;
+        if (!state) return;
+
+        if (state.active) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+
+        const shouldToggle =
+          !!state.active &&
+          !!state.armed &&
+          !state.cancelled &&
+          e.changedTouches.length === 1 &&
+          Date.now() - lastTriggeredAt >= COOLDOWN_MS;
+
+        resetPullBookmarkUI(true);
+
+        if (shouldToggle) {
+          lastTriggeredAt = Date.now();
+          postToRN('toggleBookmark', {});
+        }
+      }, { passive: false, capture: true });
+
+      doc.addEventListener('touchcancel', () => {
+        pullState = null;
+        resetPullBookmarkUI(true);
+      }, { passive: true, capture: true });
     }
 
     // ─── Selection detection ───
@@ -1132,6 +1366,14 @@ a { color: ${primary} !important; }
     window.requestPageSnippet = function () {
       var snippet = getVisibleTextSnippet(80);
       postToRN('bookmarkSnippet', { textSnippet: snippet || '' });
+    };
+    window.setBookmarkPullState = function (params) {
+      bookmarkPullStateMeta = {
+        ...bookmarkPullStateMeta,
+        ...(params || {}),
+      };
+      const { text } = getPullBookmarkElements();
+      if (text) text.textContent = getPullBookmarkLabel(false);
     };
     window.getVisibleText = function () {
       var result = doGetVisibleText();

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -152,6 +152,7 @@
     let totalSections = 0;
     let currentThemeColors = { bg: '#1c1c1e', fg: '#e8e8ed', muted: '#7c7c82', primary: '#3b82f6' };
     let lastRendererStyles = '';
+    let currentViewMode = 'paginated';
     let tapNavigationInFlight = false;
     let tapNavigationResetTimer = null;
     let readerElement = null;
@@ -706,6 +707,7 @@
       }
 
       if (settings.viewMode) {
+        currentViewMode = settings.viewMode;
         if (settings.viewMode === 'scroll') {
           renderer.setAttribute('flow', 'scrolled');
           renderer.setAttribute('max-inline-size', '9999px');
@@ -898,7 +900,7 @@ a { color: ${primary} !important; }
       let lastTriggeredAt = 0;
 
       doc.addEventListener('touchstart', (e) => {
-        if (!view || e.touches.length !== 1) {
+        if (!view || e.touches.length !== 1 || currentViewMode === 'scroll') {
           pullState = null;
           return;
         }

--- a/packages/app-expo/package.json
+++ b/packages/app-expo/package.json
@@ -15,12 +15,17 @@
     }
   },
   "scripts": {
+    "prestart": "pnpm run build:reader",
     "start": "expo start",
+    "preandroid": "pnpm run build:reader",
     "android": "expo run:android",
+    "preios": "pnpm run build:reader",
     "ios": "expo run:ios",
+    "preprebuild": "pnpm run build:reader",
     "prebuild": "expo prebuild",
     "build:reader": "node scripts/build-reader.js",
     "lint": "biome check .",
+    "eas-build-post-install": "pnpm run build:reader",
     "eas:build:android": "eas build --platform android",
     "eas:build:ios": "eas build --platform ios"
   },

--- a/packages/app-expo/src/components/reader/BookmarkRibbon.tsx
+++ b/packages/app-expo/src/components/reader/BookmarkRibbon.tsx
@@ -5,13 +5,14 @@ import Svg, { Path } from "react-native-svg";
 
 interface BookmarkRibbonProps {
   visible: boolean;
+  topOffset?: number;
 }
 
 /**
  * A bookmark ribbon shown at the top-right of the reader page
  * when the current position is bookmarked.
  */
-export function BookmarkRibbon({ visible }: BookmarkRibbonProps) {
+export function BookmarkRibbon({ visible, topOffset = 0 }: BookmarkRibbonProps) {
   const colors = useColors();
   const anim = useRef(new Animated.Value(visible ? 1 : 0)).current;
 
@@ -33,7 +34,7 @@ export function BookmarkRibbon({ visible }: BookmarkRibbonProps) {
   return (
     <Animated.View
       pointerEvents="none"
-      style={[styles.container, { opacity, transform: [{ translateY }] }]}
+      style={[styles.container, { top: topOffset, opacity, transform: [{ translateY }] }]}
     >
       <Svg width={14} height={60} viewBox="0 0 14 60">
         <Path d="M0 0h14v54l-7-4-7 4V0z" fill={colors.primary} />

--- a/packages/app-expo/src/components/ui/Icon.tsx
+++ b/packages/app-expo/src/components/ui/Icon.tsx
@@ -50,6 +50,16 @@ export const MessageSquareIcon = icon(() => (
   </>
 ));
 
+export const BotIcon = icon(() => (
+  <>
+    <Rect x="4" y="7" width="16" height="12" rx="4" />
+    <Path d="M12 3v4" />
+    <Path d="M8 12h.01" />
+    <Path d="M16 12h.01" />
+    <Path d="M9 16c.8.6 1.8 1 3 1s2.2-.4 3-1" />
+  </>
+));
+
 export const NotebookPenIcon = icon(() => (
   <>
     <Path d="M13.4 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7.4" />
@@ -179,6 +189,15 @@ export const Volume2Icon = icon(() => (
     <Path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
     <Path d="M16 9a5 5 0 0 1 0 6" />
     <Path d="M19.364 18.364a9 9 0 0 0 0-12.728" />
+  </>
+));
+
+export const HeadphonesIcon = icon(() => (
+  <>
+    <Path d="M4 13a8 8 0 0 1 16 0" />
+    <Rect x="3" y="12" width="4" height="7" rx="2" />
+    <Rect x="17" y="12" width="4" height="7" rx="2" />
+    <Path d="M7 19v1a2 2 0 0 0 2 2h6" />
   </>
 ));
 

--- a/packages/app-expo/src/hooks/use-reader-bridge.ts
+++ b/packages/app-expo/src/hooks/use-reader-bridge.ts
@@ -28,6 +28,12 @@ export interface SelectionEvent {
   };
 }
 
+export interface BookmarkPullEvent {
+  offset: number;
+  armed: boolean;
+  active: boolean;
+}
+
 export interface ReaderBridgeCallbacks {
   onRelocate?: (detail: RelocateEvent) => void;
   onTocReady?: (items: TOCItem[]) => void;
@@ -52,6 +58,7 @@ export interface ReaderBridgeCallbacks {
   onPageSnippet?: (text: string) => void;
   onBookmarkSnippet?: (text: string) => void;
   onToggleBookmark?: () => void;
+  onBookmarkPull?: (detail: BookmarkPullEvent) => void;
 }
 
 export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
@@ -192,6 +199,19 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
   const setNavigationLocked = useCallback(
     (locked: boolean) => {
       inject(`window.setNavigationLocked(${locked})`);
+    },
+    [inject],
+  );
+
+  const setBookmarkPullState = useCallback(
+    (params: {
+      bookmarked: boolean;
+      pullToAdd: string;
+      releaseToAdd: string;
+      pullToRemove: string;
+      releaseToRemove: string;
+    }) => {
+      inject(`window.setBookmarkPullState(${JSON.stringify(params)})`);
     },
     [inject],
   );
@@ -432,6 +452,13 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
         case "toggleBookmark":
           cb.onToggleBookmark?.();
           break;
+        case "bookmarkPull":
+          cb.onBookmarkPull?.({
+            offset: typeof msg.offset === "number" ? msg.offset : 0,
+            armed: !!msg.armed,
+            active: !!msg.active,
+          });
+          break;
         case "visibleText":
           console.log(
             "[ReaderBridge] received visibleText:",
@@ -497,6 +524,7 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
       applySettings,
       setThemeColors,
       setNavigationLocked,
+      setBookmarkPullState,
       requestPageSnippet,
       getVisibleText,
       flashHighlight,
@@ -523,6 +551,7 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
       applySettings,
       setThemeColors,
       setNavigationLocked,
+      setBookmarkPullState,
       requestPageSnippet,
       getVisibleText,
       getChapterParagraphs,

--- a/packages/app-expo/src/hooks/use-reader-bridge.ts
+++ b/packages/app-expo/src/hooks/use-reader-bridge.ts
@@ -151,14 +151,16 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
 
   const addAnnotation = useCallback(
     (annotation: { value: string; type?: string; color?: string; note?: string }) => {
-      inject(`window.addAnnotation(${JSON.stringify(annotation)})`);
+      const msg = JSON.stringify({ type: "addAnnotation", annotation });
+      inject(`handleCommand(${msg})`);
     },
     [inject],
   );
 
   const removeAnnotation = useCallback(
     (annotation: { value: string }) => {
-      inject(`window.removeAnnotation(${JSON.stringify(annotation)})`);
+      const msg = JSON.stringify({ type: "removeAnnotation", annotation });
+      inject(`handleCommand(${msg})`);
     },
     [inject],
   );

--- a/packages/app-expo/src/screens/ReaderScreen.tsx
+++ b/packages/app-expo/src/screens/ReaderScreen.tsx
@@ -302,6 +302,7 @@ export function ReaderScreen({ route, navigation }: Props) {
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const TOOLBAR_HIDE_OFFSET = 200;
   const toolbarAnim = useRef(new Animated.Value(TOOLBAR_HIDE_OFFSET)).current;
+  const readerPullAnim = useRef(new Animated.Value(0)).current;
   const lastCfiRef = useRef<string>("");
   const progressRef = useRef(0);
   const locationHistoryRef = useRef<string[]>([]);
@@ -572,6 +573,18 @@ export function ReaderScreen({ route, navigation }: Props) {
     onToggleBookmark: () => {
       handleToggleBookmark();
     },
+    onBookmarkPull: ({ offset, active }) => {
+      if (active) {
+        readerPullAnim.setValue(offset);
+        return;
+      }
+
+      Animated.timing(readerPullAnim, {
+        toValue: 0,
+        duration: 180,
+        useNativeDriver: true,
+      }).start();
+    },
     onSearchResult: (index: number, count: number) => {
       setSearchIndex(index);
       setSearchResultCount(count);
@@ -650,6 +663,17 @@ export function ReaderScreen({ route, navigation }: Props) {
 
   bridgeRef.current = bridge;
   chapterTranslationBridgeRef.current = bridge;
+
+  useEffect(() => {
+    if (!webViewReady) return;
+    bridge.setBookmarkPullState({
+      bookmarked: isBookmarked,
+      pullToAdd: t("bookmarks.pullToAdd", "下滑添加书签"),
+      releaseToAdd: t("bookmarks.releaseToAdd", "松手添加书签"),
+      pullToRemove: t("bookmarks.pullToRemove", "下滑删除书签"),
+      releaseToRemove: t("bookmarks.releaseToRemove", "松手删除书签"),
+    });
+  }, [bridge, isBookmarked, t, webViewReady]);
 
   // Sync webViewRefForVisibility when WebView is ready
   useEffect(() => {
@@ -1047,43 +1071,64 @@ export function ReaderScreen({ route, navigation }: Props) {
     : null;
 
   return (
-    <View style={[s.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
-      {/* WebView with foliate-js */}
-      <View style={{ flex: 1 }}>
-        <WebView
-          ref={bridge.webViewRef}
-          source={{ uri: readerHtmlUri }}
-          style={[s.webview, { marginTop: 24 }]}
-          pointerEvents={isPanelOpen ? "none" : "auto"}
-          onMessage={bridge.handleMessage}
-          onError={(e) => {
-            console.error("[ReaderScreen] WebView error:", e.nativeEvent);
-          }}
-          onHttpError={(e) => {
-            console.error("[ReaderScreen] WebView HTTP error:", e.nativeEvent);
-          }}
-          onContentProcessDidTerminate={() => {
-            console.warn("[ReaderScreen] WebView content process terminated");
-          }}
-          javaScriptEnabled
-          domStorageEnabled
-          allowFileAccess
-          allowFileAccessFromFileURLs
-          allowUniversalAccessFromFileURLs
-          allowsInlineMediaPlayback
-          scrollEnabled={false}
-          showsVerticalScrollIndicator={false}
-          originWhitelist={["*"]}
-          mixedContentMode="always"
-        />
-      </View>
-
-      {/* Loading overlay */}
-      {loading && (
-        <View style={s.loadingOverlay}>
-          <ActivityIndicator size="large" color={colors.primary} />
+    <View style={[s.container, { paddingBottom: insets.bottom }]}>
+      <Animated.View
+        style={[s.readerStage, { transform: [{ translateY: readerPullAnim }] }]}
+        pointerEvents="box-none"
+      >
+        {/* WebView with foliate-js */}
+        <View style={{ flex: 1 }}>
+          <WebView
+            ref={bridge.webViewRef}
+            source={{ uri: readerHtmlUri }}
+            style={[s.webview, { marginTop: insets.top + 24 }]}
+            pointerEvents={isPanelOpen ? "none" : "auto"}
+            onMessage={bridge.handleMessage}
+            onError={(e) => {
+              console.error("[ReaderScreen] WebView error:", e.nativeEvent);
+            }}
+            onHttpError={(e) => {
+              console.error("[ReaderScreen] WebView HTTP error:", e.nativeEvent);
+            }}
+            onContentProcessDidTerminate={() => {
+              console.warn("[ReaderScreen] WebView content process terminated");
+            }}
+            javaScriptEnabled
+            domStorageEnabled
+            allowFileAccess
+            allowFileAccessFromFileURLs
+            allowUniversalAccessFromFileURLs
+            allowsInlineMediaPlayback
+            scrollEnabled={false}
+            showsVerticalScrollIndicator={false}
+            originWhitelist={["*"]}
+            mixedContentMode="always"
+          />
         </View>
-      )}
+
+        {/* Loading overlay */}
+        {loading && (
+          <View style={s.loadingOverlay}>
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
+        )}
+
+        {/* ─── Top Info Bar (always visible) ─── */}
+        {!showSearch && (
+          <View style={[s.topInfoBar, { top: insets.top }]}>
+            <Text style={s.topInfoText} numberOfLines={1}>
+              {currentChapter || bookTitle}
+            </Text>
+            <Text style={s.topInfoPageText}>
+              {currentPage > 0 && totalPages > 0 ? `${currentPage}/${totalPages}` : ""}
+            </Text>
+          </View>
+        )}
+
+      </Animated.View>
+
+      {/* ─── Bookmark Ribbon (top-right) ─── */}
+      <BookmarkRibbon visible={isBookmarked} topOffset={0} />
 
       {/* Selection Popover */}
       {selection && (
@@ -1191,21 +1236,6 @@ export function ReaderScreen({ route, navigation }: Props) {
           </View>
         </TouchableOpacity>
       )}
-
-      {/* ─── Top Info Bar (always visible) ─── */}
-      {!showSearch && (
-        <View style={[s.topInfoBar, { top: insets.top }]}>
-          <Text style={s.topInfoText} numberOfLines={1}>
-            {currentChapter || bookTitle}
-          </Text>
-          <Text style={s.topInfoPageText}>
-            {currentPage > 0 && totalPages > 0 ? `${currentPage}/${totalPages}` : ""}
-          </Text>
-        </View>
-      )}
-
-      {/* ─── Bookmark Ribbon (top-right) ─── */}
-      <BookmarkRibbon visible={isBookmarked} />
 
       {/* ─── Bottom Toolbar (moved from top) ─── */}
       {!showSearch && (
@@ -1998,6 +2028,7 @@ const noteTooltipMdStyles = {
 const makeStyles = (colors: ThemeColors) =>
   StyleSheet.create({
     container: { flex: 1, backgroundColor: colors.background },
+    readerStage: { flex: 1 },
     webview: { flex: 1 },
     loadingWrap: { flex: 1, alignItems: "center", justifyContent: "center", gap: 12 },
     loadingText: { fontSize: fontSize.sm, color: colors.mutedForeground },

--- a/packages/app-expo/src/screens/ReaderScreen.tsx
+++ b/packages/app-expo/src/screens/ReaderScreen.tsx
@@ -5,6 +5,7 @@ import { SelectionPopover } from "@/components/reader/SelectionPopover";
 import { TTSControls } from "@/components/reader/TTSControls";
 import { TranslationPanel } from "@/components/reader/TranslationPanel";
 import {
+  BotIcon,
   BookmarkFilledIcon,
   BookmarkIcon,
   CheckIcon,
@@ -12,12 +13,11 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   EditIcon,
+  HeadphonesIcon,
   LanguagesIcon,
-  MessageSquareIcon,
   NotebookPenIcon,
   SearchIcon,
   Trash2Icon,
-  Volume2Icon,
   XIcon,
 } from "@/components/ui/Icon";
 import { RichTextEditor } from "@/components/ui/RichTextEditor";
@@ -32,7 +32,14 @@ import {
   useTTSStore,
 } from "@/stores";
 import { useTheme } from "@/styles/ThemeContext";
-import { type ThemeColors, fontSize, fontWeight, radius, useColors } from "@/styles/theme";
+import {
+  type ThemeColors,
+  fontSize,
+  fontWeight,
+  radius,
+  useColors,
+  withOpacity,
+} from "@/styles/theme";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { readingContextService } from "@readany/core/ai/reading-context-service";
 import { runWithDbRetry } from "@readany/core/db/write-retry";
@@ -60,6 +67,7 @@ import {
   Alert,
   Animated,
   Dimensions,
+  Easing,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -221,6 +229,10 @@ export function ReaderScreen({ route, navigation }: Props) {
   const { bookId, cfi, highlight: shouldHighlight } = route.params;
   const { t, i18n } = useTranslation();
   const insets = useSafeAreaInsets();
+  const isWideLayout = SCREEN_WIDTH >= 768;
+  const isIPadLayout = Platform.OS === "ios" && Platform.isPad;
+  const shouldToggleSystemStatusBar = !isIPadLayout;
+  const baseTopInset = Platform.OS === "ios" ? 20 : 24;
 
   // State
   const [loading, setLoading] = useState(true);
@@ -252,6 +264,9 @@ export function ReaderScreen({ route, navigation }: Props) {
   const [currentCfi, setCurrentCfi] = useState("");
   const [pageSnippet, setPageSnippet] = useState("");
   const [selection, setSelection] = useState<SelectionEvent | null>(null);
+  const [stableTopInset, setStableTopInset] = useState(() =>
+    Math.max(insets.top, isIPadLayout ? 24 : baseTopInset)
+  );
   const [noteViewHighlight, setNoteViewHighlight] = useState<{
     id: string;
     text: string;
@@ -300,7 +315,7 @@ export function ReaderScreen({ route, navigation }: Props) {
 
   const controlsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const TOOLBAR_HIDE_OFFSET = 200;
+const TOOLBAR_HIDE_OFFSET = 100;
   const toolbarAnim = useRef(new Animated.Value(TOOLBAR_HIDE_OFFSET)).current;
   const readerPullAnim = useRef(new Animated.Value(0)).current;
   const lastCfiRef = useRef<string>("");
@@ -441,13 +456,30 @@ export function ReaderScreen({ route, navigation }: Props) {
     addBookmark,
   ]);
 
-  // Hide status bar for immersive reading on mount, restore on unmount
+  // Keep the reserved top inset stable even when the system status bar hides.
   useEffect(() => {
-    setStatusBarHidden(true, "slide");
+    if (!shouldToggleSystemStatusBar) {
+      setStatusBarHidden(false, "none");
+      return;
+    }
+    setStatusBarHidden(!showControls && !showSearch, "slide");
+  }, [showControls, showSearch, shouldToggleSystemStatusBar]);
+
+  useEffect(() => {
     return () => {
       setStatusBarHidden(false, "slide");
     };
   }, []);
+
+  useEffect(() => {
+    const nextInset = Math.max(insets.top, isIPadLayout ? 24 : baseTopInset);
+    setStableTopInset((prev) => {
+      if (isIPadLayout) {
+        return Math.max(prev, nextInset);
+      }
+      return nextInset;
+    });
+  }, [baseTopInset, insets.top, isIPadLayout]);
 
   // Load reader HTML asset
   useEffect(() => {
@@ -845,25 +877,22 @@ export function ReaderScreen({ route, navigation }: Props) {
   const toggleControls = useCallback(() => {
     const willShow = !showControls;
     setShowControls(willShow);
-    // Sync status bar with controls visibility for immersive reading
-    setStatusBarHidden(!willShow, "slide");
-    Animated.spring(toolbarAnim, {
+    Animated.timing(toolbarAnim, {
       toValue: willShow ? 0 : TOOLBAR_HIDE_OFFSET,
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
-      friction: 20,
-      tension: 100,
     }).start();
 
     if (willShow) {
       if (controlsTimer.current) clearTimeout(controlsTimer.current);
       controlsTimer.current = setTimeout(() => {
         setShowControls(false);
-        setStatusBarHidden(true, "slide");
-        Animated.spring(toolbarAnim, {
+        Animated.timing(toolbarAnim, {
           toValue: TOOLBAR_HIDE_OFFSET,
+          duration: 180,
+          easing: Easing.out(Easing.cubic),
           useNativeDriver: true,
-          friction: 20,
-          tension: 100,
         }).start();
       }, CONTROLS_TIMEOUT);
     }
@@ -1063,7 +1092,35 @@ export function ReaderScreen({ route, navigation }: Props) {
     );
   }
 
+  const layoutTopInset = stableTopInset;
+  const topToolbarRowHeight = isWideLayout ? 62 : 48;
+  const bottomDockIconSize = isWideLayout ? 24 : 22;
+  const topToolbarIconSize = isWideLayout ? 24 : 22;
   const percent = Math.round(progress * 100);
+  const topControlsTranslate = toolbarAnim.interpolate({
+    inputRange: [0, TOOLBAR_HIDE_OFFSET],
+    outputRange: [0, -10],
+  });
+  const topControlsOpacity = toolbarAnim.interpolate({
+    inputRange: [0, TOOLBAR_HIDE_OFFSET * 0.5, TOOLBAR_HIDE_OFFSET],
+    outputRange: [1, 0.28, 0],
+  });
+  const bottomControlsTranslate = toolbarAnim.interpolate({
+    inputRange: [0, TOOLBAR_HIDE_OFFSET],
+    outputRange: [0, 12],
+  });
+  const bottomControlsOpacity = toolbarAnim.interpolate({
+    inputRange: [0, TOOLBAR_HIDE_OFFSET * 0.5, TOOLBAR_HIDE_OFFSET],
+    outputRange: [1, 0.28, 0],
+  });
+  const auxToolsTranslate = toolbarAnim.interpolate({
+    inputRange: [0, TOOLBAR_HIDE_OFFSET],
+    outputRange: [0, 14],
+  });
+  const auxToolsOpacity = toolbarAnim.interpolate({
+    inputRange: [0, TOOLBAR_HIDE_OFFSET * 0.55, TOOLBAR_HIDE_OFFSET],
+    outputRange: [1, 0.24, 0],
+  });
 
   const isPanelOpen = showTOC || showSettings || showSearch || showNotebook || showTranslation;
   const existingSelectionHighlight = selection
@@ -1081,7 +1138,7 @@ export function ReaderScreen({ route, navigation }: Props) {
           <WebView
             ref={bridge.webViewRef}
             source={{ uri: readerHtmlUri }}
-            style={[s.webview, { marginTop: insets.top + 24 }]}
+            style={[s.webview, { marginTop: layoutTopInset + 24 }]}
             pointerEvents={isPanelOpen ? "none" : "auto"}
             onMessage={bridge.handleMessage}
             onError={(e) => {
@@ -1114,8 +1171,8 @@ export function ReaderScreen({ route, navigation }: Props) {
         )}
 
         {/* ─── Top Info Bar (always visible) ─── */}
-        {!showSearch && (
-          <View style={[s.topInfoBar, { top: insets.top }]}>
+        {!showSearch && !showControls && (
+          <View style={[s.topInfoBar, { top: layoutTopInset }]}>
             <Text style={s.topInfoText} numberOfLines={1}>
               {currentChapter || bookTitle}
             </Text>
@@ -1129,6 +1186,65 @@ export function ReaderScreen({ route, navigation }: Props) {
 
       {/* ─── Bookmark Ribbon (top-right) ─── */}
       <BookmarkRibbon visible={isBookmarked} topOffset={0} />
+
+      {!showSearch && (
+        <Animated.View
+          pointerEvents={showControls ? "auto" : "none"}
+          style={[
+            s.topToolbar,
+            {
+              top: 0,
+              left: 0,
+              right: 0,
+              opacity: topControlsOpacity,
+              transform: [{ translateY: topControlsTranslate }],
+            },
+          ]}
+        >
+          <View
+            style={[
+              s.topToolbarBar,
+              {
+                paddingTop: layoutTopInset,
+                minHeight: layoutTopInset + topToolbarRowHeight,
+              },
+            ]}
+          >
+            <View
+              style={[
+                s.topToolbarRow,
+                {
+                  minHeight: topToolbarRowHeight,
+                  paddingLeft: insets.left + 12,
+                  paddingRight: insets.right + 16,
+                },
+              ]}
+            >
+              <View style={s.topToolbarSideSlot}>
+                <TouchableOpacity
+                  style={s.topToolbarBackBtn}
+                  onPress={() => navigation.reset({ routes: [{ name: "Tabs" }] })}
+                >
+                  <ChevronLeftIcon size={topToolbarIconSize} color={colors.foreground} />
+                </TouchableOpacity>
+              </View>
+              <View style={s.topToolbarTitleWrap}>
+                <Text style={s.topToolbarTitleText} numberOfLines={1}>
+                  {currentChapter || bookTitle}
+                </Text>
+              </View>
+              <View style={[s.topToolbarSideSlot, s.topToolbarMetaWrap]}>
+                <Text style={s.topToolbarMetaText}>
+                  {currentPage > 0 && totalPages > 0 ? `${currentPage}/${totalPages}` : `${percent}%`}
+                </Text>
+              </View>
+            </View>
+            <View style={s.topToolbarProgressTrack}>
+              <View style={[s.topToolbarProgressFill, { width: `${percent}%` }]} />
+            </View>
+          </View>
+        </Animated.View>
+      )}
 
       {/* Selection Popover */}
       {selection && (
@@ -1237,92 +1353,121 @@ export function ReaderScreen({ route, navigation }: Props) {
         </TouchableOpacity>
       )}
 
-      {/* ─── Bottom Toolbar (moved from top) ─── */}
       {!showSearch && (
-        <Animated.View style={[s.bottomToolbar, { transform: [{ translateY: toolbarAnim }] }]}>
-          <View style={[s.bottomToolbarGlass, { marginBottom: insets.bottom + 4 }]}>
-            <View style={s.toolbarRow}>
+        <Animated.View
+          pointerEvents={showControls ? "auto" : "none"}
+          style={[
+            s.floatingTools,
+            {
+              right: insets.right + 16,
+              bottom: insets.bottom + 110,
+              opacity: auxToolsOpacity,
+              transform: [{ translateY: auxToolsTranslate }],
+            },
+          ]}
+        >
+          <TouchableOpacity
+            style={[
+              s.floatingToolBtn,
+              (showChapterTranslation || chapterTranslation.state.status !== "idle") &&
+                s.floatingToolBtnActive,
+            ]}
+            onPress={() => setShowChapterTranslation(true)}
+          >
+            <LanguagesIcon size={18} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[s.floatingToolBtn, showTTS && s.floatingToolBtnActive]}
+            onPress={handleToggleTTS}
+          >
+            <HeadphonesIcon size={20} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={s.floatingToolBtn}
+            onPress={() => navigation.navigate("BookChat", { bookId })}
+          >
+            <BotIcon size={20} color="#fff" />
+          </TouchableOpacity>
+        </Animated.View>
+      )}
+
+      {/* ─── Bottom Toolbar ─── */}
+      {!showSearch && (
+        <Animated.View
+          pointerEvents={showControls ? "auto" : "none"}
+          style={[
+            s.bottomToolbar,
+            {
+              left: 0,
+              right: 0,
+              opacity: bottomControlsOpacity,
+              transform: [{ translateY: bottomControlsTranslate }],
+            },
+          ]}
+        >
+          <View
+            style={[
+              s.bottomToolbarGlass,
+              {
+                paddingBottom: Math.max(insets.bottom, 8) + 6,
+                paddingLeft: insets.left + 18,
+                paddingRight: insets.right + 18,
+              },
+            ]}
+          >
+            <View style={s.bottomToolbarProgressTrack}>
+              <View style={[s.bottomToolbarProgressFill, { width: `${percent}%` }]} />
+            </View>
+            <View style={s.bottomDockRow}>
               <TouchableOpacity
-                style={s.toolbarBtn}
-                onPress={() => navigation.reset({ routes: [{ name: "Tabs" }] })}
+                style={s.bottomDockBtn}
+                onPress={() => {
+                  setTocActiveTab("toc");
+                  setShowTOC(true);
+                }}
               >
-                <ChevronLeftIcon size={20} color="#fff" />
+                <ListIcon size={bottomDockIconSize} color={colors.foreground} />
+                <Text style={s.bottomDockLabel}>{t("reader.toc", "目录")}</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={s.toolbarBtn}
-                onPress={() => navigation.navigate("FullScreenNotes", { bookId })}
-              >
-                <NotebookPenIcon size={18} color="#fff" />
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[s.toolbarBtn, isBookmarked && s.toolbarBtnActive]}
+                style={[s.bottomDockBtn, isBookmarked && s.bottomDockBtnActive]}
                 onPress={handleToggleBookmark}
               >
                 {isBookmarked ? (
-                  <BookmarkFilledIcon size={18} color={colors.primary} />
+                  <BookmarkFilledIcon size={bottomDockIconSize} color={colors.primary} />
                 ) : (
-                  <BookmarkIcon size={18} color="#fff" />
+                  <BookmarkIcon size={bottomDockIconSize} color={colors.foreground} />
                 )}
+                <Text style={[s.bottomDockLabel, isBookmarked && s.bottomDockLabelActive]}>
+                  {t("reader.bookmarks", "书签")}
+                </Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={s.toolbarBtn}
-                onPress={() => navigation.navigate("BookChat", { bookId })}
+                style={s.bottomDockBtn}
+                onPress={() => navigation.navigate("FullScreenNotes", { bookId })}
               >
-                <MessageSquareIcon size={18} color="#fff" />
-              </TouchableOpacity>
-              <TouchableOpacity style={s.toolbarBtn} onPress={() => setShowTOC(true)}>
-                <ListIcon size={18} color="#fff" />
+                <NotebookPenIcon size={bottomDockIconSize} color={colors.foreground} />
+                <Text style={s.bottomDockLabel}>{t("notes.title", "笔记")}</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={[
-                  s.toolbarBtn,
-                  chapterTranslation.state.status !== "idle" && s.toolbarBtnActive,
-                ]}
-                onPress={() => setShowChapterTranslation(true)}
-              >
-                <LanguagesIcon
-                  size={18}
-                  color={chapterTranslation.state.status !== "idle" ? colors.primary : "#fff"}
-                />
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={s.toolbarBtn}
+                style={s.bottomDockBtn}
                 onPress={() => {
                   setShowSearch(true);
                   setShowControls(false);
-                  // Keep status bar visible for search bar at top
-                  setStatusBarHidden(false, "slide");
-                  Animated.spring(toolbarAnim, {
+                  Animated.timing(toolbarAnim, {
                     toValue: TOOLBAR_HIDE_OFFSET,
+                    duration: 180,
+                    easing: Easing.out(Easing.cubic),
                     useNativeDriver: true,
-                    friction: 20,
-                    tension: 100,
                   }).start();
                 }}
               >
-                <SearchIcon size={18} color="#fff" />
+                <SearchIcon size={bottomDockIconSize} color={colors.foreground} />
+                <Text style={s.bottomDockLabel}>{t("reader.search", "搜索")}</Text>
               </TouchableOpacity>
-              <TouchableOpacity
-                style={[s.toolbarBtn, showTTS && s.toolbarBtnActive]}
-                onPress={handleToggleTTS}
-              >
-                <Volume2Icon size={18} color={showTTS ? colors.primary : "#fff"} />
-              </TouchableOpacity>
-              <TouchableOpacity style={s.toolbarBtn} onPress={() => setShowSettings(true)}>
-                <SettingsIcon size={18} color="#fff" />
-              </TouchableOpacity>
-            </View>
-            <View style={s.footerSliderRow}>
-              <TouchableOpacity style={s.footerNavBtn} onPress={bridge.goLeft}>
-                <ChevronLeftIcon size={18} color="rgba(255,255,255,0.7)" />
-              </TouchableOpacity>
-              <View style={s.sliderWrap}>
-                <View style={s.sliderTrack}>
-                  <View style={[s.sliderFill, { width: `${percent}%` }]} />
-                </View>
-              </View>
-              <TouchableOpacity style={s.footerNavBtn} onPress={bridge.goRight}>
-                <ChevronRightIcon size={18} color="rgba(255,255,255,0.7)" />
+              <TouchableOpacity style={s.bottomDockBtn} onPress={() => setShowSettings(true)}>
+                <SettingsIcon size={bottomDockIconSize} color={colors.foreground} />
+                <Text style={s.bottomDockLabel}>{t("common.settings", "设置")}</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -1331,7 +1476,7 @@ export function ReaderScreen({ route, navigation }: Props) {
 
       {/* ─── Search Bar ─── */}
       {showSearch && (
-        <View style={[s.searchBarWrap, { paddingTop: insets.top }]}>
+        <View style={[s.searchBarWrap, { paddingTop: layoutTopInset }]}>
           <View style={s.searchBarRow}>
             <View style={s.searchInputWrap}>
               <SearchIcon size={16} color={colors.mutedForeground} />
@@ -1410,12 +1555,11 @@ export function ReaderScreen({ route, navigation }: Props) {
                 setSearchIndex(0);
                 bridge.clearSearch();
                 setShowControls(true);
-                setStatusBarHidden(false, "slide");
-                Animated.spring(toolbarAnim, {
+                Animated.timing(toolbarAnim, {
                   toValue: 0,
+                  duration: 180,
+                  easing: Easing.out(Easing.cubic),
                   useNativeDriver: true,
-                  friction: 20,
-                  tension: 100,
                 }).start();
               }}
             >
@@ -2062,19 +2206,156 @@ const makeStyles = (colors: ThemeColors) =>
       zIndex: 20,
     },
 
-    bottomToolbar: { position: "absolute", bottom: 0, left: 12, right: 12, zIndex: 30 },
-    bottomToolbarGlass: {
-      backgroundColor: "rgba(28, 28, 30, 0.85)",
-      borderRadius: 20,
-      paddingVertical: 8,
+    topToolbar: {
+      position: "absolute",
+      zIndex: 34,
+      left: 0,
+      right: 0,
+      top: 0,
+    },
+    topToolbarBar: {
+      backgroundColor: withOpacity(colors.background, 0.94),
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: withOpacity(colors.foreground, 0.1),
+    },
+    topToolbarRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    topToolbarBackBtn: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    topToolbarSideSlot: {
+      width: 68,
+      justifyContent: "center",
+      alignItems: "flex-start",
+    },
+    topToolbarSpacer: {
+      flex: 1,
+      minHeight: 44,
+    },
+    topToolbarTitleWrap: {
+      flex: 1,
+      minWidth: 0,
+      alignItems: "center",
+      justifyContent: "center",
       paddingHorizontal: 12,
-      shadowColor: "#000",
-      shadowOffset: { width: 0, height: -4 },
-      shadowOpacity: 0.3,
-      shadowRadius: 16,
-      elevation: 12,
-      borderWidth: 1,
-      borderColor: "rgba(255,255,255,0.1)",
+    },
+    topToolbarTitleText: {
+      fontSize: fontSize.sm,
+      color: colors.foreground,
+      fontWeight: fontWeight.medium,
+    },
+    topToolbarMetaWrap: {
+      width: 60,
+      alignItems: "flex-end",
+      justifyContent: "center",
+    },
+    topToolbarMetaText: {
+      fontSize: fontSize.sm,
+      color: colors.mutedForeground,
+      fontWeight: fontWeight.medium,
+    },
+    topToolbarRight: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 2,
+    },
+    topToolbarBtn: {
+      width: 40,
+      height: 40,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    topToolbarBtnActive: {
+      backgroundColor: withOpacity(colors.foreground, 0.06),
+    },
+    topToolbarProgressTrack: {
+      height: 2,
+      backgroundColor: withOpacity(colors.foreground, 0.08),
+      overflow: "hidden",
+    },
+    topToolbarProgressFill: {
+      height: "100%",
+      backgroundColor: withOpacity(colors.foreground, 0.48),
+    },
+
+    floatingTools: {
+      position: "absolute",
+      zIndex: 34,
+      gap: 10,
+      alignItems: "center",
+    },
+    floatingToolBtn: {
+      width: 52,
+      height: 52,
+      borderRadius: 26,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: "rgba(76, 82, 94, 0.88)",
+    },
+    floatingToolBtnActive: {
+      backgroundColor: "rgba(59, 130, 246, 0.9)",
+    },
+
+    bottomToolbar: {
+      position: "absolute",
+      bottom: 0,
+      zIndex: 30,
+      left: 0,
+      right: 0,
+    },
+    bottomToolbarGlass: {
+      backgroundColor: withOpacity(colors.background, 0.98),
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderColor: withOpacity(colors.foreground, 0.12),
+      paddingTop: 10,
+    },
+    bottomDockRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: 2,
+    },
+    bottomDockBtn: {
+      flex: 1,
+      height: 54,
+      borderRadius: 10,
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 4,
+      paddingTop: 4,
+    },
+    bottomDockBtnActive: {
+      backgroundColor: withOpacity(colors.foreground, 0.06),
+    },
+    bottomDockLabel: {
+      fontSize: fontSize.xs,
+      lineHeight: 14,
+      color: colors.mutedForeground,
+      fontWeight: fontWeight.medium,
+    },
+    bottomDockLabelActive: {
+      color: colors.primary,
+    },
+    bottomToolbarProgressTrack: {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      height: 2,
+      backgroundColor: withOpacity(colors.foreground, 0.08),
+      overflow: "hidden",
+    },
+    bottomToolbarProgressFill: {
+      height: "100%",
+      backgroundColor: withOpacity(colors.foreground, 0.48),
+      borderRadius: 999,
     },
     toolbarRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
     toolbarBtn: {
@@ -2102,8 +2383,8 @@ const makeStyles = (colors: ThemeColors) =>
       flexDirection: "row",
       justifyContent: "space-between",
       alignItems: "center",
-      paddingHorizontal: 16,
-      paddingVertical: 4,
+      paddingHorizontal: 18,
+      paddingVertical: 6,
     },
     topInfoText: {
       flex: 1,

--- a/packages/core/src/i18n/locales/en.json
+++ b/packages/core/src/i18n/locales/en.json
@@ -355,6 +355,10 @@
     "remove": "Remove bookmark",
     "added": "Bookmark added",
     "removed": "Bookmark removed",
+    "pullToAdd": "Pull down to add bookmark",
+    "releaseToAdd": "Release to add bookmark",
+    "pullToRemove": "Pull down to remove bookmark",
+    "releaseToRemove": "Release to remove bookmark",
     "empty": "No bookmarks yet",
     "emptyHint": "Use the bookmark button in the toolbar to mark pages"
   },

--- a/packages/core/src/i18n/locales/zh.json
+++ b/packages/core/src/i18n/locales/zh.json
@@ -353,6 +353,10 @@
     "remove": "移除书签",
     "added": "已添加书签",
     "removed": "已移除书签",
+    "pullToAdd": "下滑添加书签",
+    "releaseToAdd": "松手添加书签",
+    "pullToRemove": "下滑删除书签",
+    "releaseToRemove": "松手删除书签",
     "empty": "暂无书签",
     "emptyHint": "使用工具栏的书签按钮来标记页面"
   },


### PR DESCRIPTION
## Summary
- rebuild the mobile reader toolbar layout and floating actions for a cleaner reading-focused UI
- add pull-to-bookmark interactions in paginated mode and disable them in scroll mode
- improve mobile reader stability around status bar handling, annotations, and packaged reader assets

## Testing
- pnpm --filter @readany/app-expo run build:reader
- pnpm --filter @readany/app-expo exec tsc --noEmit