### PR TITLE
feat: 滚动翻页、AI对话导出、书库显示作者

### DIFF
--- a/packages/app-expo/src/components/chat/MessageList.tsx
+++ b/packages/app-expo/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from "@/components/ui/Icon";
+import { CheckIcon, ChevronDownIcon, CopyIcon } from "@/components/ui/Icon";
 import { fontSize as fs, radius, useColors, withOpacity } from "@/styles/theme";
 import type { ThemeColors } from "@/styles/theme";
 import type { CitationPart, MessageV2, QuotePart, TextPart } from "@readany/core/types/message";
@@ -17,6 +17,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import * as Clipboard from "expo-clipboard";
 import { PartRenderer } from "./PartRenderer";
 import { StreamingIndicator } from "./StreamingIndicator";
 
@@ -272,6 +273,14 @@ function MessageBubble({
   );
   if (!hasContent) return null;
 
+  const copyText = () => {
+    const text = message.parts
+      .filter((p) => p.type === "text" && (p as TextPart).text.trim())
+      .map((p) => (p as TextPart).text)
+      .join("\n\n");
+    if (text) Clipboard.setStringAsync(text);
+  };
+
   // Show gap indicator between parts when streaming
   const lastPart = message.parts[message.parts.length - 1];
   const isLastPartRunningText = lastPart?.type === "text" && lastPart.status === "running";
@@ -299,7 +308,39 @@ function MessageBubble({
         />
       ))}
       {showGapIndicator && <StreamingIndicator step="thinking" />}
+      {!isStreaming && (
+        <CopyButton onPress={copyText} colors={colors} />
+      )}
     </View>
+  );
+}
+
+function CopyButton({ onPress, colors }: { onPress: () => void; colors: ThemeColors }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <TouchableOpacity
+      activeOpacity={0.7}
+      onPress={() => {
+        onPress();
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        alignSelf: "flex-start",
+        paddingHorizontal: 6,
+        paddingVertical: 3,
+        borderRadius: 6,
+        backgroundColor: copied ? `${colors.primary}14` : "transparent",
+      }}
+    >
+      {copied ? (
+        <CheckIcon size={13} color={colors.primary} />
+      ) : (
+        <CopyIcon size={13} color={colors.mutedForeground} />
+      )}
+    </TouchableOpacity>
   );
 }
 

