### PR TITLE
feat(tts): 系统音色支持与 TTS 引擎重构

### DIFF
--- a/docs/system-voice-design.md
+++ b/docs/system-voice-design.md
@@ -1,0 +1,546 @@
+# 系统语音方案设计
+
+## 一、背景
+
+当前项目的朗读能力分成三类：
+
+- **桌面端系统语音**：`packages/app/src/lib/tts/tts-service.ts` 里通过浏览器 `speechSynthesis` 提供，当前在配置层被命名为 `browser`
+- **移动端系统语音**：`packages/app-expo/src/lib/platform/expo-speech-player.ts` 里通过 `expo-speech` 提供
+- **云端语音**：`Edge TTS` 与 `DashScope TTS`
+
+这套结构已经能工作，但存在几个明显问题：
+
+- `browser` 这个命名不准确。对用户来说，这是“系统语音”，不是“浏览器语音”
+- 桌面端系统语音仍然依赖 WebView 的 `speechSynthesis`，在 macOS / Windows / Linux 上的能力和一致性较弱
+- 移动端虽然已经用上原生系统语音，但还缺少完整的语音枚举、语言筛选、质量标记和设备差异处理
+- `TTSConfig` 目前只有 `voiceName`，不足以表达系统语音的来源、语言、质量、平台能力等信息
+- UI 上尚未形成“系统语音”和“云端语音”并列的清晰模型
+
+这个方案的目标是把 **系统语音** 提升为一等能力，并在 Tauri 桌面端与 Expo 移动端下形成统一抽象。
+
+## 二、目标
+
+### 目标
+
+- 将当前 `browser` 引擎升级为语义更准确的 `system` 引擎
+- 在 **Tauri** 下接入原生系统语音，而不是继续依赖浏览器 `speechSynthesis`
+- 在 **Expo** 下保留 `expo-speech`，并补齐系统语音枚举与元数据能力
+- 提供统一的 `SystemVoice` 数据结构，支撑桌面端和移动端同一套 UI
+- 在设置页、朗读页、歌词页内统一展示系统语音
+- 保留 `Edge` 和 `DashScope`，将其视为“云端语音”能力而不是替代系统语音
+
+### 非目标
+
+- 第一阶段不做自建离线语音包下载器
+- 第一阶段不尝试解决 Linux 各发行版缺失语音引擎的安装问题
+- 第一阶段不替换现有 `Edge` / `DashScope` 的播放链路
+- 第一阶段不追求多端完全相同的 voice ID，只追求统一模型和稳定回退
+
+## 三、平台调研结论
+
+### 1. Tauri 桌面端
+
+### macOS
+
+- 底层可使用 Apple 系统语音能力
+- 系统自带语音最丰富，通常支持更多语言、更高质量语音包
+- 是桌面端系统语音体验最好的平台
+
+### Windows
+
+- 可使用系统安装的语音列表
+- 整体语音质量和语种覆盖较好
+- 语音能力依赖用户是否安装语言包和语音组件
+
+### Linux
+
+- 没有统一且丰富的“系统自带语音包”概念
+- 实际能力通常依赖 `Speech Dispatcher`、`eSpeak NG`、`RHVoice` 等后端
+- 可播放不代表体验好，语言质量和可用性会明显分化
+
+### 桌面端选型结论
+
+推荐优先采用：
+
+- **Rust `tts` crate + 自定义 Tauri commands**
+
+备选方案：
+
+- `tauri-plugin-tts`
+
+不推荐继续作为主方案的方式：
+
+- 单纯依赖浏览器 `speechSynthesis`
+
+原因：
+
+- `tts` crate 的控制边界更清晰，适合我们按自己的状态机与事件协议封装
+- `tauri-plugin-tts` 可以作为调研分支或对照实现，但它仍然是第三方插件，当前不应比自有命令链路更优先
+- WebView `speechSynthesis` 无法给我们稳定的跨平台能力，也不利于后续统一 voice metadata
+
+### 2. Expo 移动端
+
+### iOS
+
+- `expo-speech` 能直接使用系统语音
+- iOS 系统语音库丰富，质量好
+- 支持 `getAvailableVoicesAsync()`，适合做语音选择器
+
+### Android
+
+- `expo-speech` 同样可以直接使用系统语音
+- 语音能力很依赖设备已安装的 TTS engine 和 voice data
+- 不同品牌、不同 ROM 的语音列表和质量会明显不同
+
+### 移动端选型结论
+
+推荐第一阶段继续采用：
+
+- **`expo-speech`**
+
+第二阶段可选增强：
+
+- **`react-native-tts`**
+
+原因：
+
+- `expo-speech` 已经在当前项目中工作，且与 Expo 架构兼容最好
+- 我们当前最缺的是统一 voice metadata、语言筛选和配置持久化，而不是立刻更换底层库
+- `react-native-tts` 更适合后续 Android 进阶控制，例如枚举 engines、提示安装语音数据、切换默认引擎
+
+## 四、现有架构问题
+
+当前共享 TTS 配置定义在 `packages/core/src/tts/types.ts`：
+
+```ts
+export type TTSEngine = "browser" | "edge" | "dashscope";
+
+export interface TTSConfig {
+  engine: TTSEngine;
+  voiceName: string;
+  rate: number;
+  pitch: number;
+  edgeVoice: string;
+  dashscopeApiKey: string;
+  dashscopeVoice: string;
+}
+```
+
+主要问题：
+
+- `browser` 对桌面端和移动端都不准确
+- `voiceName` 是纯字符串，无法表达 voice 的语言、质量、来源、可用状态
+- 移动端和桌面端都没有统一的“系统语音枚举服务”
+- UI 目前是以引擎实现细节驱动，不是以产品语义驱动
+
+## 五、目标架构
+
+### 1. 引擎模型
+
+将 TTS 引擎统一为：
+
+```ts
+export type TTSEngine = "system" | "edge" | "dashscope";
+```
+
+说明：
+
+- `system`：设备内置系统语音
+- `edge`：Microsoft Edge 云端神经语音
+- `dashscope`：阿里云语音
+
+迁移规则：
+
+- 历史配置中的 `browser` 统一迁移为 `system`
+
+### 2. 系统语音统一数据结构
+
+新增共享类型：
+
+```ts
+export type TTSVoiceProvider = "system" | "edge" | "dashscope";
+export type TTSVoiceQuality = "default" | "enhanced" | "premium" | "neural" | "unknown";
+export type TTSVoicePlatform = "macos" | "windows" | "linux" | "ios" | "android" | "unknown";
+
+export interface TTSVoiceDescriptor {
+  id: string;
+  provider: TTSVoiceProvider;
+  platform: TTSVoicePlatform;
+  name: string;
+  locale: string;
+  language: string;
+  quality: TTSVoiceQuality;
+  gender?: "male" | "female" | "neutral" | "unknown";
+  installed: boolean;
+  offlineAvailable: boolean;
+  requiresDownload?: boolean;
+  isDefault?: boolean;
+  rawName?: string;
+}
+```
+
+设计原则：
+
+- `id` 是配置持久化的主键
+- `locale` 和 `language` 用于筛选和匹配
+- `quality` 不要求所有平台都能精确识别，但要允许表达 richer metadata
+- `rawName` 用于兼容平台原始 voice label
+
+### 3. 统一系统语音能力接口
+
+新增平台能力抽象：
+
+```ts
+export interface ISystemVoiceService {
+  listVoices(): Promise<TTSVoiceDescriptor[]>;
+  getCapabilities(): Promise<{
+    canPause: boolean;
+    canResume: boolean;
+    supportsRate: boolean;
+    supportsPitch: boolean;
+    supportsVoiceSelection: boolean;
+  }>;
+}
+```
+
+说明：
+
+- **voice 枚举** 与 **语音播放** 分开建模
+- 能力检测必须显式化，尤其是 Android / Linux
+- UI 和 store 不再直接依赖底层 API 细节
+
+### 4. 播放器架构
+
+当前 `ITTSPlayer` 保持不变，但增加新的系统语音播放器实现：
+
+- 桌面端：`TauriSystemTTSPlayer`
+- 移动端：`ExpoSystemTTSPlayer`
+
+其中：
+
+- `EdgeTTSPlayer` 和 `DashScopeTTSPlayer` 保持现状
+- 当前的 `BrowserTTSPlayer` 逐步退役，仅作为过渡或 Web fallback
+
+## 六、平台实现方案
+
+### 1. Tauri 桌面端
+
+### 推荐方案
+
+在 `packages/app/src-tauri` 中新增系统语音命令层，底层使用 Rust `tts` crate。
+
+建议新增命令：
+
+```rust
+#[tauri::command]
+async fn tts_list_system_voices() -> Result<Vec<SystemVoiceDto>, String>;
+
+#[tauri::command]
+async fn tts_speak_system(req: SpeakSystemTtsRequest) -> Result<(), String>;
+
+#[tauri::command]
+async fn tts_pause_system() -> Result<(), String>;
+
+#[tauri::command]
+async fn tts_resume_system() -> Result<(), String>;
+
+#[tauri::command]
+async fn tts_stop_system() -> Result<(), String>;
+
+#[tauri::command]
+async fn tts_get_system_capabilities() -> Result<SystemTtsCapabilitiesDto, String>;
+```
+
+建议同时通过事件向前端回传状态：
+
+- `tts://state`
+- `tts://chunk-start`
+- `tts://utterance-end`
+- `tts://error`
+
+### 为什么不用浏览器 `speechSynthesis`
+
+- 无法稳定获得统一 voice metadata
+- 在不同 WebView / 不同系统上的行为差异较大
+- 不利于控制 pause/resume/stop 与事件同步
+- 长期会让桌面端系统语音与移动端系统语音走成两套产品模型
+
+### 为什么不优先选 `tauri-plugin-tts`
+
+- 可以作为备选或调研分支
+- 但第一阶段我们更希望核心控制权掌握在自己手里
+- 当前项目已经有较复杂的 TTS store、歌词同步、高亮和跨书状态，自己定义 Tauri 命令更容易对齐现有状态机
+
+### 2. Expo 移动端
+
+### 推荐方案
+
+保留 `expo-speech`，新增系统语音服务层：
+
+- `ExpoSystemVoiceService`
+- `ExpoSystemTTSPlayer`
+
+它们分别负责：
+
+- 调用 `Speech.getAvailableVoicesAsync()` 枚举系统语音
+- 将平台原始 voice 数据映射成 `TTSVoiceDescriptor`
+- 使用 `Speech.speak(..., { voice, language, rate, pitch })` 播放
+
+### Android 特殊处理
+
+需要明确记录以下现实：
+
+- 不同设备的 `voice.id` 与 `voice.name` 不稳定
+- 某些设备上 pause / resume 能力有限
+- 某些设备系统虽然有 TTS，但语音数据并不完整
+
+因此移动端系统语音策略应当是：
+
+- **能枚举就枚举**
+- **能选 voice 就选**
+- **选不到时按 locale 回退**
+- **再不行就回退到系统默认 voice**
+
+### 第二阶段增强
+
+如果后续安卓系统语音体验依然不理想，再单独评估：
+
+- `react-native-tts`
+
+适合解决的问题：
+
+- 枚举 Android TTS engines
+- 提示安装 voice data
+- 切换默认 TTS engine
+
+不建议第一阶段就切它，原因是当前我们更需要统一模型，而不是引入新的原生复杂度。
+
+## 七、配置模型调整
+
+建议将 `TTSConfig` 调整为：
+
+```ts
+export interface TTSConfig {
+  engine: TTSEngine;
+
+  // system
+  systemVoiceId: string;
+  systemVoiceName: string;
+  systemVoiceLocale: string;
+
+  // common
+  rate: number;
+  pitch: number;
+
+  // edge
+  edgeVoice: string;
+
+  // dashscope
+  dashscopeApiKey: string;
+  dashscopeVoice: string;
+}
+```
+
+迁移策略：
+
+- 旧配置：
+  - `engine === "browser"` -> `engine = "system"`
+  - `voiceName` -> 尝试映射为 `systemVoiceId`
+- 若映射失败：
+  - 清空 `systemVoiceId`
+  - 使用系统默认 voice
+
+## 八、UI 方案
+
+## 1. 引擎选择
+
+将所有 TTS UI 统一为三类：
+
+- `系统语音`
+- `Edge`
+- `DashScope`
+
+不再向用户暴露 `browser` 这个实现词。
+
+## 2. 系统语音选择器
+
+建议展示维度：
+
+- 语音名称
+- 语言 / locale
+- 质量标签
+- 是否系统默认
+- 是否已安装 / 是否需要下载
+
+推荐交互：
+
+- 默认先按当前书籍语言过滤
+- 提供“全部语音”切换
+- 支持试听
+- 对当前已选语音显示勾选状态
+
+## 3. 标签设计
+
+建议标签：
+
+- `系统默认`
+- `高质量`
+- `Premium`
+- `需下载`
+- `仅本机`
+
+注意：
+
+- 不要假设所有平台都能识别 `premium`
+- 标签体系必须允许“信息缺失但还能展示”
+
+## 九、建议改动文件
+
+### Core
+
+- `packages/core/src/tts/types.ts`
+- `packages/core/src/tts/display.ts`
+- `packages/core/src/stores/tts-store.ts`
+
+### Desktop App
+
+- `packages/app/src/lib/tts/tts-service.ts`
+- `packages/app/src/lib/platform/` 下新增 Tauri 系统语音服务
+- `packages/app/src/components/reader/TTSControls.tsx`
+- `packages/app/src/components/reader/TTSPage.tsx`
+- `packages/app/src/components/reader/FooterBar.tsx`
+- `packages/app/src-tauri/src/` 下新增 TTS command 与事件桥
+
+### Expo App
+
+- `packages/app-expo/src/lib/platform/expo-speech-player.ts`
+- `packages/app-expo/src/lib/platform/rn-tts-factories.ts`
+- `packages/app-expo/src/screens/settings/TTSSettingsScreen.tsx`
+- `packages/app-expo/src/components/reader/TTSPage.tsx`
+- `packages/app-expo/src/stores/tts-store.ts`
+
+## 十、实施阶段
+
+### Phase 1：统一模型与配置迁移
+
+目标：
+
+- 把 `browser` 升级为 `system`
+- 新增 `TTSVoiceDescriptor`
+- 完成 `TTSConfig` 迁移
+- UI 上完成“系统语音”命名替换
+
+产出：
+
+- 类型层完成统一
+- 现有桌面 / 移动端不需要一次性全部重写
+
+### Phase 2：Expo 系统语音补强
+
+目标：
+
+- 为 `expo-speech` 增加 voice 枚举和 metadata 映射
+- 在移动端提供可用的系统语音选择器
+
+产出：
+
+- iOS / Android 系统语音能力显式化
+- 选择和回退逻辑稳定
+
+### Phase 3：Tauri 原生系统语音接入
+
+目标：
+
+- 新增 Tauri Rust 系统语音命令
+- 实现 `TauriSystemTTSPlayer`
+- 桌面端不再依赖浏览器 `speechSynthesis` 作为主实现
+
+产出：
+
+- macOS / Windows / Linux 的桌面系统语音形成统一入口
+
+### Phase 4：Android 进阶能力评估
+
+目标：
+
+- 评估是否引入 `react-native-tts`
+- 仅在 `expo-speech` 无法满足需求时推进
+
+产出：
+
+- 明确 Android 是否需要“engine 层能力”
+
+## 十一、风险与回退
+
+### 1. Linux 语音质量差异大
+
+风险：
+
+- 有的设备能播但声音很差
+- 有的设备根本没有可用 voice
+
+策略：
+
+- 让 `system` 语音能力暴露 availability
+- UI 上允许明确回退到 `Edge` / `DashScope`
+
+### 2. 系统 voice ID 不稳定
+
+风险：
+
+- OS 更新后某些 voice ID 可能变化
+
+策略：
+
+- 持久化 `id + locale + name`
+- 恢复时优先按 `id`，失败再按 `locale + name` 模糊匹配
+
+### 3. Android 能力不完整
+
+风险：
+
+- pause / resume、voice data 安装等行为不一致
+
+策略：
+
+- 通过 `capabilities` 显式上报
+- UI 和 store 避免假设所有平台能力相同
+
+### 4. Tauri 原生命令状态同步复杂
+
+风险：
+
+- 当前项目已有歌词同步、高亮、连续朗读、跨书状态
+
+策略：
+
+- Tauri 原生命令层只做“系统语音能力”
+- 播放状态机仍以现有 TS store 为核心
+
+## 十二、最终建议
+
+按当前项目现状，推荐路线是：
+
+1. 先完成 **配置与命名统一**，把 `browser` 正式改成 `system`
+2. 先补强 **Expo `expo-speech`**，把移动端系统语音做完整
+3. 再做 **Tauri 原生系统语音接入**
+4. Linux 先接受“可用但不保证高质量”的现实
+5. Android 原生增强放到后续评估，不与第一阶段绑定
+
+这样做的好处是：
+
+- 风险最低
+- 与现有架构最兼容
+- 能尽快把“系统语音”从实现细节提升成真正的产品能力
+
+## 参考资料
+
+- Expo Speech: https://docs.expo.dev/versions/latest/sdk/speech/
+- react-native-tts: https://github.com/ak1394/react-native-tts
+- Rust tts crate: https://docs.rs/tts
+- tauri-plugin-tts: https://docs.rs/tauri-plugin-tts
+- Apple AVSpeechSynthesizer: https://developer.apple.com/documentation/avfaudio/avspeechsynthesizer/
+- Android TextToSpeech: https://developer.android.com/reference/android/speech/tts/TextToSpeech
+- Windows SpeechSynthesizer.AllVoices: https://learn.microsoft.com/uwp/api/windows.media.speechsynthesis.speechsynthesizer.allvoices
+- Speech Dispatcher: https://freebsoft.org/speechd/
+- eSpeak NG: https://github.com/espeak-ng/espeak-ng