--- a/packages/app-expo/src/components/library/BookCard.tsx
+++ b/packages/app-expo/src/components/library/BookCard.tsx
@@ -292,6 +292,11 @@ export const BookCard = memo(function BookCard({
           <Text style={s.bookTitle} numberOfLines={1}>
             {book.meta.title}
           </Text>
+          {book.meta.author ? (
+            <Text style={s.bookAuthor} numberOfLines={1}>
+              {book.meta.author}
+            </Text>
+          ) : null}
 
           {/* Tag badges */}
           {book.tags.length > 0 ? (

--- a/packages/app-expo/src/components/library/book-card-styles.ts
+++ b/packages/app-expo/src/components/library/book-card-styles.ts
@@ -116,6 +116,7 @@ export const makeStyles = (colors: ThemeColors, cardWidth: number) => {
     },
     infoWrap: { paddingTop: 6, paddingHorizontal: 1 },
     bookTitle: { fontSize: 13, fontWeight: fontWeight.semibold, color: colors.foreground, lineHeight: 14 },
+    bookAuthor: { fontSize: 10, color: colors.mutedForeground, lineHeight: 14, marginTop: 1 },
     tagsRow: { flexDirection: "row", flexWrap: "wrap", gap: 3, marginTop: 3 },
     tagBadge: { backgroundColor: `${colors.muted}`, borderRadius: radius.full, paddingHorizontal: 6, paddingVertical: 1 },
     tagText: { fontSize: 8, color: colors.mutedForeground },

--- a/packages/app/src/components/chat/ChatPage.tsx
+++ b/packages/app/src/components/chat/ChatPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "@readany/core/utils";
 import {
   BookOpen,
+  Download,
   History,
   Library,
   Lightbulb,
@@ -278,6 +279,35 @@ export function ChatPage() {
         <div className="flex items-center gap-1">
           <ModelSelector />
           <ContextPopover />
+          {allMessages.length > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                const md = allMessages
+                  .map((m) => {
+                    const role = m.role === "user" ? "**You**" : "**AI**";
+                    const text = m.parts
+                      .filter((p) => p.type === "text" && (p as { text: string }).text.trim())
+                      .map((p) => (p as { text: string }).text)
+                      .join("\n\n");
+                    return `${role}\n\n${text}`;
+                  })
+                  .filter((s) => s.trim())
+                  .join("\n\n---\n\n");
+                const blob = new Blob([md], { type: "text/markdown" });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = `chat-${new Date().toISOString().slice(0, 10)}.md`;
+                a.click();
+                URL.revokeObjectURL(url);
+              }}
+              className="rounded-full p-1.5 text-neutral-600 hover:bg-muted"
+              title={t("notes.export", "导出")}
+            >
+              <Download className="size-4" />
+            </button>
+          )}
           <button
             type="button"
             onClick={handleNewThread}

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -170,7 +170,7 @@ function CopyMessageButton({ message }: { message: MessageV2 }) {
   return (
     <button
       type="button"
-      className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+      className="inline-flex w-fit items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
       onClick={() => {
         const text = extractMessageText(message);
         if (text) {

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -3,7 +3,7 @@
  * Uses Part-based rendering for real-time updates
  */
 import type { CitationPart, MessageV2, QuotePart } from "@readany/core/types/message";
-import { ArrowDown, Quote } from "lucide-react";
+import { ArrowDown, Check, Copy, Quote } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PartRenderer } from "./PartRenderer";
@@ -156,6 +156,36 @@ function UserQuoteBlock({ part }: { part: QuotePart }) {
   );
 }
 
+/** Extract plain text from a message's parts for clipboard copy */
+function extractMessageText(message: MessageV2): string {
+  return message.parts
+    .filter((p) => p.type === "text" && p.text.trim())
+    .map((p) => (p as { text: string }).text)
+    .join("\n\n");
+}
+
+function CopyMessageButton({ message }: { message: MessageV2 }) {
+  const [copied, setCopied] = useState(false);
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+      onClick={() => {
+        const text = extractMessageText(message);
+        if (text) {
+          navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }
+      }}
+      title={t("common.copy", "复制")}
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+    </button>
+  );
+}
+
 function MessageBubble({ message, onCitationClick, isStreaming, currentStep }: MessageBubbleProps) {
   if (message.role === "user") {
     const quoteParts = message.parts.filter((p) => p.type === "quote") as QuotePart[];
@@ -222,6 +252,7 @@ function MessageBubble({ message, onCitationClick, isStreaming, currentStep }: M
         />
       ))}
       {showGapIndicator && <StreamingIndicator step="thinking" />}
+      {!isStreaming && <CopyMessageButton message={message} />}
     </div>
   );
 }

--- a/packages/app/src/components/home/BookCard.tsx
+++ b/packages/app/src/components/home/BookCard.tsx
@@ -372,6 +372,11 @@ export const BookCard = memo(function BookCard({ book }: BookCardProps) {
         <h4 className="truncate text-xs font-semibold leading-tight text-foreground">
           {book.meta.title}
         </h4>
+        {book.meta.author && (
+          <p className="truncate text-[10px] leading-tight text-muted-foreground">
+            {book.meta.author}
+          </p>
+        )}
 
         {/* Tag badges */}
         {book.tags.length > 0 ? (

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -2149,6 +2149,11 @@ function applyReflowLayoutSettings(view: FoliateView, settings: ViewSettings) {
   } else {
     renderer.removeAttribute("flow");
   }
+
+  // Force re-render to ensure layout mode change takes effect immediately
+  if (typeof renderer.render === "function") {
+    renderer.render();
+  }
 }
 
 /** Generate CSS string for renderer styles */

--- a/packages/app/src/components/settings/ReadSettings.tsx
+++ b/packages/app/src/components/settings/ReadSettings.tsx
@@ -1,7 +1,6 @@
 /**
  * ReadSettings — reading view settings using shadcn components
  */
-import { useEffect } from "react";
 import {
   Select,
   SelectContent,
@@ -20,12 +19,6 @@ export function ReadSettingsPanel() {
   const customFonts = useFontStore((s) => s.fonts);
   const selectedFontId = useFontStore((s) => s.selectedFontId);
   const setSelectedFont = useFontStore((s) => s.setSelectedFont);
-
-  useEffect(() => {
-    if (readSettings.viewMode === "scroll") {
-      updateReadSettings({ viewMode: "paginated" });
-    }
-  }, [readSettings.viewMode, updateReadSettings]);
 
   const currentFontValue = selectedFontId ?? "system";
 
@@ -46,6 +39,25 @@ export function ReadSettingsPanel() {
 
         <div className="space-y-5">
           <div className="flex items-center justify-between">
+            <span className="text-sm text-foreground">{t("settings.viewMode")}</span>
+            <Select
+              value={readSettings.viewMode ?? "paginated"}
+              onValueChange={(v) =>
+                updateReadSettings({ viewMode: v as "paginated" | "scroll" })
+              }
+            >
+              <SelectTrigger className="w-[140px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="paginated">{t("settings.paginated")}</SelectItem>
+                <SelectItem value="scroll">{t("settings.scroll")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {readSettings.viewMode !== "scroll" && (
+          <div className="flex items-center justify-between">
             <span className="text-sm text-foreground">{t("settings.paginatedLayout")}</span>
             <Select
               value={readSettings.paginatedLayout ?? "double"}
@@ -62,6 +74,7 @@ export function ReadSettingsPanel() {
               </SelectContent>
             </Select>
           </div>
+          )}
 
           {/* Font */}
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- **#34/#58 滚动翻页模式**：foliate-js 已原生支持 `flow="scrolled"`，现在在阅读设置中暴露该选项，用户可选择翻页或滚动模式
- **#55 AI 对话复制和导出**：assistant 消息添加 hover 复制按钮；ChatPage 顶栏添加导出按钮，一键将整轮对话导出为 Markdown 文件
- **#62 书库显示作者**：BookCard 标题下方显示作者名

## Test plan

- [ ] 阅读设置 → 切换阅读模式为"滚动" → 书籍以上下滚动方式阅读
- [ ] 滚动模式下"分页布局"选项自动隐藏
- [ ] AI 对话中 hover 到 assistant 消息 → 出现复制按钮 → 点击复制成功
- [ ] AI 对话顶栏 → 点击导出按钮 → 下载 Markdown 文件
- [ ] 书库页面 → 书卡显示作者名（单行截断）

Closes #34, #58, #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)