--- a/packages/app-expo/index.js
+++ b/packages/app-expo/index.js
@@ -1,7 +1,70 @@
 // crypto polyfill — MUST be the very first import (before any core/lib code)
 import "react-native-get-random-values";
+import * as ExpoCrypto from "expo-crypto";
 
 import { registerRootComponent } from "expo";
 import App from "./src/App";
+
+function bytesToString(bytes) {
+  if (typeof TextDecoder !== "undefined") {
+    return new TextDecoder().decode(bytes);
+  }
+
+  let result = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    result += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return result;
+}
+
+function hexToArrayBuffer(hex) {
+  const normalized = hex.trim();
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < normalized.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(normalized.slice(i, i + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+function resolveDigestAlgorithm(algorithm) {
+  const name = typeof algorithm === "string" ? algorithm : algorithm?.name;
+  switch ((name || "").toUpperCase()) {
+    case "SHA-1":
+      return ExpoCrypto.CryptoDigestAlgorithm.SHA1;
+    case "SHA-256":
+      return ExpoCrypto.CryptoDigestAlgorithm.SHA256;
+    default:
+      throw new Error(`Unsupported digest algorithm: ${String(name || algorithm)}`);
+  }
+}
+
+const cryptoObject = globalThis.crypto ?? {};
+if (!globalThis.crypto) {
+  globalThis.crypto = cryptoObject;
+}
+
+if (!cryptoObject.subtle) {
+  Object.defineProperty(cryptoObject, "subtle", {
+    configurable: true,
+    enumerable: true,
+    value: {
+      async digest(algorithm, data) {
+        const bytes =
+          data instanceof Uint8Array
+            ? data
+            : ArrayBuffer.isView(data)
+              ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+              : new Uint8Array(data);
+        const hex = await ExpoCrypto.digestStringAsync(
+          resolveDigestAlgorithm(algorithm),
+          bytesToString(bytes),
+          { encoding: ExpoCrypto.CryptoEncoding.HEX },
+        );
+        return hexToArrayBuffer(hex);
+      },
+    },
+  });
+}
 
 registerRootComponent(App);

--- a/packages/app-expo/src/components/reader/TTSPage.tsx
+++ b/packages/app-expo/src/components/reader/TTSPage.tsx
@@ -320,7 +320,7 @@ export function TTSPage({
       ? "Edge TTS"
       : config.engine === "dashscope"
         ? "DashScope"
-        : t("tts.browser");
+        : t("tts.system");
 
   const pendingCenterRef = useRef<number | null>(null);
 
@@ -878,4 +878,3 @@ export function TTSPage({
     </Modal>
   );
 }
-

--- a/packages/app-expo/src/components/reader/tts/VoicePickerModal.tsx
+++ b/packages/app-expo/src/components/reader/tts/VoicePickerModal.tsx
@@ -1,9 +1,20 @@
 import { useColors, radius } from "@/styles/theme";
 import {
+  DEFAULT_SYSTEM_VOICE_VALUE,
+  findSystemVoiceLabel,
+  getSystemVoiceOptionsAsync,
+  groupSystemVoiceOptions,
+  resolveSystemVoiceValue,
+  type NativeSystemVoiceOption,
+} from "@/lib/platform/system-voices";
+import {
   DASHSCOPE_VOICES,
   EDGE_TTS_VOICES,
+  getLocaleDisplayLabel,
+  groupEdgeTTSVoices,
   type TTSConfig,
 } from "@readany/core/tts";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Modal,
@@ -31,7 +42,24 @@ export function VoicePickerModal({
 }: VoicePickerModalProps) {
   const colors = useColors();
   const s = makeStyles(colors);
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const [systemVoices, setSystemVoices] = useState<NativeSystemVoiceOption[]>([]);
+  const displayLocale = i18n.resolvedLanguage || i18n.language;
+
+  useEffect(() => {
+    if (!visible) return;
+    void getSystemVoiceOptionsAsync().then(setSystemVoices);
+  }, [visible]);
+
+  const systemVoiceGroups = useMemo(
+    () => groupSystemVoiceOptions(systemVoices),
+    [systemVoices],
+  );
+  const edgeVoiceGroups = useMemo(() => groupEdgeTTSVoices(EDGE_TTS_VOICES), []);
+  const selectedSystemVoiceValue = useMemo(
+    () => resolveSystemVoiceValue(config.voiceName, systemVoices),
+    [config.voiceName, systemVoices],
+  );
 
   return (
     <Modal
@@ -53,10 +81,10 @@ export function VoicePickerModal({
 
           {/* Engine selector */}
           <View style={s.engineSection}>
-            {(["edge", "dashscope", "browser"] as const).map((eng) => {
+            {(["edge", "dashscope", "system"] as const).map((eng) => {
               const isActive = config.engine === eng;
               const label =
-                eng === "edge" ? "Edge TTS" : eng === "dashscope" ? "DashScope" : t("tts.browser");
+                eng === "edge" ? "Edge TTS" : eng === "dashscope" ? "DashScope" : t("tts.system");
               const desc =
                 eng === "edge"
                   ? "Microsoft · 多语言"
@@ -87,7 +115,7 @@ export function VoicePickerModal({
           </View>
 
           {/* Divider + voice section title */}
-          {config.engine !== "browser" && (
+          {config.engine !== "system" && (
             <View style={s.voicePickerHeader}>
               <Text style={s.voicePickerTitle}>{t("tts.selectVoice")}</Text>
             </View>
@@ -118,52 +146,95 @@ export function VoicePickerModal({
 
             {/* Edge TTS voices — grouped by language, zh-* first */}
             {config.engine === "edge" &&
-              (() => {
-                const grouped = EDGE_TTS_VOICES.reduce<Record<string, typeof EDGE_TTS_VOICES>>(
-                  (acc, v) => {
-                    (acc[v.lang] ??= []).push(v);
-                    return acc;
-                  },
-                  {},
-                );
-                const langs = Object.keys(grouped).sort((a, b) => {
-                  const aZh = a.startsWith("zh") ? -1 : 0;
-                  const bZh = b.startsWith("zh") ? -1 : 0;
-                  return aZh - bZh || a.localeCompare(b);
-                });
-                return langs.map((lang) => (
+              edgeVoiceGroups.map(([lang, voices]) => (
+                <View key={lang}>
+                  <View style={s.voiceLangHeader}>
+                    <Text style={s.voiceLangTxt}>
+                      {getLocaleDisplayLabel(lang, displayLocale)}
+                    </Text>
+                  </View>
+                  {voices.map((v) => {
+                    const isSelected = config.edgeVoice === v.id;
+                    return (
+                      <TouchableOpacity
+                        key={v.id}
+                        style={[s.voiceItem, isSelected && s.voiceItemSelected]}
+                        onPress={() => {
+                          onUpdateConfig({ edgeVoice: v.id });
+                          onClose();
+                        }}
+                        activeOpacity={0.7}
+                      >
+                        <Text style={[s.voiceItemTxt, isSelected && s.voiceItemTxtSelected]}>
+                          {v.name}
+                        </Text>
+                        {isSelected && <Text style={s.voiceItemCheck}>✓</Text>}
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              ))}
+
+            {/* System voices */}
+            {config.engine === "system" && (
+              <>
+                <TouchableOpacity
+                  style={[
+                    s.voiceItem,
+                    selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE &&
+                      s.voiceItemSelected,
+                  ]}
+                  onPress={() => {
+                    onUpdateConfig({ voiceName: "", systemVoiceLabel: "" });
+                    onClose();
+                  }}
+                  activeOpacity={0.7}
+                >
+                  <Text
+                    style={[
+                      s.voiceItemTxt,
+                      selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE &&
+                        s.voiceItemTxtSelected,
+                    ]}
+                  >
+                    {t("tts.defaultVoice")}
+                  </Text>
+                  {selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE && (
+                    <Text style={s.voiceItemCheck}>✓</Text>
+                  )}
+                </TouchableOpacity>
+                {systemVoiceGroups.map(([lang, voices]) => (
                   <View key={lang}>
                     <View style={s.voiceLangHeader}>
-                      <Text style={s.voiceLangTxt}>{lang}</Text>
+                      <Text style={s.voiceLangTxt}>
+                        {getLocaleDisplayLabel(lang, displayLocale)}
+                      </Text>
                     </View>
-                    {grouped[lang]!.map((v) => {
-                      const isSelected = config.edgeVoice === v.id;
+                    {voices.map((voice) => {
+                      const isSelected = selectedSystemVoiceValue === voice.id;
                       return (
                         <TouchableOpacity
-                          key={v.id}
+                          key={voice.id}
                           style={[s.voiceItem, isSelected && s.voiceItemSelected]}
                           onPress={() => {
-                            onUpdateConfig({ edgeVoice: v.id });
+                            onUpdateConfig({
+                              voiceName: voice.id,
+                              systemVoiceLabel: findSystemVoiceLabel(voice.id, systemVoices),
+                            });
                             onClose();
                           }}
                           activeOpacity={0.7}
                         >
                           <Text style={[s.voiceItemTxt, isSelected && s.voiceItemTxtSelected]}>
-                            {v.name}
+                            {voice.label}
                           </Text>
                           {isSelected && <Text style={s.voiceItemCheck}>✓</Text>}
                         </TouchableOpacity>
                       );
                     })}
                   </View>
-                ));
-              })()}
-
-            {/* Browser — no selectable voices */}
-            {config.engine === "browser" && (
-              <View style={s.voiceBrowserNote}>
-                <Text style={s.voiceBrowserNoteTxt}>{t("tts.browserVoiceNote")}</Text>
-              </View>
+                ))}
+              </>
             )}
           </ScrollView>
 

--- a/packages/app-expo/src/lib/platform/expo-av-edge-player.ts
+++ b/packages/app-expo/src/lib/platform/expo-av-edge-player.ts
@@ -114,7 +114,7 @@ export class ExpoAVEdgeTTSPlayer implements ITTSPlayer {
         await this._playChunk();
       }
     } catch (err) {
-      if ((err as Error)?.message !== "aborted") {
+      if (!this._stopped && (err as Error)?.message !== "aborted") {
         console.error("[ExpoAVEdgeTTSPlayer] chunk error:", err);
       }
       if (this._currentSound) {

--- a/packages/app-expo/src/lib/platform/expo-platform-service.ts
+++ b/packages/app-expo/src/lib/platform/expo-platform-service.ts
@@ -401,11 +401,84 @@ export class ExpoPlatformService implements IPlatformService {
   }
 
   async createWebSocket(url: string, _options?: WebSocketOptions): Promise<IWebSocket> {
-    // RN has built-in WebSocket (note: custom headers not supported like Tauri)
-    const ws = new WebSocket(url);
+    const formatWebSocketError = (value: unknown): string => {
+      if (value instanceof Error) return value.message;
+      if (typeof value === "string") return value;
+      if (value && typeof value === "object") {
+        const maybeMessage =
+          "message" in value && typeof (value as { message?: unknown }).message === "string"
+            ? (value as { message: string }).message
+            : null;
+        if (maybeMessage) return maybeMessage;
+        try {
+          return JSON.stringify(value);
+        } catch {
+          return String(value);
+        }
+      }
+      return String(value);
+    };
+
+    // RN WebSocket supports constructor headers via the third argument.
+    // Edge TTS relies on Origin/User-Agent/Cookie, so we must pass them through.
+    // We also wait for `open` so send() never races the handshake.
+    const ReactNativeWebSocket = WebSocket as unknown as new (
+      url: string,
+      protocols?: string | string[] | null,
+      options?: { headers?: Record<string, string> },
+    ) => WebSocket;
+
+    const ws = new ReactNativeWebSocket(url, undefined, {
+      headers: _options?.headers ?? {},
+    });
+    ws.binaryType = "arraybuffer";
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let pendingErrorMessage = "";
+      const timeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          ws.close();
+        } catch {}
+        reject(new Error(`WebSocket connection timeout: ${url}`));
+      }, 10000);
+
+      ws.onopen = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+
+      ws.onerror = (err) => {
+        if (settled) return;
+        pendingErrorMessage = formatWebSocketError(err);
+      };
+
+      ws.onclose = (event) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        const closeReason =
+          event && typeof event === "object" && "reason" in event
+            ? String((event as { reason?: unknown }).reason || "")
+            : "";
+        const detail = closeReason || pendingErrorMessage || formatWebSocketError(event);
+        reject(
+          new Error(
+            `WebSocket closed before open: ${url} (${detail})`,
+          ),
+        );
+      };
+    });
 
     return {
       send(data: string | ArrayBuffer) {
+        if (ws.readyState !== WebSocket.OPEN) {
+          throw new Error(`WebSocket is not open (readyState=${ws.readyState})`);
+        }
         ws.send(data);
       },
       close() {
@@ -418,7 +491,7 @@ export class ExpoPlatformService implements IPlatformService {
         ws.onclose = () => handler();
       },
       onError(handler) {
-        ws.onerror = (err) => handler(err);
+        ws.onerror = (err) => handler(new Error(formatWebSocketError(err)));
       },
     };
   }

--- a/packages/app-expo/src/lib/platform/expo-speech-player.ts
+++ b/packages/app-expo/src/lib/platform/expo-speech-player.ts
@@ -60,7 +60,7 @@ export class ExpoSpeechTTSPlayer implements ITTSPlayer {
       Speech.speak(chunk, {
         rate: config.rate,
         pitch: config.pitch,
-        language: guessLanguage(chunk),
+        ...(config.voiceName ? { voice: config.voiceName } : { language: guessLanguage(chunk) }),
         onDone: () => {
           this._currentIndex++;
           this._speakChunk(config).then(resolve);

--- a/packages/app-expo/src/lib/platform/rn-tts-factories.ts
+++ b/packages/app-expo/src/lib/platform/rn-tts-factories.ts
@@ -10,7 +10,7 @@ import { ExpoAVEdgeTTSPlayer } from "./expo-av-edge-player";
 import { ExpoSpeechTTSPlayer } from "./expo-speech-player";
 
 export const rnTTSPlayerFactories: TTSPlayerFactories = {
-  createBrowserTTS: () => new ExpoSpeechTTSPlayer(),
+  createSystemTTS: () => new ExpoSpeechTTSPlayer(),
   createEdgeTTS: () => new ExpoAVEdgeTTSPlayer(),
   // DashScope TTS needs PCM streaming via expo-av — falls back to expo-speech for now.
   createDashScopeTTS: () => new ExpoSpeechTTSPlayer(),

--- a/packages/app-expo/src/lib/platform/system-voices.ts
+++ b/packages/app-expo/src/lib/platform/system-voices.ts
@@ -1,0 +1,68 @@
+import * as Speech from "expo-speech";
+import { compareVoiceLanguage } from "@readany/core/tts";
+
+export const DEFAULT_SYSTEM_VOICE_VALUE = "__default__";
+
+export interface NativeSystemVoiceOption {
+  id: string;
+  label: string;
+  lang: string;
+  quality?: string;
+}
+
+export async function getSystemVoiceOptionsAsync(): Promise<NativeSystemVoiceOption[]> {
+  try {
+    const voices = await Speech.getAvailableVoicesAsync();
+    const deduped = new Map<string, NativeSystemVoiceOption>();
+    for (const voice of voices) {
+      const option = {
+        id: voice.identifier,
+        label: voice.name || voice.identifier,
+        lang: voice.language || "und",
+        quality: voice.quality,
+      };
+      const existing = deduped.get(option.id);
+      if (!existing || (existing.quality !== "Enhanced" && option.quality === "Enhanced")) {
+        deduped.set(option.id, option);
+      }
+    }
+    return Array.from(deduped.values()).sort((a, b) => a.label.localeCompare(b.label));
+  } catch (error) {
+    console.warn("[SystemVoices] Failed to load native system voices", error);
+    return [];
+  }
+}
+
+export function groupSystemVoiceOptions(
+  voices: NativeSystemVoiceOption[],
+): Array<[string, NativeSystemVoiceOption[]]> {
+  const grouped = new Map<string, NativeSystemVoiceOption[]>();
+  for (const voice of voices) {
+    const bucket = grouped.get(voice.lang) || [];
+    bucket.push(voice);
+    grouped.set(voice.lang, bucket);
+  }
+  return Array.from(grouped.entries())
+    .sort(([a], [b]) => compareVoiceLanguage(a, b))
+    .map(([lang, items]) => [
+      lang,
+      [...items].sort((a, b) => a.label.localeCompare(b.label)),
+    ] as [string, NativeSystemVoiceOption[]]);
+}
+
+export function resolveSystemVoiceValue(
+  selectedVoice: string | null | undefined,
+  voices: NativeSystemVoiceOption[],
+): string {
+  if (!selectedVoice) return DEFAULT_SYSTEM_VOICE_VALUE;
+  const match = voices.find((voice) => voice.id === selectedVoice || voice.label === selectedVoice);
+  return match?.id || DEFAULT_SYSTEM_VOICE_VALUE;
+}
+
+export function findSystemVoiceLabel(
+  selectedVoice: string | null | undefined,
+  voices: NativeSystemVoiceOption[],
+): string {
+  if (!selectedVoice) return "";
+  return voices.find((voice) => voice.id === selectedVoice || voice.label === selectedVoice)?.label || "";
+}

--- a/packages/app-expo/src/lib/platform/tts-preview.ts
+++ b/packages/app-expo/src/lib/platform/tts-preview.ts
@@ -1,0 +1,34 @@
+import type { TTSConfig } from "@readany/core/tts";
+import { ExpoAVEdgeTTSPlayer } from "./expo-av-edge-player";
+import { ExpoSpeechTTSPlayer } from "./expo-speech-player";
+
+const systemPreviewPlayer = new ExpoSpeechTTSPlayer();
+const edgePreviewPlayer = new ExpoAVEdgeTTSPlayer();
+const dashscopePreviewPlayer = new ExpoSpeechTTSPlayer();
+
+function stopPlayer(player: { stop: () => void }) {
+  try {
+    player.stop();
+  } catch {}
+}
+
+export function stopTTSPreview() {
+  stopPlayer(systemPreviewPlayer);
+  stopPlayer(edgePreviewPlayer);
+  stopPlayer(dashscopePreviewPlayer);
+}
+
+export async function previewTTSConfig(text: string, config: TTSConfig) {
+  stopTTSPreview();
+  const player =
+    config.engine === "edge"
+      ? edgePreviewPlayer
+      : config.engine === "dashscope"
+        ? dashscopePreviewPlayer
+        : systemPreviewPlayer;
+  try {
+    await Promise.resolve(player.speak(text, config));
+  } catch (error) {
+    console.error("[TTSPreview] Preview failed", error);
+  }
+}

--- a/packages/app-expo/src/screens/ReaderScreen.tsx
+++ b/packages/app-expo/src/screens/ReaderScreen.tsx
@@ -1522,7 +1522,7 @@ export function ReaderScreen({ route, navigation }: Props) {
         onAdjustRate={tts.handleAdjustTTSRate}
         onAdjustPitch={tts.handleAdjustTTSPitch}
         onToggleContinuous={tts.handleToggleTTSContinuous}
-        onUpdateConfig={ttsConfig ? undefined : undefined}
+        onUpdateConfig={tts.handleUpdateTTSConfig}
         onPrevChapter={toc.length > 0 ? tts.handleTTSPrevChapter : undefined}
         onNextChapter={toc.length > 0 ? tts.handleTTSNextChapter : undefined}
       />

--- a/packages/app-expo/src/screens/reader/useReaderTTS.ts
+++ b/packages/app-expo/src/screens/reader/useReaderTTS.ts
@@ -10,7 +10,7 @@
  */
 
 import { useTTSStore } from "@/stores";
-import { splitNarrationText } from "@readany/core/tts";
+import { normalizeTTSConfig, splitNarrationText, type TTSConfig } from "@readany/core/tts";
 import { getPlatformService } from "@readany/core/services";
 import { eventBus } from "@readany/core/utils/event-bus";
 import type { VisibleTTSSegment } from "@/hooks/use-reader-bridge";
@@ -86,6 +86,7 @@ export interface UseReaderTTSResult {
   handleTTSPlayPause: () => Promise<void>;
   handleAdjustTTSRate: (delta: number) => void;
   handleAdjustTTSPitch: (delta: number) => void;
+  handleUpdateTTSConfig: (updates: Partial<TTSConfig>) => void;
   handleToggleTTSContinuous: () => void;
   handleJumpToTTSSegment: (offsetFromCurrent: number) => void;
   handleJumpToTTSLyricSegment: (
@@ -1263,6 +1264,70 @@ export function useReaderTTS({
     [ttsConfig.pitch, ttsUpdateConfig],
   );
 
+  const handleUpdateTTSConfig = useCallback(
+    (updates: Partial<TTSConfig>) => {
+      const nextConfig = normalizeTTSConfig({ ...ttsConfig, ...updates });
+      const hasActiveSession =
+        ttsCurrentBookId === bookId &&
+        (ttsPlayState === "playing" || ttsPlayState === "paused" || ttsPlayState === "loading");
+      const restartSourceKind = ttsSourceKind;
+      const restartSelectionText = (ttsCurrentText || ttsLastText).trim();
+      const restartCfi =
+        currentTTSSegment?.cfi || resolvedTTSSegmentCfi || ttsCurrentLocationCfi || currentCfi;
+      const restartText =
+        currentTTSSegment?.text || normalizeTTSDebugText(ttsCurrentSegmentText) || undefined;
+
+      console.log("[ReaderScreen][TTS] update-config", {
+        updates,
+        currentEngine: ttsConfig.engine,
+        nextEngine: nextConfig.engine,
+        hasActiveSession,
+        sourceKind: restartSourceKind,
+        restartCfi,
+      });
+
+      ttsUpdateConfig(updates);
+
+      if (!hasActiveSession) return;
+
+      setTimeout(() => {
+        if (restartSourceKind === "selection") {
+          if (restartSelectionText) {
+            startSelectionTTS(restartSelectionText, restartCfi || undefined);
+          }
+          return;
+        }
+
+        const restartFromCfi = startPageTTSFromCfiRef.current;
+        if (restartFromCfi && restartCfi) {
+          void restartFromCfi(restartCfi, restartText);
+          return;
+        }
+
+        void startPageTTS(ttsContinuousEnabled);
+      }, 0);
+    },
+    [
+      bookId,
+      currentCfi,
+      currentTTSSegment?.cfi,
+      currentTTSSegment?.text,
+      resolvedTTSSegmentCfi,
+      startPageTTS,
+      startSelectionTTS,
+      ttsConfig,
+      ttsContinuousEnabled,
+      ttsCurrentBookId,
+      ttsCurrentLocationCfi,
+      ttsCurrentSegmentText,
+      ttsCurrentText,
+      ttsLastText,
+      ttsPlayState,
+      ttsSourceKind,
+      ttsUpdateConfig,
+    ],
+  );
+
   const handleToggleTTSContinuous = useCallback(() => {
     setTtsContinuousEnabled((prev) => {
       const next = !prev;
@@ -1994,6 +2059,7 @@ export function useReaderTTS({
     handleTTSPlayPause,
     handleAdjustTTSRate,
     handleAdjustTTSPitch,
+    handleUpdateTTSConfig,
     handleToggleTTSContinuous,
     handleJumpToTTSSegment,
     handleJumpToTTSLyricSegment,

--- a/packages/app-expo/src/screens/settings/AISettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/AISettingsScreen.tsx
@@ -4,6 +4,7 @@ import { getDefaultBaseUrl, PROVIDER_CONFIGS } from "@readany/core/utils";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -36,6 +37,7 @@ export default function AISettingsScreen() {
   } = useSettingsStore();
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   const handleAddEndpoint = useCallback(async () => {
     const defaultProvider = "openai";
@@ -55,6 +57,7 @@ export default function AISettingsScreen() {
 
   const handleFetchModels = useCallback(
     async (ep: AIEndpoint) => {
+      setFetchError(null);
       await updateEndpoint(ep.id, {
         name: ep.name,
         apiKey: ep.apiKey,
@@ -67,12 +70,20 @@ export default function AISettingsScreen() {
         if (models.length > 0 && !aiConfig.activeModel) {
           setActiveEndpoint(ep.id);
           setActiveModel(models[0]);
+        } else if (models.length === 0) {
+          const message =
+            "No models returned. Check your API key, model access, and whether the base URL points to the API root.";
+          setFetchError(message);
+          Alert.alert(t("common.failed", "失败"), message);
         }
       } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to fetch models";
         console.error("Failed to fetch models:", err);
+        setFetchError(message);
+        Alert.alert(t("common.failed", "失败"), message);
       }
     },
-    [fetchModels, updateEndpoint, aiConfig.activeModel, setActiveEndpoint, setActiveModel],
+    [fetchModels, updateEndpoint, aiConfig.activeModel, setActiveEndpoint, setActiveModel, t],
   );
 
   const addButton = (
@@ -146,6 +157,8 @@ export default function AISettingsScreen() {
               </View>
             );
           })}
+
+          {fetchError ? <Text style={styles.errorText}>{fetchError}</Text> : null}
 
           {/* Global Settings */}
           <View style={styles.sectionCard}>

--- a/packages/app-expo/src/screens/settings/TTSSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/TTSSettingsScreen.tsx
@@ -1,6 +1,21 @@
 import { useTTSStore } from "@/stores";
-import { DASHSCOPE_VOICES, EDGE_TTS_VOICES, type TTSEngine } from "@readany/core/tts";
-import { useCallback, useMemo } from "react";
+import {
+  DEFAULT_SYSTEM_VOICE_VALUE,
+  findSystemVoiceLabel,
+  getSystemVoiceOptionsAsync,
+  groupSystemVoiceOptions,
+  resolveSystemVoiceValue,
+  type NativeSystemVoiceOption,
+} from "@/lib/platform/system-voices";
+import { previewTTSConfig, stopTTSPreview } from "@/lib/platform/tts-preview";
+import {
+  DASHSCOPE_VOICES,
+  EDGE_TTS_VOICES,
+  getLocaleDisplayLabel,
+  groupEdgeTTSVoices,
+  type TTSEngine,
+} from "@readany/core/tts";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   KeyboardAvoidingView,
@@ -26,36 +41,39 @@ import { SettingsHeader } from "./SettingsHeader";
 
 const ENGINES: { id: TTSEngine; labelKey: string }[] = [
   { id: "edge", labelKey: "tts.edgeEngine" },
-  { id: "browser", labelKey: "tts.browser" },
+  { id: "system", labelKey: "tts.system" },
   { id: "dashscope", labelKey: "tts.tongyi" },
 ];
 
 export default function TTSSettingsScreen() {
   const colors = useColors();
   const styles = makeStyles(colors);
-  const { t } = useTranslation();
-  const { config, updateConfig, play, stop } = useTTSStore();
+  const { t, i18n } = useTranslation();
+  const { config, updateConfig, stop } = useTTSStore();
+  const [systemVoices, setSystemVoices] = useState<NativeSystemVoiceOption[]>([]);
 
-  const edgeVoiceGroups = useMemo(() => {
-    const groups: Record<string, typeof EDGE_TTS_VOICES> = {};
-    for (const v of EDGE_TTS_VOICES) {
-      const lang = v.lang;
-      if (!groups[lang]) groups[lang] = [];
-      groups[lang].push(v);
-    }
-    return Object.entries(groups).sort(([a], [b]) => {
-      if (a.startsWith("zh")) return -1;
-      if (b.startsWith("zh")) return 1;
-      if (a.startsWith("en")) return -1;
-      if (b.startsWith("en")) return 1;
-      return a.localeCompare(b);
-    });
+  const displayLocale = i18n.resolvedLanguage || i18n.language;
+  const edgeVoiceGroups = useMemo(() => groupEdgeTTSVoices(EDGE_TTS_VOICES), []);
+
+  const systemVoiceGroups = useMemo(
+    () => groupSystemVoiceOptions(systemVoices),
+    [systemVoices],
+  );
+  const selectedSystemVoiceValue = useMemo(
+    () => resolveSystemVoiceValue(config.voiceName, systemVoices),
+    [config.voiceName, systemVoices],
+  );
+
+  useEffect(() => {
+    void getSystemVoiceOptionsAsync().then(setSystemVoices);
   }, []);
+
+  useEffect(() => stopTTSPreview, []);
 
   const handlePreview = useCallback(() => {
     stop();
-    setTimeout(() => play(t("tts.testText", "这是一段测试文本")), 100);
-  }, [play, stop, t]);
+    void previewTTSConfig(t("tts.testText", "这是一段测试文本"), config);
+  }, [config, stop, t]);
 
   const previewBtn = (
     <TouchableOpacity style={styles.previewBtn} onPress={handlePreview} activeOpacity={0.7}>
@@ -115,7 +133,9 @@ export default function TTSSettingsScreen() {
                 {edgeVoiceGroups.map(([lang, voices]) => (
                   <View key={lang}>
                     <View style={styles.voiceGroupHeader}>
-                      <Text style={styles.voiceGroupLabel}>{lang}</Text>
+                      <Text style={styles.voiceGroupLabel}>
+                        {getLocaleDisplayLabel(lang, displayLocale)}
+                      </Text>
                     </View>
                     {voices.map((v) => (
                       <TouchableOpacity
@@ -180,14 +200,66 @@ export default function TTSSettingsScreen() {
               </>
             )}
 
-            {config.engine === "browser" && (
-              <View style={styles.voiceList}>
-                <View style={styles.emptyVoice}>
-                  <Text style={styles.emptyVoiceText}>
-                    {t("tts.browserNote", "浏览器 TTS 引擎使用系统自带语音合成")}
+            {config.engine === "system" && (
+              <ScrollView style={styles.voiceList} nestedScrollEnabled>
+                <TouchableOpacity
+                  style={styles.voiceItem}
+                  onPress={() => updateConfig({ voiceName: "", systemVoiceLabel: "" })}
+                  activeOpacity={0.7}
+                >
+                  <Text
+                    style={[
+                      styles.voiceName,
+                      selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE &&
+                        styles.voiceNameActive,
+                    ]}
+                  >
+                    {t("tts.defaultVoice")}
                   </Text>
-                </View>
-              </View>
+                  {selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE && (
+                    <Text style={styles.micIcon}>♪</Text>
+                  )}
+                </TouchableOpacity>
+                {systemVoiceGroups.map(([lang, voices]) => (
+                  <View key={lang}>
+                    <View style={styles.voiceGroupHeader}>
+                      <Text style={styles.voiceGroupLabel}>
+                        {getLocaleDisplayLabel(lang, displayLocale)}
+                      </Text>
+                    </View>
+                    {voices.map((voice) => (
+                      <TouchableOpacity
+                        key={voice.id}
+                        style={styles.voiceItem}
+                        onPress={() =>
+                          updateConfig({
+                            voiceName: voice.id,
+                            systemVoiceLabel: findSystemVoiceLabel(voice.id, systemVoices),
+                          })
+                        }
+                        activeOpacity={0.7}
+                      >
+                        <View>
+                          <Text
+                            style={[
+                              styles.voiceName,
+                              selectedSystemVoiceValue === voice.id && styles.voiceNameActive,
+                            ]}
+                          >
+                            {voice.label}
+                          </Text>
+                          <Text style={styles.voiceSubLabel}>
+                            {getLocaleDisplayLabel(voice.lang, displayLocale)}
+                          </Text>
+                        </View>
+                        {selectedSystemVoiceValue === voice.id && (
+                          <Text style={styles.micIcon}>♪</Text>
+                        )}
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                ))}
+              </ScrollView>
             )}
           </View>
 
@@ -214,8 +286,8 @@ export default function TTSSettingsScreen() {
                 />
               </View>
 
-              {/* Pitch (browser only) */}
-              {config.engine === "browser" && (
+              {/* Pitch (system only) */}
+              {config.engine === "system" && (
                 <View style={styles.paramRow}>
                   <View style={styles.paramHeader}>
                     <Text style={styles.paramLabel}>{t("tts.pitch", "音调")}</Text>

--- a/packages/app-expo/src/screens/settings/ai/ai-settings-styles.ts
+++ b/packages/app-expo/src/screens/settings/ai/ai-settings-styles.ts
@@ -213,6 +213,11 @@ export const makeStyles = (colors: ThemeColors) =>
     endpointTestResult: { fontSize: fontSize.xs, marginTop: spacing.xs },
     endpointTestSuccess: { color: "#16a34a" },
     endpointTestError: { color: colors.destructive },
+    errorText: {
+      fontSize: fontSize.xs,
+      color: colors.destructive,
+      marginTop: spacing.xs,
+    },
     modelTags: { flexDirection: "row", flexWrap: "wrap", gap: spacing.xs },
     modelTag: {
       flexDirection: "row",

--- a/packages/app-expo/src/stores/persist.ts
+++ b/packages/app-expo/src/stores/persist.ts
@@ -83,6 +83,7 @@ export function withPersist<T extends object>(
   creator: StateCreator<T>,
   /** Keys to always reset to these values after hydration (transient state that should not be restored) */
   resetAfterHydrate?: Partial<T>,
+  migrate?: (persisted: T) => T,
 ): StateCreator<T> {
   return (set, get, api) => {
     let persistLoaded = false;
@@ -105,9 +106,10 @@ export function withPersist<T extends object>(
     // Load persisted data and notify when done
     loadFromFS<T>(key).then(async (persisted) => {
       if (persisted) {
+        const migrated = migrate ? migrate(persisted) : persisted;
         // Merge persisted data with current state (don't replace methods)
         const currentState = get();
-        const mergedState = { ...currentState, ...persisted, ...(resetAfterHydrate ?? {}), _hasHydrated: true };
+        const mergedState = { ...currentState, ...migrated, ...(resetAfterHydrate ?? {}), _hasHydrated: true };
         (set as (state: T, replace: true) => void)(mergedState as T, true);
       } else {
         const currentState = get();

--- a/packages/app-expo/src/stores/settings-store.ts
+++ b/packages/app-expo/src/stores/settings-store.ts
@@ -85,24 +85,19 @@ async function fetchModelsFromEndpoint(endpoint: AIEndpoint): Promise<string[]> 
     );
   }
 
-  try {
-    switch (endpoint.provider) {
-      case "anthropic":
-        return await fetchAnthropicModels(endpoint);
-      case "google":
-        return await fetchGoogleModels(endpoint);
-      case "deepseek":
-        return await fetchDeepSeekModels(endpoint);
-      case "ollama":
-        return await fetchOllamaModels(endpoint);
-      case "lmstudio":
-        return await fetchLMStudioModels(endpoint);
-      default:
-        return await fetchOpenAIModels(endpoint);
-    }
-  } catch (error) {
-    console.error(`[fetchModels] Failed for ${endpoint.provider}:`, error);
-    return [];
+  switch (endpoint.provider) {
+    case "anthropic":
+      return await fetchAnthropicModels(endpoint);
+    case "google":
+      return await fetchGoogleModels(endpoint);
+    case "deepseek":
+      return await fetchDeepSeekModels(endpoint);
+    case "ollama":
+      return await fetchOllamaModels(endpoint);
+    case "lmstudio":
+      return await fetchLMStudioModels(endpoint);
+    default:
+      return await fetchOpenAIModels(endpoint);
   }
 }
 
@@ -120,8 +115,24 @@ async function fetchOpenAIModels(endpoint: AIEndpoint): Promise<string[]> {
   if (!response.ok) {
     throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`);
   }
-  const data = await response.json();
-  return (data.data || [])
+  const rawBody = await response.text();
+  let data: { data?: Array<{ id: string }> };
+
+  try {
+    data = JSON.parse(rawBody);
+  } catch {
+    throw new Error(
+      "The endpoint did not return JSON. Check whether the base URL points to the API root instead of a console page.",
+    );
+  }
+
+  if (!Array.isArray(data.data)) {
+    throw new Error(
+      "The endpoint returned an unexpected models response. Check whether the base URL points to the OpenAI-compatible API root.",
+    );
+  }
+
+  return data.data
     .map((m: { id: string }) => m.id)
     .sort((a: string, b: string) => a.localeCompare(b));
 }
@@ -441,7 +452,7 @@ export const useSettingsStore = create<SettingsState>()(
               ),
             },
           }));
-          return [];
+          throw err;
         }
       },
 

--- a/packages/app-expo/src/stores/tts-store.ts
+++ b/packages/app-expo/src/stores/tts-store.ts
@@ -1,13 +1,133 @@
-import { splitNarrationText, type TTSConfig } from "@readany/core/tts";
-import * as Speech from "expo-speech";
-/**
- * TTS Store for React Native
- * Uses expo-speech for text-to-speech
- */
+import {
+  DEFAULT_TTS_CONFIG,
+  normalizeTTSConfig,
+  splitNarrationText,
+  type ITTSPlayer,
+  type TTSConfig,
+} from "@readany/core/tts";
+import { ExpoAVEdgeTTSPlayer } from "../lib/platform/expo-av-edge-player";
+import { ExpoSpeechTTSPlayer } from "../lib/platform/expo-speech-player";
 import { create } from "zustand";
 import { withPersist } from "./persist";
 
 export type TTSPlayState = "stopped" | "playing" | "paused" | "loading";
+
+export interface TTSPlayerFactories {
+  createSystemTTS: () => ITTSPlayer;
+  createEdgeTTS: () => ITTSPlayer;
+  createDashScopeTTS: () => ITTSPlayer;
+}
+
+const defaultFactories: TTSPlayerFactories = {
+  createSystemTTS: () => new ExpoSpeechTTSPlayer(),
+  createEdgeTTS: () => new ExpoAVEdgeTTSPlayer(),
+  // DashScope streaming is not wired on RN yet; keep a predictable system fallback.
+  createDashScopeTTS: () => new ExpoSpeechTTSPlayer(),
+};
+
+let _factories: TTSPlayerFactories = defaultFactories;
+let _systemTTS: ITTSPlayer | null = null;
+let _edgeTTS: ITTSPlayer | null = null;
+let _dashscopeTTS: ITTSPlayer | null = null;
+
+let _sessionSegments: string[] = [];
+let _sessionCurrentIndex = 0;
+let _sessionGeneration = 0;
+
+function getSystemTTS(): ITTSPlayer {
+  if (!_systemTTS) _systemTTS = _factories.createSystemTTS();
+  return _systemTTS;
+}
+
+function getEdgeTTS(): ITTSPlayer {
+  if (!_edgeTTS) _edgeTTS = _factories.createEdgeTTS();
+  return _edgeTTS;
+}
+
+function getDashScopeTTS(): ITTSPlayer {
+  if (!_dashscopeTTS) _dashscopeTTS = _factories.createDashScopeTTS();
+  return _dashscopeTTS;
+}
+
+function detachAndStopPlayer(player: ITTSPlayer | null): void {
+  if (!player) return;
+  player.onStateChange = undefined;
+  player.onChunkChange = undefined;
+  player.onEnd = undefined;
+  try {
+    player.stop();
+  } catch {}
+}
+
+function detachAndStopAllPlayers(): void {
+  detachAndStopPlayer(_systemTTS);
+  detachAndStopPlayer(_edgeTTS);
+  detachAndStopPlayer(_dashscopeTTS);
+}
+
+function normalizeSegments(text: string | string[]): string[] {
+  if (Array.isArray(text)) {
+    return text.map((segment) => segment.trim()).filter(Boolean);
+  }
+  return splitNarrationText(text).map((segment) => segment.trim()).filter(Boolean);
+}
+
+function getPlayerForConfig(config: TTSConfig): ITTSPlayer {
+  if (config.engine === "dashscope" && config.dashscopeApiKey) {
+    return getDashScopeTTS();
+  }
+  if (config.engine === "edge") {
+    return getEdgeTTS();
+  }
+  return getSystemTTS();
+}
+
+function startPlayback(
+  segments: string[],
+  config: TTSConfig,
+  startIndex: number,
+  set: (partial: Partial<TTSState>) => void,
+  get: () => TTSState,
+): void {
+  const player = getPlayerForConfig(config);
+  const gen = _sessionGeneration;
+
+  player.onStateChange = (playState) => {
+    if (gen !== _sessionGeneration) return;
+    set({ playState });
+  };
+
+  player.onChunkChange = (chunkIndex) => {
+    if (gen !== _sessionGeneration) return;
+    const absoluteIndex = startIndex + chunkIndex;
+    _sessionCurrentIndex = absoluteIndex;
+    set({
+      currentChunkIndex: absoluteIndex,
+      totalChunks: _sessionSegments.length,
+      currentSegmentText: _sessionSegments[absoluteIndex] || "",
+    });
+  };
+
+  player.onEnd = () => {
+    if (gen !== _sessionGeneration) return;
+    const lastIndex = Math.max(0, _sessionSegments.length - 1);
+    _sessionCurrentIndex = lastIndex;
+    set({
+      playState: "stopped",
+      currentChunkIndex: lastIndex,
+      totalChunks: _sessionSegments.length,
+      currentSegmentText: _sessionSegments[lastIndex] || "",
+    });
+    get().onEnd?.();
+  };
+
+  const playback = player.speak(segments, config);
+  void Promise.resolve(playback).catch((error) => {
+    if (gen !== _sessionGeneration) return;
+    console.error("[TTSStore] play failed:", error);
+    set({ playState: "stopped" });
+  });
+}
 
 export interface TTSState {
   playState: TTSPlayState;
@@ -33,254 +153,202 @@ export interface TTSState {
   setCurrentBook: (title: string, chapter: string, bookId?: string) => void;
   setCurrentLocation: (cfi?: string | null) => void;
   setChunkProgress: (index: number, total: number) => void;
-  /** Jump to a specific chunk index within the current session, restarting speech from that point */
   jumpToChunk: (index: number) => void;
 }
 
-const DEFAULT_TTS_CONFIG: TTSConfig = {
-  engine: "browser",
-  voiceName: "",
-  rate: 1.0,
-  pitch: 1.0,
-  edgeVoice: "zh-CN-XiaoxiaoNeural",
-  dashscopeApiKey: "",
-  dashscopeVoice: "Cherry",
-};
-
-let _sessionSegments: string[] = [];
-let _sessionIndex = 0;
-let _sessionStopped = false;
-let _sessionLanguage = "zh-CN";
-/** Generation counter — incremented on every play/jumpToChunk to invalidate stale callbacks */
-let _sessionGeneration = 0;
-
-function normalizeSegments(text: string | string[]): string[] {
-  if (Array.isArray(text)) {
-    return text.map((segment) => segment.trim()).filter(Boolean);
-  }
-  return splitNarrationText(text).map((segment) => segment.trim()).filter(Boolean);
-}
-
-function stopSpeechSilently() {
-  try {
-    Speech.stop();
-  } catch {}
-}
-
-function detectLanguage(text: string): string {
-  const cjk = text.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g);
-  return cjk && cjk.length > text.length * 0.1 ? "zh-CN" : "en-US";
-}
-
-function speakSegmentQueue(
-  set: (partial: Partial<TTSState>) => void,
-  get: () => TTSState,
-  language: string,
-  options?: { showLoading?: boolean },
-) {
-  const gen = _sessionGeneration;
-  if (_sessionStopped || _sessionIndex >= _sessionSegments.length) {
-    const currentOnEnd = get().onEnd;
-    console.log("[TTSStore] Session finished", {
-      sessionIndex: _sessionIndex,
-      sessionLength: _sessionSegments.length,
-      hasOnEnd: !!currentOnEnd,
-    });
-    set({ playState: "stopped" });
-    currentOnEnd?.();
-    return;
-  }
-
-  const segment = _sessionSegments[_sessionIndex];
-  if (options?.showLoading) {
-    set({
-      playState: "loading",
-      currentSegmentText: segment,
-      currentChunkIndex: _sessionIndex,
-      totalChunks: _sessionSegments.length,
-    });
-  } else {
-    set({
-      currentSegmentText: segment,
-      currentChunkIndex: _sessionIndex,
-      totalChunks: _sessionSegments.length,
-    });
-  }
-
-  Speech.speak(segment, {
-    rate: get().config.rate || 1.0,
-    pitch: get().config.pitch || 1.0,
-    language,
-    onDone: () => {
-      if (_sessionStopped || gen !== _sessionGeneration) return;
-      _sessionIndex += 1;
-      speakSegmentQueue(set, get, language);
-    },
-    onStopped: () => {
-      console.log("[TTSStore] Speech.onStopped");
-    },
-    onError: (e) => {
-      console.log("[TTSStore] Speech.onError:", e);
-      if (_sessionStopped || gen !== _sessionGeneration) return;
-      _sessionIndex += 1;
-      speakSegmentQueue(set, get, language);
-    },
-    onStart: () => {
-      if (gen !== _sessionGeneration) return;
-      console.log("[TTSStore] Speech.onStart");
-      set({
-        playState: "playing",
-        currentSegmentText: segment,
-        currentChunkIndex: _sessionIndex,
-        totalChunks: _sessionSegments.length,
-      });
-    },
-  });
-}
-
 export const useTTSStore = create<TTSState>()(
-  withPersist<TTSState>("tts", (set, get) => ({
-    playState: "stopped",
-    currentText: "",
-    currentSegmentText: "",
-    config: DEFAULT_TTS_CONFIG,
-    onEnd: null,
-    currentBookTitle: "",
-    currentChapterTitle: "",
-    currentBookId: "",
-    currentLocationCfi: "",
-    currentChunkIndex: 0,
-    totalChunks: 0,
+  withPersist<TTSState>(
+    "tts",
+    (set, get) => ({
+      playState: "stopped",
+      currentText: "",
+      currentSegmentText: "",
+      config: DEFAULT_TTS_CONFIG,
+      onEnd: null,
+      currentBookTitle: "",
+      currentChapterTitle: "",
+      currentBookId: "",
+      currentLocationCfi: "",
+      currentChunkIndex: 0,
+      totalChunks: 0,
 
-    play: (text: string | string[]) => {
-      const segments = normalizeSegments(text);
-      const joinedText = segments.join(" ").trim();
-      console.log("[TTSStore] play called with segments:", segments.length);
-      if (!joinedText) {
-        console.log("[TTSStore] No text to speak");
-        return;
-      }
-      stopSpeechSilently();
-      _sessionGeneration += 1;
-      _sessionSegments = segments;
-      _sessionIndex = 0;
-      _sessionStopped = false;
-      _sessionLanguage = detectLanguage(joinedText);
-      set({
-        playState: "loading",
-        currentText: joinedText,
-        currentSegmentText: segments[0] || "",
-        currentChunkIndex: 0,
-        totalChunks: segments.length,
-      });
-      console.log("[TTSStore] detected language:", _sessionLanguage);
-      speakSegmentQueue(set, get, _sessionLanguage, { showLoading: true });
-    },
+      play: (text: string | string[]) => {
+        const segments = normalizeSegments(text);
+        const joinedText = segments.join(" ").trim();
+        if (!joinedText) {
+          console.log("[TTSStore] No text to speak");
+          return;
+        }
 
-    pause: () => {
-      console.log("[TTSStore] pause called");
-      const state = get().playState;
-      if (state !== "playing" && state !== "loading") return;
-      _sessionGeneration += 1;
-      _sessionStopped = true;
-      stopSpeechSilently();
-      set({ playState: "paused" });
-    },
+        const config = normalizeTTSConfig(get().config);
+        detachAndStopAllPlayers();
+        _sessionGeneration += 1;
+        _sessionSegments = segments;
+        _sessionCurrentIndex = 0;
 
-    resume: () => {
-      console.log("[TTSStore] resume called");
-      if (_sessionSegments.length === 0 || _sessionIndex >= _sessionSegments.length) {
-        set({ playState: "stopped" });
-        return;
-      }
-      _sessionGeneration += 1;
-      _sessionStopped = false;
-      set({
-        playState: "loading",
-        currentSegmentText: _sessionSegments[_sessionIndex] || "",
-        currentChunkIndex: _sessionIndex,
-        totalChunks: _sessionSegments.length,
-      });
-      speakSegmentQueue(set, get, _sessionLanguage, { showLoading: false });
-    },
+        console.log("[TTSStore] play called", {
+          engine: config.engine,
+          segments: segments.length,
+          edgeVoice: config.edgeVoice,
+          voiceName: config.voiceName,
+        });
 
-    stop: () => {
-      console.log("[TTSStore] stop called");
-      _sessionGeneration += 1;
-      _sessionStopped = true;
-      _sessionSegments = [];
-      _sessionIndex = 0;
-      stopSpeechSilently();
-      set({
-        playState: "stopped",
-        currentText: "",
-        currentSegmentText: "",
-        onEnd: null,
-        currentChunkIndex: 0,
-        totalChunks: 0,
-        currentBookTitle: "",
-        currentChapterTitle: "",
-        currentBookId: "",
-        currentLocationCfi: "",
-      });
-    },
+        set({
+          playState: "loading",
+          currentText: joinedText,
+          currentSegmentText: segments[0] || "",
+          currentChunkIndex: 0,
+          totalChunks: segments.length,
+        });
 
-    toggle: (text?: string) => {
-      console.log("[TTSStore] toggle called, playState:", get().playState);
-      const { playState, currentText, play } = get();
-      if (playState === "playing") {
-        get().pause();
-      } else if (playState === "paused") {
-        get().resume();
-      } else if (text) {
-        play(text);
-      } else if (currentText) {
-        play(currentText);
-      }
-    },
+        startPlayback(segments, config, 0, set, get);
+      },
 
-    updateConfig: (updates) => set((s) => ({ config: { ...s.config, ...updates } })),
+      pause: () => {
+        console.log("[TTSStore] pause called");
+        const { playState } = get();
+        if (playState !== "playing" && playState !== "loading") return;
+        _sessionGeneration += 1;
+        detachAndStopAllPlayers();
+        set({ playState: "paused" });
+      },
 
-    setPlayState: (playState) => set({ playState }),
+      resume: () => {
+        console.log("[TTSStore] resume called");
+        if (_sessionSegments.length === 0 || _sessionCurrentIndex >= _sessionSegments.length) {
+          set({ playState: "stopped" });
+          return;
+        }
 
-    setOnEnd: (cb) => {
-      console.log("[TTSStore] setOnEnd", {
-        hasCallback: !!cb,
-      });
-      set({ onEnd: cb });
-    },
+        const config = normalizeTTSConfig(get().config);
+        const nextIndex = Math.max(0, Math.min(_sessionCurrentIndex, _sessionSegments.length - 1));
+        const remainingSegments = _sessionSegments.slice(nextIndex);
+        if (remainingSegments.length === 0) {
+          set({ playState: "stopped" });
+          return;
+        }
 
-    setCurrentBook: (title, chapter, bookId) =>
-      set({ currentBookTitle: title, currentChapterTitle: chapter, currentBookId: bookId ?? "" }),
+        detachAndStopAllPlayers();
+        _sessionGeneration += 1;
+        _sessionCurrentIndex = nextIndex;
 
-    setCurrentLocation: (cfi) => set({ currentLocationCfi: cfi ?? "" }),
+        set({
+          playState: "loading",
+          currentSegmentText: _sessionSegments[nextIndex] || "",
+          currentChunkIndex: nextIndex,
+          totalChunks: _sessionSegments.length,
+        });
 
-    setChunkProgress: (index, total) => set({ currentChunkIndex: index, totalChunks: total }),
+        startPlayback(remainingSegments, config, nextIndex, set, get);
+      },
 
-    jumpToChunk: (index: number) => {
-      if (index < 0 || index >= _sessionSegments.length) return;
-      stopSpeechSilently();
-      _sessionGeneration += 1;
-      _sessionIndex = index;
-      _sessionStopped = false;
-      set({
-        playState: "loading",
-        currentSegmentText: _sessionSegments[index] || "",
-        currentChunkIndex: index,
-        totalChunks: _sessionSegments.length,
-      });
-      speakSegmentQueue(set, get, _sessionLanguage, { showLoading: false });
-    },
-  }), {
-    playState: "stopped" as const,
-    currentText: "",
-    currentSegmentText: "",
-    currentChunkIndex: 0,
-    totalChunks: 0,
-    currentLocationCfi: "",
-  } as Partial<TTSState>),
+      stop: () => {
+        console.log("[TTSStore] stop called");
+        _sessionGeneration += 1;
+        detachAndStopAllPlayers();
+        _sessionSegments = [];
+        _sessionCurrentIndex = 0;
+        set({
+          playState: "stopped",
+          currentText: "",
+          currentSegmentText: "",
+          onEnd: null,
+          currentChunkIndex: 0,
+          totalChunks: 0,
+          currentBookTitle: "",
+          currentChapterTitle: "",
+          currentBookId: "",
+          currentLocationCfi: "",
+        });
+      },
+
+      toggle: (text?: string) => {
+        console.log("[TTSStore] toggle called, playState:", get().playState);
+        const { playState, currentText, play } = get();
+        if (playState === "playing" || playState === "loading") {
+          get().pause();
+        } else if (playState === "paused") {
+          get().resume();
+        } else if (text) {
+          play(text);
+        } else if (currentText) {
+          play(currentText);
+        }
+      },
+
+      updateConfig: (updates) =>
+        set((state) => ({
+          config: normalizeTTSConfig({ ...state.config, ...updates }),
+        })),
+
+      setPlayState: (playState) => set({ playState }),
+
+      setOnEnd: (cb) => {
+        console.log("[TTSStore] setOnEnd", { hasCallback: !!cb });
+        set({ onEnd: cb });
+      },
+
+      setCurrentBook: (title, chapter, bookId) =>
+        set({ currentBookTitle: title, currentChapterTitle: chapter, currentBookId: bookId ?? "" }),
+
+      setCurrentLocation: (cfi) => set({ currentLocationCfi: cfi ?? "" }),
+
+      setChunkProgress: (index, total) =>
+        set({
+          currentChunkIndex: index,
+          totalChunks: total,
+          currentSegmentText: _sessionSegments[index] || "",
+        }),
+
+      jumpToChunk: (index: number) => {
+        if (index < 0 || index >= _sessionSegments.length) return;
+
+        const config = normalizeTTSConfig(get().config);
+        const remainingSegments = _sessionSegments.slice(index);
+        if (remainingSegments.length === 0) {
+          set({ playState: "stopped" });
+          return;
+        }
+
+        console.log("[TTSStore] jumpToChunk", {
+          index,
+          engine: config.engine,
+          segments: _sessionSegments.length,
+        });
+
+        detachAndStopAllPlayers();
+        _sessionGeneration += 1;
+        _sessionCurrentIndex = index;
+
+        set({
+          playState: "loading",
+          currentSegmentText: _sessionSegments[index] || "",
+          currentChunkIndex: index,
+          totalChunks: _sessionSegments.length,
+        });
+
+        startPlayback(remainingSegments, config, index, set, get);
+      },
+    }),
+    {
+      playState: "stopped" as const,
+      currentText: "",
+      currentSegmentText: "",
+      currentChunkIndex: 0,
+      totalChunks: 0,
+      currentLocationCfi: "",
+    } as Partial<TTSState>,
+    (persisted) => ({
+      ...persisted,
+      config: normalizeTTSConfig((persisted as TTSState).config),
+    }),
+  ),
 );
 
-export function setTTSPlayerFactories(): void {
-  console.log("TTS using expo-speech");
+export function setTTSPlayerFactories(factories: Partial<TTSPlayerFactories>): void {
+  _factories = { ...defaultFactories, ...factories };
+  detachAndStopAllPlayers();
+  _systemTTS = null;
+  _edgeTTS = null;
+  _dashscopeTTS = null;
 }

--- a/packages/app/src/components/reader/FooterBar.tsx
+++ b/packages/app/src/components/reader/FooterBar.tsx
@@ -8,10 +8,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { DASHSCOPE_VOICES, EDGE_TTS_VOICES, getBrowserVoices } from "@/lib/tts/tts-service";
+import { DASHSCOPE_VOICES, EDGE_TTS_VOICES, getSystemVoices } from "@/lib/tts/tts-service";
+import {
+  DEFAULT_SYSTEM_VOICE_VALUE,
+  findSystemVoiceLabel,
+  getSystemVoiceOptions,
+  groupSystemVoiceOptions,
+  resolveSystemVoiceValue,
+} from "@/lib/tts/system-voices";
 import type { TTSEngine } from "@/lib/tts/tts-service";
 import { useReaderStore } from "@/stores/reader-store";
 import { useTTSStore } from "@/stores/tts-store";
+import { getLocaleDisplayLabel, groupEdgeTTSVoices } from "@readany/core/tts";
 import {
   ChevronDown,
   ChevronLeft,
@@ -24,7 +32,7 @@ import {
   Plus,
   Square,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 interface FooterBarProps {
@@ -53,7 +61,7 @@ export function FooterBar({
   showTTS = false,
   onTTSClose,
 }: FooterBarProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const tab = useReaderStore((s) => s.tabs[tabId]);
 
   const playState = useTTSStore((s) => s.playState);
@@ -67,11 +75,23 @@ export function FooterBar({
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
 
   useEffect(() => {
-    const loadVoices = () => setVoices(getBrowserVoices());
+    const loadVoices = () => setVoices(getSystemVoices());
     loadVoices();
     window.speechSynthesis?.addEventListener?.("voiceschanged", loadVoices);
     return () => window.speechSynthesis?.removeEventListener?.("voiceschanged", loadVoices);
   }, []);
+
+  const displayLocale = i18n.resolvedLanguage || i18n.language;
+  const edgeVoiceGroups = useMemo(() => groupEdgeTTSVoices(EDGE_TTS_VOICES), []);
+  const systemVoiceOptions = useMemo(() => getSystemVoiceOptions(voices), [voices]);
+  const systemVoiceGroups = useMemo(
+    () => groupSystemVoiceOptions(systemVoiceOptions),
+    [systemVoiceOptions],
+  );
+  const selectedSystemVoiceValue = useMemo(
+    () => resolveSystemVoiceValue(config.voiceName, systemVoiceOptions),
+    [config.voiceName, systemVoiceOptions],
+  );
 
   // Collapse settings when TTS is hidden
   useEffect(() => {
@@ -109,7 +129,7 @@ export function FooterBar({
             <div className="flex items-center gap-3">
               <span className="text-xs text-muted-foreground w-16 shrink-0">{t("tts.engine")}</span>
               <div className="flex gap-1">
-                {(["edge", "browser", "dashscope"] as TTSEngine[]).map((eng) => (
+                {(["edge", "system", "dashscope"] as TTSEngine[]).map((eng) => (
                   <Button
                     key={eng}
                     variant={config.engine === eng ? "default" : "secondary"}
@@ -117,8 +137,8 @@ export function FooterBar({
                     className="h-7 text-xs"
                     onClick={() => updateConfig({ engine: eng })}
                   >
-                    {eng === "browser"
-                      ? t("tts.browserEngine")
+                    {eng === "system"
+                      ? t("tts.systemEngine")
                       : eng === "edge"
                         ? t("tts.edgeEngine")
                         : t("tts.dashscopeEngine")}
@@ -141,36 +161,57 @@ export function FooterBar({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent className="max-h-[200px]">
-                    {EDGE_TTS_VOICES.filter((v) => {
-                      const selectedLang =
-                        config.edgeVoice?.split("-").slice(0, 2).join("-") || "zh-CN";
-                      return v.lang === selectedLang;
-                    }).map((v) => (
-                      <SelectItem key={v.id} value={v.id}>
-                        {v.name} ({v.lang})
-                      </SelectItem>
+                    {edgeVoiceGroups.map(([lang, voices]) => (
+                      <div key={lang}>
+                        <div className="px-2 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                          {getLocaleDisplayLabel(lang, displayLocale)}
+                        </div>
+                        {voices.map((v) => (
+                          <SelectItem key={v.id} value={v.id}>
+                            {v.name}
+                          </SelectItem>
+                        ))}
+                      </div>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
-            ) : config.engine === "browser" ? (
+            ) : config.engine === "system" ? (
               <div className="flex items-center gap-3">
                 <span className="text-xs text-muted-foreground w-16 shrink-0">
                   {t("tts.voice")}
                 </span>
                 <Select
-                  value={config.voiceName || "__default__"}
-                  onValueChange={(v) => updateConfig({ voiceName: v === "__default__" ? "" : v })}
+                  value={selectedSystemVoiceValue}
+                  onValueChange={(v) => {
+                    if (v === DEFAULT_SYSTEM_VOICE_VALUE) {
+                      updateConfig({ voiceName: "", systemVoiceLabel: "" });
+                      return;
+                    }
+                    updateConfig({
+                      voiceName: v,
+                      systemVoiceLabel: findSystemVoiceLabel(v, systemVoiceOptions),
+                    });
+                  }}
                 >
                   <SelectTrigger className="h-7 flex-1 text-xs">
                     <SelectValue placeholder={t("tts.defaultVoice")} />
                   </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__default__">{t("tts.defaultVoice")}</SelectItem>
-                    {voices.map((v) => (
-                      <SelectItem key={v.name} value={v.name}>
-                        {v.name} ({v.lang})
-                      </SelectItem>
+                  <SelectContent className="max-h-[220px]">
+                    <SelectItem value={DEFAULT_SYSTEM_VOICE_VALUE}>
+                    {t("tts.defaultVoice")}
+                  </SelectItem>
+                  {systemVoiceGroups.map(([lang, langVoices]) => (
+                    <div key={lang}>
+                      <div className="px-2 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                          {getLocaleDisplayLabel(lang, displayLocale)}
+                      </div>
+                      {langVoices.map((voice) => (
+                        <SelectItem key={voice.id} value={voice.id}>
+                            {voice.label}
+                          </SelectItem>
+                        ))}
+                      </div>
                     ))}
                   </SelectContent>
                 </Select>

--- a/packages/app/src/components/reader/TTSControls.tsx
+++ b/packages/app/src/components/reader/TTSControls.tsx
@@ -8,9 +8,17 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { DASHSCOPE_VOICES, getBrowserVoices } from "@/lib/tts/tts-service";
+import { DASHSCOPE_VOICES, getSystemVoices } from "@/lib/tts/tts-service";
+import {
+  DEFAULT_SYSTEM_VOICE_VALUE,
+  findSystemVoiceLabel,
+  getSystemVoiceOptions,
+  groupSystemVoiceOptions,
+  resolveSystemVoiceValue,
+} from "@/lib/tts/system-voices";
 import type { TTSEngine } from "@/lib/tts/tts-service";
 import { useTTSStore } from "@/stores/tts-store";
+import { getLocaleDisplayLabel } from "@readany/core/tts";
 import { cn } from "@readany/core/utils";
 import { ChevronDown, ChevronUp, Headphones, Minus, Pause, Play, Plus, Square } from "lucide-react";
 /**
@@ -19,7 +27,7 @@ import { ChevronDown, ChevronUp, Headphones, Minus, Pause, Play, Plus, Square } 
  * Appears at bottom of reader when TTS is active.
  * Uses shadcn/ui: Button, Select, Slider, Tooltip.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 interface TTSControlsProps {
@@ -28,7 +36,7 @@ interface TTSControlsProps {
 }
 
 export function TTSControls({ onClose, className }: TTSControlsProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const playState = useTTSStore((s) => s.playState);
   const config = useTTSStore((s) => s.config);
   const pause = useTTSStore((s) => s.pause);
@@ -40,11 +48,22 @@ export function TTSControls({ onClose, className }: TTSControlsProps) {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
 
   useEffect(() => {
-    const loadVoices = () => setVoices(getBrowserVoices());
+    const loadVoices = () => setVoices(getSystemVoices());
     loadVoices();
     window.speechSynthesis?.addEventListener?.("voiceschanged", loadVoices);
     return () => window.speechSynthesis?.removeEventListener?.("voiceschanged", loadVoices);
   }, []);
+
+  const displayLocale = i18n.resolvedLanguage || i18n.language;
+  const systemVoiceOptions = useMemo(() => getSystemVoiceOptions(voices), [voices]);
+  const systemVoiceGroups = useMemo(
+    () => groupSystemVoiceOptions(systemVoiceOptions),
+    [systemVoiceOptions],
+  );
+  const selectedSystemVoiceValue = useMemo(
+    () => resolveSystemVoiceValue(config.voiceName, systemVoiceOptions),
+    [config.voiceName, systemVoiceOptions],
+  );
 
   const handleStop = () => {
     stop();
@@ -71,7 +90,7 @@ export function TTSControls({ onClose, className }: TTSControlsProps) {
             <div className="flex items-center gap-3">
               <span className="text-xs text-muted-foreground w-16 shrink-0">{t("tts.engine")}</span>
               <div className="flex gap-1">
-                {(["browser", "dashscope"] as TTSEngine[]).map((eng) => (
+                {(["system", "dashscope"] as TTSEngine[]).map((eng) => (
                   <Button
                     key={eng}
                     variant={config.engine === eng ? "default" : "secondary"}
@@ -79,31 +98,49 @@ export function TTSControls({ onClose, className }: TTSControlsProps) {
                     className="h-7 text-xs"
                     onClick={() => updateConfig({ engine: eng })}
                   >
-                    {eng === "browser" ? t("tts.browserEngine") : t("tts.dashscopeEngine")}
+                    {eng === "system" ? t("tts.systemEngine") : t("tts.dashscopeEngine")}
                   </Button>
                 ))}
               </div>
             </div>
 
             {/* Voice selection */}
-            {config.engine === "browser" ? (
+            {config.engine === "system" ? (
               <div className="flex items-center gap-3">
                 <span className="text-xs text-muted-foreground w-16 shrink-0">
                   {t("tts.voice")}
                 </span>
                 <Select
-                  value={config.voiceName || "__default__"}
-                  onValueChange={(v) => updateConfig({ voiceName: v === "__default__" ? "" : v })}
+                  value={selectedSystemVoiceValue}
+                  onValueChange={(v) => {
+                    if (v === DEFAULT_SYSTEM_VOICE_VALUE) {
+                      updateConfig({ voiceName: "", systemVoiceLabel: "" });
+                      return;
+                    }
+                    updateConfig({
+                      voiceName: v,
+                      systemVoiceLabel: findSystemVoiceLabel(v, systemVoiceOptions),
+                    });
+                  }}
                 >
                   <SelectTrigger className="h-7 flex-1 text-xs">
                     <SelectValue placeholder={t("tts.defaultVoice")} />
                   </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__default__">{t("tts.defaultVoice")}</SelectItem>
-                    {voices.map((v) => (
-                      <SelectItem key={v.name} value={v.name}>
-                        {v.name} ({v.lang})
-                      </SelectItem>
+                  <SelectContent className="max-h-[220px]">
+                    <SelectItem value={DEFAULT_SYSTEM_VOICE_VALUE}>
+                    {t("tts.defaultVoice")}
+                  </SelectItem>
+                    {systemVoiceGroups.map(([lang, langVoices]) => (
+                      <div key={lang}>
+                        <div className="px-2 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                          {getLocaleDisplayLabel(lang, displayLocale)}
+                        </div>
+                        {langVoices.map((voice) => (
+                          <SelectItem key={voice.id} value={voice.id}>
+                            {voice.label}
+                          </SelectItem>
+                        ))}
+                      </div>
                     ))}
                   </SelectContent>
                 </Select>

--- a/packages/app/src/components/reader/TTSPage.tsx
+++ b/packages/app/src/components/reader/TTSPage.tsx
@@ -2,10 +2,20 @@ import {
   buildNarrationPreview,
   DASHSCOPE_VOICES,
   EDGE_TTS_VOICES,
+  getLocaleDisplayLabel,
   getTTSVoiceLabel,
+  groupEdgeTTSVoices,
   type TTSConfig,
   type TTSPlayState,
 } from "@readany/core/tts";
+import { getSystemVoices } from "@/lib/tts/tts-service";
+import {
+  DEFAULT_SYSTEM_VOICE_VALUE,
+  findSystemVoiceLabel,
+  getSystemVoiceOptions,
+  groupSystemVoiceOptions,
+  resolveSystemVoiceValue,
+} from "@/lib/tts/system-voices";
 import {
   ChevronLeft,
   ChevronRight,
@@ -101,8 +111,9 @@ export function TTSPage({
   onPrevChapter: _onPrevChapter,
   onNextChapter: _onNextChapter,
 }: TTSPageProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [voicePickerOpen, setVoicePickerOpen] = useState(false);
+  const [systemVoices, setSystemVoices] = useState<SpeechSynthesisVoice[]>([]);
   const voiceAnchorRef = useRef<HTMLButtonElement>(null);
   const activeLyricRef = useRef<HTMLButtonElement | null>(null);
   const pendingScrollRef = useRef(false);
@@ -120,6 +131,24 @@ export function TTSPage({
   const loadMoreBelowLockRef = useRef(false);
 
   const fallbackPreview = useMemo(() => buildNarrationPreview(currentText), [currentText]);
+  useEffect(() => {
+    const loadVoices = () => setSystemVoices(getSystemVoices());
+    loadVoices();
+    window.speechSynthesis?.addEventListener?.("voiceschanged", loadVoices);
+    return () => window.speechSynthesis?.removeEventListener?.("voiceschanged", loadVoices);
+  }, []);
+
+  const displayLocale = i18n.resolvedLanguage || i18n.language;
+  const edgeVoiceGroups = useMemo(() => groupEdgeTTSVoices(EDGE_TTS_VOICES), []);
+  const systemVoiceOptions = useMemo(() => getSystemVoiceOptions(systemVoices), [systemVoices]);
+  const systemVoiceGroups = useMemo(
+    () => groupSystemVoiceOptions(systemVoiceOptions),
+    [systemVoiceOptions],
+  );
+  const selectedSystemVoiceValue = useMemo(
+    () => resolveSystemVoiceValue(config.voiceName, systemVoiceOptions),
+    [config.voiceName, systemVoiceOptions],
+  );
   const prevCount =
     prevNarrationSegments?.filter((segment) => segment.text.trim().length > 0).length ?? 0;
   const lyricSegments = useMemo(() => {
@@ -304,7 +333,7 @@ export function TTSPage({
                   ? "Edge TTS"
                   : config.engine === "dashscope"
                     ? "DashScope"
-                    : t("tts.browser")}
+                    : t("tts.system")}
                 {onUpdateConfig && <ChevronRight className="h-2.5 w-2.5" />}
               </button>
             </div>
@@ -333,10 +362,10 @@ export function TTSPage({
                     <div className="sticky top-0 z-10 border-b border-border/30 bg-background/95 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                       {t("tts.selectEngine")}
                     </div>
-                    {(["edge", "dashscope", "browser"] as const).map((eng) => {
+                    {(["edge", "dashscope", "system"] as const).map((eng) => {
                       const isActive = config.engine === eng;
                       const label =
-                        eng === "edge" ? "Edge TTS" : eng === "dashscope" ? "DashScope" : t("tts.browser");
+                        eng === "edge" ? "Edge TTS" : eng === "dashscope" ? "DashScope" : t("tts.system");
                       const desc =
                         eng === "edge"
                           ? "Microsoft · 多语言"
@@ -362,7 +391,7 @@ export function TTSPage({
                     })}
 
                     {/* Voice section */}
-                    {config.engine !== "browser" && (
+                    {config.engine !== "system" && (
                       <div className="sticky top-8 z-10 border-y border-border/30 bg-background/95 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                         {t("tts.selectVoice")}
                       </div>
@@ -385,45 +414,77 @@ export function TTSPage({
                         </button>
                       ))}
                     {config.engine === "edge" &&
-                      (() => {
-                        // Group by language, show zh-* first
-                        const grouped = EDGE_TTS_VOICES.reduce<Record<string, typeof EDGE_TTS_VOICES>>((acc, v) => {
-                          (acc[v.lang] ??= []).push(v);
-                          return acc;
-                        }, {});
-                        const langs = Object.keys(grouped).sort((a, b) => {
-                          const aZh = a.startsWith("zh") ? -1 : 0;
-                          const bZh = b.startsWith("zh") ? -1 : 0;
-                          return aZh - bZh || a.localeCompare(b);
-                        });
-                        return langs.map((lang) => (
-                          <div key={lang}>
-                            <div className="bg-muted/60 px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground/70">
-                              {lang}
-                            </div>
-                            {grouped[lang].map((v) => (
+                      edgeVoiceGroups.map(([lang, voices]) => (
+                        <div key={lang}>
+                          <div className="bg-muted/60 px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                            {getLocaleDisplayLabel(lang, displayLocale)}
+                          </div>
+                          {voices.map((v) => (
+                            <button
+                              key={v.id}
+                              type="button"
+                              onClick={() => {
+                                onUpdateConfig({ edgeVoice: v.id });
+                                setVoicePickerOpen(false);
+                              }}
+                              className={`flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors hover:bg-muted ${config.edgeVoice === v.id ? "font-semibold text-primary" : "text-foreground"}`}
+                            >
+                              {v.name}
+                              {config.edgeVoice === v.id && (
+                                <span className="text-[11px] font-bold text-primary">✓</span>
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      ))}
+                    {config.engine === "system" && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onUpdateConfig?.({ voiceName: "", systemVoiceLabel: "" });
+                            setVoicePickerOpen(false);
+                          }}
+                          className={`flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors hover:bg-muted ${selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE ? "font-semibold text-primary" : "text-foreground"}`}
+                        >
+                          {t("tts.defaultVoice")}
+                          {selectedSystemVoiceValue === DEFAULT_SYSTEM_VOICE_VALUE && (
+                            <span className="text-[11px] font-bold text-primary">✓</span>
+                          )}
+                        </button>
+                        {systemVoiceGroups.map(([lang, langVoices]) => (
+                        <div key={lang}>
+                          <div className="bg-muted/60 px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                            {getLocaleDisplayLabel(lang, displayLocale)}
+                          </div>
+                          {langVoices.map((voice) => {
+                            const isSelected = selectedSystemVoiceValue === voice.id;
+                            return (
                               <button
-                                key={v.id}
+                                key={voice.id}
                                 type="button"
                                 onClick={() => {
-                                  onUpdateConfig({ edgeVoice: v.id });
+                                  onUpdateConfig?.({
+                                    voiceName: voice.id,
+                                    systemVoiceLabel: findSystemVoiceLabel(
+                                      voice.id,
+                                      systemVoiceOptions,
+                                    ),
+                                  });
                                   setVoicePickerOpen(false);
                                 }}
-                                className={`flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors hover:bg-muted ${config.edgeVoice === v.id ? "font-semibold text-primary" : "text-foreground"}`}
+                                className={`flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors hover:bg-muted ${isSelected ? "font-semibold text-primary" : "text-foreground"}`}
                               >
-                                {v.name}
-                                {config.edgeVoice === v.id && (
+                                {voice.label}
+                                {isSelected && (
                                   <span className="text-[11px] font-bold text-primary">✓</span>
                                 )}
                               </button>
-                            ))}
-                          </div>
-                        ));
-                      })()}
-                    {config.engine === "browser" && (
-                      <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                        {t("tts.browserVoiceNote")}
-                      </div>
+                            );
+                          })}
+                        </div>
+                        ))}
+                      </>
                     )}
                   </div>
                 </>

--- a/packages/app/src/components/settings/AISettings.tsx
+++ b/packages/app/src/components/settings/AISettings.tsx
@@ -542,7 +542,9 @@ export function AISettings() {
       try {
         const models = await fetchModels(endpointId);
         if (models.length === 0) {
-          setFetchError("No models returned. Check your API key and URL.");
+          setFetchError(
+            "No models returned. Check your API key, model access, and whether the base URL points to the API root.",
+          );
         } else if (!aiConfig.activeModel) {
           // 自动选中第一个模型（如果当前没有选中任何模型）
           setActiveEndpoint(endpointId);

--- a/packages/app/src/components/settings/TTSSettings.tsx
+++ b/packages/app/src/components/settings/TTSSettings.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/ui/password-input";
 import {
   Select,
@@ -7,11 +8,20 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
-import { DASHSCOPE_VOICES, EDGE_TTS_VOICES, getBrowserVoices } from "@/lib/tts/tts-service";
+import { DASHSCOPE_VOICES, EDGE_TTS_VOICES, getSystemVoices } from "@/lib/tts/tts-service";
+import {
+  DEFAULT_SYSTEM_VOICE_VALUE,
+  findSystemVoiceLabel,
+  getSystemVoiceOptions,
+  groupSystemVoiceOptions,
+  resolveSystemVoiceValue,
+} from "@/lib/tts/system-voices";
+import { previewTTSConfig, stopTTSPreview } from "@/lib/tts/tts-preview";
 import type { TTSEngine } from "@/lib/tts/tts-service";
 import { useTTSStore } from "@/stores/tts-store";
+import { getLocaleDisplayLabel, groupEdgeTTSVoices } from "@readany/core/tts";
 import { cn } from "@readany/core/utils";
-import { Globe, Mic, type Volume2, Zap } from "lucide-react";
+import { Headphones, Mic, Play, type Volume2, Zap } from "lucide-react";
 /**
  * TTSSettings — TTS configuration panel in the settings dialog.
  *
@@ -21,33 +31,49 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export function TTSSettings() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const config = useTTSStore((s) => s.config);
   const updateConfig = useTTSStore((s) => s.updateConfig);
+  const stop = useTTSStore((s) => s.stop);
 
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
 
   useEffect(() => {
-    const loadVoices = () => setVoices(getBrowserVoices());
+    const loadVoices = () => setVoices(getSystemVoices());
     loadVoices();
     window.speechSynthesis?.addEventListener?.("voiceschanged", loadVoices);
     return () => window.speechSynthesis?.removeEventListener?.("voiceschanged", loadVoices);
   }, []);
 
   // Group Edge TTS voices by language
-  const edgeVoicesByLang = useMemo(() => {
-    const map = new Map<string, typeof EDGE_TTS_VOICES>();
-    for (const v of EDGE_TTS_VOICES) {
-      const group = map.get(v.lang) || [];
-      group.push(v);
-      map.set(v.lang, group);
-    }
-    return map;
-  }, []);
+  const displayLocale = i18n.resolvedLanguage || i18n.language;
+  const edgeVoiceGroups = useMemo(() => groupEdgeTTSVoices(EDGE_TTS_VOICES), []);
+
+  const systemVoiceOptions = useMemo(() => getSystemVoiceOptions(voices), [voices]);
+  const systemVoiceGroups = useMemo(
+    () => groupSystemVoiceOptions(systemVoiceOptions),
+    [systemVoiceOptions],
+  );
+  const selectedSystemVoiceValue = useMemo(
+    () => resolveSystemVoiceValue(config.voiceName, systemVoiceOptions),
+    [config.voiceName, systemVoiceOptions],
+  );
+
+  useEffect(() => stopTTSPreview, []);
+
+  const handlePreview = async () => {
+    stop();
+    await previewTTSConfig(t("tts.testText", "这是一段测试文本"), config);
+  };
 
   const engines: { id: TTSEngine; icon: typeof Volume2; label: string; desc: string }[] = [
     { id: "edge", icon: Zap, label: t("tts.edgeEngine"), desc: t("tts.edgeEngineDesc") },
-    { id: "browser", icon: Globe, label: t("tts.browserEngine"), desc: t("tts.browserEngineDesc") },
+    {
+      id: "system",
+      icon: Headphones,
+      label: t("tts.systemEngine"),
+      desc: t("tts.systemEngineDesc"),
+    },
     {
       id: "dashscope",
       icon: Mic,
@@ -59,8 +85,16 @@ export function TTSSettings() {
   return (
     <div className="space-y-4 p-4 pt-3">
       <section className="rounded-lg bg-muted/60 p-4">
-        <h2 className="mb-4 text-sm font-medium text-foreground">{t("tts.settingsTitle")}</h2>
-        <p className="mb-4 text-xs text-muted-foreground">{t("tts.settingsDesc")}</p>
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-medium text-foreground">{t("tts.settingsTitle")}</h2>
+            <p className="mt-1 text-xs text-muted-foreground">{t("tts.settingsDesc")}</p>
+          </div>
+          <Button type="button" variant="secondary" size="sm" className="shrink-0" onClick={handlePreview}>
+            <Play className="mr-1.5 h-3.5 w-3.5" />
+            {t("common.preview", "试听")}
+          </Button>
+        </div>
 
         <div className="space-y-5">
           {/* Engine selection — 3 engines */}
@@ -106,8 +140,8 @@ export function TTSSettings() {
             />
           </div>
 
-          {/* Pitch (browser only) */}
-          {config.engine === "browser" && (
+          {/* Pitch (system only) */}
+          {config.engine === "system" && (
             <div>
               <div className="mb-3 flex items-center justify-between">
                 <span className="text-sm text-foreground">{t("tts.pitch")}</span>
@@ -137,10 +171,10 @@ export function TTSSettings() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="max-h-[300px]">
-                  {Array.from(edgeVoicesByLang.entries()).map(([lang, langVoices]) => (
+                  {edgeVoiceGroups.map(([lang, langVoices]) => (
                     <div key={lang}>
                       <div className="px-2 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
-                        {lang}
+                        {getLocaleDisplayLabel(lang, displayLocale)}
                       </div>
                       {langVoices.map((v) => (
                         <SelectItem key={v.id} value={v.id}>
@@ -154,22 +188,40 @@ export function TTSSettings() {
             </div>
           )}
 
-          {config.engine === "browser" && (
+          {config.engine === "system" && (
             <div className="flex items-center justify-between">
               <span className="text-sm text-foreground">{t("tts.voice")}</span>
               <Select
-                value={config.voiceName || "__default__"}
-                onValueChange={(v) => updateConfig({ voiceName: v === "__default__" ? "" : v })}
+                value={selectedSystemVoiceValue}
+                onValueChange={(v) => {
+                  if (v === DEFAULT_SYSTEM_VOICE_VALUE) {
+                    updateConfig({ voiceName: "", systemVoiceLabel: "" });
+                    return;
+                  }
+                  updateConfig({
+                    voiceName: v,
+                    systemVoiceLabel: findSystemVoiceLabel(v, systemVoiceOptions),
+                  });
+                }}
               >
                 <SelectTrigger className="w-[200px]">
                   <SelectValue placeholder={t("tts.defaultVoice")} />
                 </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__default__">{t("tts.defaultVoice")}</SelectItem>
-                  {voices.map((v) => (
-                    <SelectItem key={v.name} value={v.name}>
-                      {v.name} ({v.lang})
-                    </SelectItem>
+                <SelectContent className="max-h-[300px]">
+                  <SelectItem value={DEFAULT_SYSTEM_VOICE_VALUE}>
+                    {t("tts.defaultVoice")}
+                  </SelectItem>
+                  {systemVoiceGroups.map(([lang, langVoices]) => (
+                    <div key={lang}>
+                      <div className="px-2 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                        {getLocaleDisplayLabel(lang, displayLocale)}
+                      </div>
+                      {langVoices.map((voice) => (
+                        <SelectItem key={voice.id} value={voice.id}>
+                          {voice.label}
+                        </SelectItem>
+                      ))}
+                    </div>
                   ))}
                 </SelectContent>
               </Select>

--- a/packages/app/src/lib/tts/system-voices.ts
+++ b/packages/app/src/lib/tts/system-voices.ts
@@ -1,0 +1,66 @@
+import { getSystemVoices } from "./tts-service";
+import { compareVoiceLanguage } from "@readany/core/tts";
+
+export const DEFAULT_SYSTEM_VOICE_VALUE = "__default__";
+
+export interface SystemVoiceOption {
+  id: string;
+  label: string;
+  lang: string;
+  isDefault?: boolean;
+}
+
+function compareVoice(a: SystemVoiceOption, b: SystemVoiceOption) {
+  if (!!a.isDefault !== !!b.isDefault) return a.isDefault ? -1 : 1;
+  return a.label.localeCompare(b.label) || a.lang.localeCompare(b.lang);
+}
+
+export function getSystemVoiceOptions(
+  voices: SpeechSynthesisVoice[] = getSystemVoices(),
+): SystemVoiceOption[] {
+  const deduped = new Map<string, SystemVoiceOption>();
+  for (const voice of voices) {
+    const option = {
+      id: voice.voiceURI || voice.name,
+      label: voice.name,
+      lang: voice.lang || "und",
+      isDefault: voice.default,
+    };
+    const existing = deduped.get(option.id);
+    if (!existing || (!existing.isDefault && option.isDefault)) {
+      deduped.set(option.id, option);
+    }
+  }
+  return Array.from(deduped.values()).sort(compareVoice);
+}
+
+export function groupSystemVoiceOptions(
+  voices: SystemVoiceOption[],
+): Array<[string, SystemVoiceOption[]]> {
+  const grouped = new Map<string, SystemVoiceOption[]>();
+  for (const voice of voices) {
+    const bucket = grouped.get(voice.lang) || [];
+    bucket.push(voice);
+    grouped.set(voice.lang, bucket);
+  }
+  return Array.from(grouped.entries())
+    .sort(([a], [b]) => compareVoiceLanguage(a, b))
+    .map(([lang, items]) => [lang, [...items].sort(compareVoice)] as [string, SystemVoiceOption[]]);
+}
+
+export function resolveSystemVoiceValue(
+  selectedVoice: string | null | undefined,
+  voices: SystemVoiceOption[],
+): string {
+  if (!selectedVoice) return DEFAULT_SYSTEM_VOICE_VALUE;
+  const match = voices.find((voice) => voice.id === selectedVoice || voice.label === selectedVoice);
+  return match?.id || DEFAULT_SYSTEM_VOICE_VALUE;
+}
+
+export function findSystemVoiceLabel(
+  selectedVoice: string | null | undefined,
+  voices: SystemVoiceOption[],
+): string {
+  if (!selectedVoice) return "";
+  return voices.find((voice) => voice.id === selectedVoice || voice.label === selectedVoice)?.label || "";
+}

--- a/packages/app/src/lib/tts/tts-preview.ts
+++ b/packages/app/src/lib/tts/tts-preview.ts
@@ -1,0 +1,33 @@
+import type { TTSConfig } from "@readany/core/tts";
+import { BrowserTTSPlayer, DashScopeTTSPlayer, EdgeTTSPlayer } from "@readany/core/tts";
+
+const systemPreviewPlayer = new BrowserTTSPlayer();
+const edgePreviewPlayer = new EdgeTTSPlayer();
+const dashscopePreviewPlayer = new DashScopeTTSPlayer();
+
+function stopPlayer(player: { stop: () => void }) {
+  try {
+    player.stop();
+  } catch {}
+}
+
+export function stopTTSPreview() {
+  stopPlayer(systemPreviewPlayer);
+  stopPlayer(edgePreviewPlayer);
+  stopPlayer(dashscopePreviewPlayer);
+}
+
+export async function previewTTSConfig(text: string, config: TTSConfig) {
+  stopTTSPreview();
+  const player =
+    config.engine === "edge"
+      ? edgePreviewPlayer
+      : config.engine === "dashscope"
+        ? dashscopePreviewPlayer
+        : systemPreviewPlayer;
+  try {
+    await Promise.resolve(player.speak(text, config));
+  } catch (error) {
+    console.error("[TTSPreview] Preview failed", error);
+  }
+}

--- a/packages/app/src/lib/tts/tts-service.ts
+++ b/packages/app/src/lib/tts/tts-service.ts
@@ -20,12 +20,15 @@ export type { EdgeTTSVoice } from "@readany/core/tts";
 // Singleton instances (kept at app level for lifecycle management)
 import { BrowserTTSPlayer, DashScopeTTSPlayer, EdgeTTSPlayer } from "@readany/core/tts";
 
-export const browserTTS = new BrowserTTSPlayer();
+export const systemTTS = new BrowserTTSPlayer();
+export const browserTTS = systemTTS;
 export const edgeTTS = new EdgeTTSPlayer();
 export const dashscopeTTS = new DashScopeTTSPlayer();
 
-/** Get available browser SpeechSynthesis voices */
-export function getBrowserVoices(): SpeechSynthesisVoice[] {
+/** Get available system SpeechSynthesis voices */
+export function getSystemVoices(): SpeechSynthesisVoice[] {
   if (!("speechSynthesis" in window)) return [];
   return window.speechSynthesis.getVoices();
 }
+
+export const getBrowserVoices = getSystemVoices;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,8 @@
     "./ai/agents/*": "./src/ai/agents/*.ts",
     "./ai/skills": "./src/ai/skills/index.ts",
     "./ai/skills/*": "./src/ai/skills/*.ts",
+    "./ai/tools": "./src/ai/tools/index.ts",
+    "./ai/tools/*": "./src/ai/tools/*.ts",
     "./rag": "./src/rag/index.ts",
     "./rag/*": "./src/rag/*.ts",
     "./db": "./src/db/index.ts",

--- a/packages/core/src/i18n/locales/en.json
+++ b/packages/core/src/i18n/locales/en.json
@@ -932,8 +932,10 @@
     "engine": "Engine",
     "edgeEngine": "Edge TTS",
     "edgeEngineDesc": "Free high-quality Microsoft Neural voices",
-    "browserEngine": "Browser Built-in",
-    "browserEngineDesc": "Free offline, uses system speech synthesis",
+    "systemEngine": "System Voice",
+    "systemEngineDesc": "Free offline, uses the device system voice",
+    "browserEngine": "System Voice",
+    "browserEngineDesc": "Free offline, uses the device system voice",
     "dashscopeEngine": "DashScope",
     "dashscopeEngineDesc": "High-quality cloud voice, requires API key",
     "voice": "Voice",
@@ -952,6 +954,7 @@
     "rate": "Rate",
     "pitch": "Pitch",
     "language": "Language",
+    "system": "System Voice",
     "browser": "System Voice",
     "listenSpace": "Listening Space",
     "fromCurrentPage": "From current page",
@@ -991,6 +994,7 @@
     "selectEngine": "TTS Engine",
     "prevChapter": "Previous Chapter",
     "nextChapter": "Next Chapter",
-    "browserVoiceNote": "Browser voice can be selected in system settings"
+    "systemVoiceNote": "Choose the system voice in your device settings",
+    "browserVoiceNote": "Choose the system voice in your device settings"
   }
 }

--- a/packages/core/src/i18n/locales/zh.json
+++ b/packages/core/src/i18n/locales/zh.json
@@ -812,8 +812,10 @@
     "engine": "引擎",
     "edgeEngine": "Edge TTS",
     "edgeEngineDesc": "免费高质量微软 Neural 语音",
-    "browserEngine": "浏览器内置",
-    "browserEngineDesc": "免费离线，使用系统语音合成",
+    "systemEngine": "系统语音",
+    "systemEngineDesc": "免费离线，使用设备系统语音",
+    "browserEngine": "系统语音",
+    "browserEngineDesc": "免费离线，使用设备系统语音",
     "dashscopeEngine": "DashScope",
     "dashscopeEngineDesc": "高质量云端语音，需要 API 密钥",
     "voice": "语音",
@@ -832,6 +834,7 @@
     "rate": "语速",
     "pitch": "音调",
     "language": "语言",
+    "system": "系统语音",
     "browser": "系统语音",
     "listenSpace": "听书空间",
     "fromCurrentPage": "从当前页开始",
@@ -871,7 +874,8 @@
     "selectEngine": "朗读引擎",
     "prevChapter": "上一章",
     "nextChapter": "下一章",
-    "browserVoiceNote": "浏览器音色请在系统设置中选择"
+    "systemVoiceNote": "系统音色请在设备系统设置中选择",
+    "browserVoiceNote": "系统音色请在设备系统设置中选择"
   },
   "mindmap": {
     "title": "思维导图",

--- a/packages/core/src/stores/persist.ts
+++ b/packages/core/src/stores/persist.ts
@@ -86,6 +86,7 @@ export function withPersist<T extends object>(
   creator: StateCreator<T>,
   /** Keys to always reset to these values after hydration (transient state that should not be restored) */
   resetAfterHydrate?: Partial<T>,
+  migrate?: (persisted: T) => T,
 ): StateCreator<T> {
   return (set, get, api) => {
     const wrappedSet = ((partial: unknown, replace?: boolean) => {
@@ -102,7 +103,8 @@ export function withPersist<T extends object>(
     // Load persisted state on creation
     loadFromFS<T>(key).then((persisted) => {
       if (persisted) {
-        set({ ...persisted, ...(resetAfterHydrate ?? {}), _hasHydrated: true } as unknown as Partial<T>);
+        const migrated = migrate ? migrate(persisted) : persisted;
+        set({ ...migrated, ...(resetAfterHydrate ?? {}), _hasHydrated: true } as unknown as Partial<T>);
       } else {
         set({ ...(resetAfterHydrate ?? {}), _hasHydrated: true } as unknown as Partial<T>);
       }

--- a/packages/core/src/stores/settings-store.ts
+++ b/packages/core/src/stores/settings-store.ts
@@ -123,8 +123,24 @@ async function fetchOpenAIModels(endpoint: AIEndpoint): Promise<string[]> {
   if (!response.ok) {
     throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`);
   }
-  const data = await response.json();
-  return (data.data || [])
+  const rawBody = await response.text();
+  let data: { data?: Array<{ id: string }> };
+
+  try {
+    data = JSON.parse(rawBody);
+  } catch {
+    throw new Error(
+      "The endpoint did not return JSON. Check whether the base URL points to the API root instead of a console page.",
+    );
+  }
+
+  if (!Array.isArray(data.data)) {
+    throw new Error(
+      "The endpoint returned an unexpected models response. Check whether the base URL points to the OpenAI-compatible API root.",
+    );
+  }
+
+  return data.data
     .map((m: { id: string }) => m.id)
     .sort((a: string, b: string) => a.localeCompare(b));
 }
@@ -380,7 +396,7 @@ export const useSettingsStore = create<SettingsState>()(
             ),
           },
         }));
-        return [];
+        throw err;
       }
     },
 

--- a/packages/core/src/stores/tts-store.ts
+++ b/packages/core/src/stores/tts-store.ts
@@ -6,14 +6,14 @@
  * - TTS configuration (engine, voice, rate, pitch, DashScope key)
  * - Persists config to FS
  *
- * Cross-platform: player factories are injectable. By default uses Web-based
- * BrowserTTSPlayer/EdgeTTSPlayer/DashScopeTTSPlayer. Platforms without Web Audio
+ * Cross-platform: player factories are injectable. By default uses a Web-based
+ * system TTS player plus EdgeTTSPlayer/DashScopeTTSPlayer. Platforms without Web Audio
  * (e.g. React Native) can override via `setTTSPlayerFactories()`.
  */
 import { create } from "zustand";
 import { BrowserTTSPlayer, DashScopeTTSPlayer, EdgeTTSPlayer } from "../tts/tts-players";
 import type { ITTSPlayer, TTSConfig } from "../tts/types";
-import { DEFAULT_TTS_CONFIG } from "../tts/types";
+import { DEFAULT_TTS_CONFIG, normalizeTTSConfig } from "../tts/types";
 import { withPersist } from "./persist";
 
 export type TTSPlayState = "stopped" | "playing" | "paused" | "loading";
@@ -22,14 +22,14 @@ export type TTSPlayState = "stopped" | "playing" | "paused" | "loading";
  * TTS player factory interface — allows platforms to provide custom player implementations.
  */
 export interface TTSPlayerFactories {
-  createBrowserTTS: () => ITTSPlayer;
+  createSystemTTS: () => ITTSPlayer;
   createEdgeTTS: () => ITTSPlayer;
   createDashScopeTTS: () => ITTSPlayer;
 }
 
 /** Default Web-based factories */
 const defaultFactories: TTSPlayerFactories = {
-  createBrowserTTS: () => new BrowserTTSPlayer(),
+  createSystemTTS: () => new BrowserTTSPlayer(),
   createEdgeTTS: () => new EdgeTTSPlayer(),
   createDashScopeTTS: () => new DashScopeTTSPlayer(),
 };
@@ -42,7 +42,7 @@ let _factories: TTSPlayerFactories = defaultFactories;
  *
  * Example (React Native):
  *   setTTSPlayerFactories({
- *     createBrowserTTS: () => new ExpoSpeechTTSPlayer(),
+ *     createSystemTTS: () => new ExpoSpeechTTSPlayer(),
  *     createEdgeTTS: () => new ExpoAVEdgeTTSPlayer(),
  *     createDashScopeTTS: () => new ExpoAVDashScopeTTSPlayer(),
  *   });
@@ -50,13 +50,13 @@ let _factories: TTSPlayerFactories = defaultFactories;
 export function setTTSPlayerFactories(factories: Partial<TTSPlayerFactories>): void {
   _factories = { ...defaultFactories, ...factories };
   // Reset cached instances so new factories take effect
-  _browserTTS = null;
+  _systemTTS = null;
   _edgeTTS = null;
   _dashscopeTTS = null;
 }
 
 /** Lazily-created singleton TTS player instances */
-let _browserTTS: ITTSPlayer | null = null;
+let _systemTTS: ITTSPlayer | null = null;
 let _edgeTTS: ITTSPlayer | null = null;
 let _dashscopeTTS: ITTSPlayer | null = null;
 let _sessionSegments: string[] = [];
@@ -64,9 +64,9 @@ let _sessionCurrentIndex = 0;
 /** Generation counter — incremented on every play/jumpToChunk to invalidate stale callbacks */
 let _sessionGeneration = 0;
 
-function getBrowserTTS(): ITTSPlayer {
-  if (!_browserTTS) _browserTTS = _factories.createBrowserTTS();
-  return _browserTTS;
+function getSystemTTS(): ITTSPlayer {
+  if (!_systemTTS) _systemTTS = _factories.createSystemTTS();
+  return _systemTTS;
 }
 
 function getEdgeTTS(): ITTSPlayer {
@@ -131,7 +131,7 @@ export const useTTSStore = create<TTSState>()(
     currentLocationCfi: "",
 
     play: (text: string | string[]) => {
-      const { config } = get();
+      const config = normalizeTTSConfig(get().config);
       const segments = Array.isArray(text) ? text.map((item) => item.trim()).filter(Boolean) : [text.trim()].filter(Boolean);
       const sessionSegments = segments.length > 0 ? segments : [Array.isArray(text) ? text.join(" ").trim() : text.trim()].filter(Boolean);
       _sessionSegments = sessionSegments;
@@ -175,7 +175,7 @@ export const useTTSStore = create<TTSState>()(
         player.onEnd = handleEnd;
         player.speak(sessionSegments, config);
       } else {
-        const player = getBrowserTTS();
+        const player = getSystemTTS();
         player.onStateChange = onState;
         player.onChunkChange = onChunk;
         player.onEnd = handleEnd;
@@ -184,7 +184,8 @@ export const useTTSStore = create<TTSState>()(
     },
 
     pause: () => {
-      const { config, playState } = get();
+      const config = normalizeTTSConfig(get().config);
+      const { playState } = get();
       if (playState !== "playing") return;
       if (config.engine === "dashscope" && config.dashscopeApiKey) {
         getDashScopeTTS().pause();
@@ -192,13 +193,14 @@ export const useTTSStore = create<TTSState>()(
         getEdgeTTS().pause();
       } else {
         // expo-speech pause is unreliable on React Native; keep a stable store-level pause by stopping.
-        getBrowserTTS().stop();
+        getSystemTTS().stop();
       }
       set({ playState: "paused" });
     },
 
     resume: () => {
-      const { config, playState } = get();
+      const config = normalizeTTSConfig(get().config);
+      const { playState } = get();
       if (playState !== "paused") return;
       if (_sessionSegments.length > 0) {
         const nextIndex = Math.max(0, Math.min(_sessionCurrentIndex, _sessionSegments.length - 1));
@@ -240,7 +242,7 @@ export const useTTSStore = create<TTSState>()(
             return;
           }
 
-          const player = getBrowserTTS();
+          const player = getSystemTTS();
           player.onStateChange = onState;
           player.onChunkChange = onChunk;
           player.onEnd = handleEnd;
@@ -252,13 +254,13 @@ export const useTTSStore = create<TTSState>()(
     },
 
     stop: () => {
-      const browser = getBrowserTTS();
+      const system = getSystemTTS();
       const edge = getEdgeTTS();
       const dashscope = getDashScopeTTS();
-      browser.onEnd = undefined;
+      system.onEnd = undefined;
       edge.onEnd = undefined;
       dashscope.onEnd = undefined;
-      browser.stop();
+      system.stop();
       edge.stop();
       dashscope.stop();
       _sessionSegments = [];
@@ -291,7 +293,7 @@ export const useTTSStore = create<TTSState>()(
 
     updateConfig: (updates) =>
       set((s) => ({
-        config: { ...s.config, ...updates },
+        config: normalizeTTSConfig({ ...s.config, ...updates }),
       })),
 
     setPlayState: (playState) => set({ playState }),
@@ -307,8 +309,8 @@ export const useTTSStore = create<TTSState>()(
 
     jumpToChunk: (index: number) => {
       if (index < 0 || index >= _sessionSegments.length) return;
-      const { config } = get();
-      getBrowserTTS().stop();
+      const config = normalizeTTSConfig(get().config);
+      getSystemTTS().stop();
       getEdgeTTS().stop();
       getDashScopeTTS().stop();
 
@@ -351,7 +353,7 @@ export const useTTSStore = create<TTSState>()(
         player.onEnd = handleEnd;
         player.speak(remainingSegments, config);
       } else {
-        const player = getBrowserTTS();
+        const player = getSystemTTS();
         player.onStateChange = onState;
         player.onChunkChange = onChunk;
         player.onEnd = handleEnd;
@@ -364,5 +366,8 @@ export const useTTSStore = create<TTSState>()(
     currentChunkIndex: 0,
     totalChunks: 0,
     currentLocationCfi: "",
-  } as Partial<TTSState>),
+  } as Partial<TTSState>, (persisted) => ({
+    ...persisted,
+    config: normalizeTTSConfig((persisted as TTSState).config),
+  })),
 );

--- a/packages/core/src/tts/display.ts
+++ b/packages/core/src/tts/display.ts
@@ -72,6 +72,5 @@ export function getTTSVoiceLabel(config: TTSConfig): string {
     return voice?.label || config.dashscopeVoice;
   }
 
-  return config.voiceName || "System Voice";
+  return config.systemVoiceLabel || config.voiceName || "System Voice";
 }
-

--- a/packages/core/src/tts/edge-tts.ts
+++ b/packages/core/src/tts/edge-tts.ts
@@ -215,6 +215,24 @@ export interface EdgeTTSPayload {
   pitch: number;
 }
 
+function formatEdgeTTSError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const maybeMessage =
+      "message" in error && typeof (error as { message?: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : null;
+    if (maybeMessage) return maybeMessage;
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+}
+
 const edgeTtsAudioCache = new Map<string, ArrayBuffer>();
 const edgeTtsInflightCache = new Map<string, Promise<ArrayBuffer>>();
 
@@ -342,13 +360,13 @@ async function fetchEdgeTTSAudioUncached(payload: EdgeTTSPayload): Promise<Array
       });
 
       ws.onError((error) => {
-        reject(new Error(`Edge TTS WebSocket error: ${error}`));
+        reject(new Error(`Edge TTS WebSocket error: ${formatEdgeTTSError(error)}`));
       });
 
       ws.send(configMsg);
       ws.send(ssmlMsg);
     } catch (error) {
-      reject(new Error(`Edge TTS WebSocket error: ${error}`));
+      reject(new Error(`Edge TTS WebSocket error: ${formatEdgeTTSError(error)}`));
     }
   });
 }

--- a/packages/core/src/tts/index.ts
+++ b/packages/core/src/tts/index.ts
@@ -1,10 +1,18 @@
 // Types & constants
-export type { TTSEngine, TTSConfig, TTSPlayState, ITTSPlayer } from "./types";
-export { DEFAULT_TTS_CONFIG, DASHSCOPE_VOICES } from "./types";
+export type {
+  ITTSPlayer,
+  LegacyTTSEngine,
+  PersistedTTSConfig,
+  TTSEngine,
+  TTSConfig,
+  TTSPlayState,
+} from "./types";
+export { DEFAULT_TTS_CONFIG, DASHSCOPE_VOICES, normalizeTTSConfig, normalizeTTSEngine } from "./types";
 
 // Text utilities
 export { cleanText, countChars, splitIntoChunks } from "./text-utils";
 export { buildNarrationPreview, getTTSVoiceLabel, splitNarrationText } from "./display";
+export { compareVoiceLanguage, getLocaleDisplayLabel, groupEdgeTTSVoices } from "./voice-groups";
 
 // Edge TTS
 export { fetchEdgeTTSAudio, EDGE_TTS_VOICES } from "./edge-tts";

--- a/packages/core/src/tts/tts-players.ts
+++ b/packages/core/src/tts/tts-players.ts
@@ -64,7 +64,9 @@ export class BrowserTTSPlayer implements ITTSPlayer {
     utt.pitch = config.pitch;
 
     if (config.voiceName) {
-      const voice = synth.getVoices().find((v) => v.name === config.voiceName);
+      const voice = synth
+        .getVoices()
+        .find((v) => v.voiceURI === config.voiceName || v.name === config.voiceName);
       if (voice) utt.voice = voice;
     }
 

--- a/packages/core/src/tts/types.ts
+++ b/packages/core/src/tts/types.ts
@@ -2,14 +2,17 @@
  * TTS types and constants — shared across all platforms.
  */
 
-export type TTSEngine = "browser" | "edge" | "dashscope";
+export type TTSEngine = "system" | "edge" | "dashscope";
+export type LegacyTTSEngine = TTSEngine | "browser";
 
 export type TTSPlayState = "stopped" | "playing" | "paused" | "loading";
 
 export interface TTSConfig {
   engine: TTSEngine;
-  /** Browser SpeechSynthesis voice name */
+  /** System voice identifier (or legacy display name on older configs) */
   voiceName: string;
+  /** Human-readable system voice label for UI display */
+  systemVoiceLabel: string;
   /** Speech rate (0.5 - 2.0) */
   rate: number;
   /** Speech pitch (0.5 - 2.0) */
@@ -25,12 +28,42 @@ export interface TTSConfig {
 export const DEFAULT_TTS_CONFIG: TTSConfig = {
   engine: "edge",
   voiceName: "",
+  systemVoiceLabel: "",
   rate: 1.0,
   pitch: 1.0,
   edgeVoice: "zh-CN-XiaoxiaoNeural",
   dashscopeApiKey: "",
   dashscopeVoice: "Cherry",
 };
+
+export interface PersistedTTSConfig extends Partial<Omit<TTSConfig, "engine">> {
+  engine?: LegacyTTSEngine | string | null;
+}
+
+export function normalizeTTSEngine(engine: LegacyTTSEngine | string | null | undefined): TTSEngine {
+  if (engine === "system" || engine === "edge" || engine === "dashscope") {
+    return engine;
+  }
+  if (engine === "browser") {
+    return "system";
+  }
+  return DEFAULT_TTS_CONFIG.engine;
+}
+
+export function normalizeTTSConfig(config: PersistedTTSConfig | null | undefined): TTSConfig {
+  return {
+    ...DEFAULT_TTS_CONFIG,
+    ...config,
+    engine: normalizeTTSEngine(config?.engine),
+    voiceName: config?.voiceName ?? DEFAULT_TTS_CONFIG.voiceName,
+    systemVoiceLabel: config?.systemVoiceLabel ?? DEFAULT_TTS_CONFIG.systemVoiceLabel,
+    rate: typeof config?.rate === "number" ? config.rate : DEFAULT_TTS_CONFIG.rate,
+    pitch: typeof config?.pitch === "number" ? config.pitch : DEFAULT_TTS_CONFIG.pitch,
+    edgeVoice: config?.edgeVoice ?? DEFAULT_TTS_CONFIG.edgeVoice,
+    dashscopeApiKey: config?.dashscopeApiKey ?? DEFAULT_TTS_CONFIG.dashscopeApiKey,
+    dashscopeVoice: config?.dashscopeVoice ?? DEFAULT_TTS_CONFIG.dashscopeVoice,
+  };
+}
 
 export const DASHSCOPE_VOICES = [
   { id: "Cherry", label: "芊悦 (Cherry)" },

--- a/packages/core/src/tts/voice-groups.ts
+++ b/packages/core/src/tts/voice-groups.ts
@@ -1,0 +1,122 @@
+import { EDGE_TTS_VOICES, type EdgeTTSVoice } from "./edge-tts";
+
+export type VoiceGroup<T> = [string, T[]];
+
+const LOCALE_LABEL_OVERRIDES: Record<string, { en: string; zh: string }> = {
+  und: { en: "Unknown language", zh: "未指定语言" },
+  "zh-CN": { en: "Chinese (Simplified, China)", zh: "中文（简体，中国）" },
+  "zh-HK": { en: "Chinese (Traditional, Hong Kong)", zh: "中文（繁体，香港）" },
+  "zh-TW": { en: "Chinese (Traditional, Taiwan)", zh: "中文（繁体，台湾）" },
+  "en-AU": { en: "English (Australia)", zh: "英语（澳大利亚）" },
+  "en-CA": { en: "English (Canada)", zh: "英语（加拿大）" },
+  "en-GB": { en: "English (United Kingdom)", zh: "英语（英国）" },
+  "en-IN": { en: "English (India)", zh: "英语（印度）" },
+  "en-US": { en: "English (United States)", zh: "英语（美国）" },
+};
+
+function normalizeLocaleCode(locale: string): string {
+  const trimmed = locale.trim().replace(/_/g, "-");
+  if (!trimmed) return "und";
+  const [language, ...rest] = trimmed.split("-");
+  if (!rest.length) return language.toLowerCase();
+  return [
+    language.toLowerCase(),
+    ...rest.map((part) =>
+      part.length === 4
+        ? `${part.slice(0, 1).toUpperCase()}${part.slice(1).toLowerCase()}`
+        : part.toUpperCase(),
+    ),
+  ].join("-");
+}
+
+function compareVoiceLanguage(a: string, b: string) {
+  const aLower = a.toLowerCase();
+  const bLower = b.toLowerCase();
+  const aZh = aLower.startsWith("zh") ? -2 : 0;
+  const bZh = bLower.startsWith("zh") ? -2 : 0;
+  const aEn = aLower.startsWith("en") ? -1 : 0;
+  const bEn = bLower.startsWith("en") ? -1 : 0;
+  return aZh - bZh || aEn - bEn || a.localeCompare(b);
+}
+
+function resolveDisplayLocale(displayLocale?: string): string {
+  if (displayLocale?.trim()) return normalizeLocaleCode(displayLocale);
+  try {
+    const runtimeLocale = Intl.DateTimeFormat().resolvedOptions().locale;
+    if (runtimeLocale) return normalizeLocaleCode(runtimeLocale);
+  } catch {
+    // Fall through to English.
+  }
+  return "en";
+}
+
+export function getLocaleDisplayLabel(locale: string, displayLocale?: string): string {
+  const normalizedLocale = normalizeLocaleCode(locale || "und");
+  const resolvedDisplayLocale = resolveDisplayLocale(displayLocale);
+  const displayLang = resolvedDisplayLocale.toLowerCase().startsWith("zh") ? "zh" : "en";
+  const override = LOCALE_LABEL_OVERRIDES[normalizedLocale];
+
+  if (override) {
+    return override[displayLang];
+  }
+
+  try {
+    const [language, maybeScriptOrRegion, maybeRegion] = normalizedLocale.split("-");
+    const languageNames = new Intl.DisplayNames([resolvedDisplayLocale, "en"], {
+      type: "language",
+    });
+    const regionNames = new Intl.DisplayNames([resolvedDisplayLocale, "en"], {
+      type: "region",
+    });
+    const scriptNames = new Intl.DisplayNames([resolvedDisplayLocale, "en"], {
+      type: "script",
+    });
+
+    const languageLabel = languageNames.of(language);
+    const extras: string[] = [];
+
+    if (maybeScriptOrRegion) {
+      if (maybeScriptOrRegion.length === 4) {
+        const scriptLabel = scriptNames.of(maybeScriptOrRegion);
+        if (scriptLabel) extras.push(scriptLabel);
+        if (maybeRegion) {
+          const regionLabel = regionNames.of(maybeRegion);
+          if (regionLabel) extras.push(regionLabel);
+        }
+      } else {
+        const regionLabel = regionNames.of(maybeScriptOrRegion);
+        if (regionLabel) extras.push(regionLabel);
+      }
+    }
+
+    if (languageLabel && extras.length > 0) {
+      return `${languageLabel} (${extras.join(", ")})`;
+    }
+    if (languageLabel) {
+      return languageLabel;
+    }
+  } catch {
+    // Fall back to the normalized locale code below.
+  }
+
+  return normalizedLocale;
+}
+
+export function groupEdgeTTSVoices(
+  voices: EdgeTTSVoice[] = EDGE_TTS_VOICES,
+): VoiceGroup<EdgeTTSVoice>[] {
+  const grouped = new Map<string, EdgeTTSVoice[]>();
+  for (const voice of voices) {
+    const bucket = grouped.get(voice.lang) || [];
+    bucket.push(voice);
+    grouped.set(voice.lang, bucket);
+  }
+  return Array.from(grouped.entries())
+    .sort(([a], [b]) => compareVoiceLanguage(a, b))
+    .map(
+      ([lang, items]) =>
+        [lang, [...items].sort((a, b) => a.name.localeCompare(b.name))] as VoiceGroup<EdgeTTSVoice>,
+    );
+}
+
+export { compareVoiceLanguage };

--- a/packages/core/src/utils/api.test.ts
+++ b/packages/core/src/utils/api.test.ts
@@ -16,6 +16,18 @@ describe("AI API URL helpers", () => {
     );
   });
 
+  it("strips console-like dashboard paths before appending /v1", () => {
+    expect(resolveProviderBaseUrl("openai", "https://elysiver.h-e.top/console")).toBe(
+      "https://elysiver.h-e.top/v1",
+    );
+    expect(resolveProviderBaseUrl("custom", "https://example.com/proxy/console")).toBe(
+      "https://example.com/proxy/v1",
+    );
+    expect(buildProviderModelsUrl("openai", "https://elysiver.h-e.top/console")).toBe(
+      "https://elysiver.h-e.top/v1/models",
+    );
+  });
+
   it("keeps custom paths as-is when the URL ends with a slash", () => {
     expect(resolveProviderBaseUrl("custom", "https://example.com/api/")).toBe(
       "https://example.com/api",

--- a/packages/core/src/utils/api.ts
+++ b/packages/core/src/utils/api.ts
@@ -207,6 +207,8 @@ const SPECIAL_HOSTS = [
   "generativelanguage.googleapis.com",
 ];
 
+const CONSOLE_PATH_SEGMENTS = new Set(["console", "playground", "dashboard", "studio"]);
+
 const VERSION_PATTERN = /\/(v[1-9]\d*|api\/v[1-9]\d*|api\/paas\/v[1-9]\d*|compatible-mode\/v[1-9]\d*|openai\/v[1-9]\d*)$/i;
 
 export function formatApiHost(host: string): string {
@@ -235,6 +237,31 @@ export function trimApiUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
+function sanitizeOpenAICompatibleBaseUrl(url: string): string {
+  const trimmed = trimApiUrl(url);
+
+  try {
+    const parsed = new URL(trimmed);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+
+    while (segments.length > 0) {
+      const lastSegment = segments[segments.length - 1]?.toLowerCase();
+      if (!lastSegment || !CONSOLE_PATH_SEGMENTS.has(lastSegment)) {
+        break;
+      }
+      segments.pop();
+    }
+
+    parsed.pathname = segments.length > 0 ? `/${segments.join("/")}` : "/";
+    parsed.search = "";
+    parsed.hash = "";
+
+    return trimApiUrl(parsed.toString());
+  } catch {
+    return trimmed;
+  }
+}
+
 export function providerSupportsExactRequestUrl(providerId: string): boolean {
   return providerId !== "anthropic" && providerId !== "google";
 }
@@ -246,16 +273,23 @@ export function resolveProviderBaseUrl(
 ): string {
   const rawBaseUrl = (baseUrl || getDefaultBaseUrl(providerId) || "").trim();
   if (!rawBaseUrl) return "";
+  const providerConfig = getProviderConfig(providerId);
+  const trimmedRawBaseUrl = trimApiUrl(rawBaseUrl);
+  const rawLastSegment = trimmedRawBaseUrl.split("/").filter(Boolean).pop()?.toLowerCase();
 
   if (exactRequestUrl && providerSupportsExactRequestUrl(providerId)) {
     return rawBaseUrl;
   }
 
-  if (!getProviderConfig(providerId).needsV1Suffix) {
+  if (!providerConfig.needsV1Suffix) {
     return trimApiUrl(rawBaseUrl);
   }
 
-  return trimApiUrl(formatApiHost(rawBaseUrl));
+  if (rawBaseUrl.endsWith("/") && (!rawLastSegment || !CONSOLE_PATH_SEGMENTS.has(rawLastSegment))) {
+    return trimApiUrl(rawBaseUrl);
+  }
+
+  return trimApiUrl(formatApiHost(sanitizeOpenAICompatibleBaseUrl(rawBaseUrl)));
 }
 
 export function buildProviderModelsUrl(


### PR DESCRIPTION
## 概述

- 新增系统音色获取模块，支持 expo-speech 和 react-native-tts 获取设备所有可用音色
- 新增音色分组管理 (voice-groups.ts)，按语言/平台智能分组
- 新增 TTS 预览功能，支持试听音色
- 重构 VoicePickerModal，支持按引擎和语言筛选音色
- 优化 TTS 设置页面，统一 Web/App/Expo 三端 UI
- 扩展 tts-store，增加引擎选择、音色缓存、预览状态
- 更新 i18n 中英文翻译
- 改进 EdgeTTS 和 API 工具

## 改动范围

```
 40 files changed, +2139 / -492
 packages/core/src/tts/     - 核心类型、引擎抽象、音色分组
 packages/app-expo/src/    - Expo 端 UI 和平台适配
 packages/app/src/         - Web/App 端 UI 和平台适配
 docs/                     - 设计文档
```

## 测试要点

- [x] iOS 设备上能列出系统音色（包括李牧、Eddy、Shelley 等）
- [x] Android 设备上能列出系统音色
- [x] Web 端能使用浏览器语音合成
- [x] 音色切换后朗读正常
- [x] 预览功能正常工作
