### PR TITLE
feat(library): 书库搜索栏重做 — 下方独立栏 + 宽屏与标签同行

### DIFF
--- a/packages/app-expo/src/screens/LibraryScreen.tsx
+++ b/packages/app-expo/src/screens/LibraryScreen.tsx
@@ -138,10 +138,6 @@ export function LibraryScreen() {
   const columnCount = layout.isTabletLandscape ? 5 : layout.isTablet ? 4 : NUM_COLUMNS;
   const contentWidth = layout.centeredContentWidth;
   const gridItemWidth = Math.floor((contentWidth - gridGap * (columnCount - 1)) / columnCount);
-  const searchExpandedWidth = Math.min(
-    layout.isTabletLandscape ? 420 : layout.isTablet ? 360 : layout.width - 210,
-    Math.max(180, contentWidth - 220),
-  );
   const s = useMemo(
     () =>
       makeStyles(colors, {
@@ -149,8 +145,9 @@ export function LibraryScreen() {
         contentWidth,
         gridGap,
         gridItemWidth,
+        isWideScreen: layout.isTablet,
       }),
-    [colors, contentWidth, gridGap, gridItemWidth, layout.horizontalPadding],
+    [colors, contentWidth, gridGap, gridItemWidth, layout.horizontalPadding, layout.isTablet],
   );
   const [showSearch, setShowSearch] = useState(false);
   const [showSort, setShowSort] = useState(false);
@@ -786,77 +783,23 @@ export function LibraryScreen() {
               <View style={s.headerActions}>
                 <SyncButton size={18} color={colors.mutedForeground} />
                 {hasBooks && (
-                  <Animated.View
-                    style={[
-                      s.animatedSearchWrap,
-                      {
-                        width: searchAnim.interpolate({
-                          inputRange: [0, 1],
-                          outputRange: [36, searchExpandedWidth],
-                        }),
-                        borderBottomColor: searchAnim.interpolate({
-                          inputRange: [0, 1],
-                          outputRange: ["transparent", colors.primary],
-                        }),
-                        borderBottomWidth: searchAnim.interpolate({
-                          inputRange: [0, 1],
-                          outputRange: [0, 1],
-                        }),
-                      },
-                    ]}
+                  <TouchableOpacity
+                    style={s.headerBtn}
+                    onPress={() => {
+                      if (showSearch) {
+                        closeSearch();
+                        Keyboard.dismiss();
+                      } else {
+                        openSearch();
+                      }
+                    }}
+                    activeOpacity={0.7}
                   >
-                    <TouchableOpacity
-                      style={s.headerBtn}
-                      onPress={() => {
-                        if (showSearch) {
-                          if (!filter.search.trim()) {
-                            closeSearch();
-                            Keyboard.dismiss();
-                          }
-                        } else {
-                          openSearch();
-                        }
-                      }}
-                      activeOpacity={0.7}
-                    >
-                      <SearchIcon
-                        size={18}
-                        color={showSearch ? colors.primary : colors.mutedForeground}
-                      />
-                    </TouchableOpacity>
-                    <Animated.View
-                      style={{
-                        flex: 1,
-                        opacity: searchAnim,
-                        flexDirection: "row",
-                        alignItems: "center",
-                      }}
-                    >
-                      <TextInput
-                        ref={searchInputRef}
-                        style={s.searchInputInline}
-                        placeholder={t("library.searchPlaceholder", "搜索...")}
-                        placeholderTextColor={colors.mutedForeground}
-                        value={filter.search}
-                        onChangeText={(text) => setFilter({ search: text })}
-                        onBlur={() => {
-                          if (!filter.search.trim()) closeSearch();
-                        }}
-                        returnKeyType="search"
-                      />
-                      {filter.search.length > 0 && showSearch && (
-                        <TouchableOpacity
-                          style={s.clearSearchBtn}
-                          onPress={() => {
-                            setFilter({ search: "" });
-                            searchInputRef.current?.focus();
-                          }}
-                        >
-                          <XIcon size={14} color={colors.mutedForeground} />
-                        </TouchableOpacity>
-                      )}
-                    </Animated.View>
-                  </Animated.View>
+                    <SearchIcon
+                      size={18}
+                      color={showSearch ? colors.primary : colors.mutedForeground}
+                    />
+                  </TouchableOpacity>
                 )}
                 {hasBooks && (
                   <TouchableOpacity style={s.headerBtn} onPress={() => setShowSort(!showSort)}>
@@ -895,45 +838,99 @@ export function LibraryScreen() {
             </View>
           )}
 
-          {hasBooks && allTags.length > 0 && (
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              style={s.tagScroll}
-              contentContainerStyle={s.tagScrollContent}
-            >
-              <TouchableOpacity
-                style={[s.tagChip, !activeTag && !activeGroupId && s.tagChipActive]}
-                onPress={() => setActiveTag("")}
-              >
-                <Text style={[s.tagChipText, !activeTag && !activeGroupId && s.tagChipTextActive]}>
-                  {t("library.all", "全部")}
-                </Text>
-              </TouchableOpacity>
-              {allTags.map((tag) => (
-                <TouchableOpacity
-                  key={tag}
-                  style={[s.tagChip, activeTag === tag && s.tagChipActive]}
-                  onPress={() => setActiveTag(activeTag === tag ? "" : tag)}
+          {hasBooks && ((!selectionMode && showSearch) || allTags.length > 0) && (
+            <View style={s.searchTagSection}>
+              {!selectionMode && showSearch && (
+                <Animated.View
+                  style={[
+                    s.searchInputContainer,
+                    layout.isTablet ? s.searchInputContainerWide : null,
+                    {
+                      opacity: searchAnim,
+                      transform: [
+                        {
+                          translateY: searchAnim.interpolate({
+                            inputRange: [0, 1],
+                            outputRange: [-4, 0],
+                          }),
+                        },
+                      ],
+                    },
+                  ]}
                 >
-                  <Text style={[s.tagChipText, activeTag === tag && s.tagChipTextActive]}>
-                    {tag}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-              <TouchableOpacity
-                style={[s.tagChip, activeTag === "__uncategorized__" && s.tagChipActive]}
-                onPress={() =>
-                  setActiveTag(activeTag === "__uncategorized__" ? "" : "__uncategorized__")
-                }
-              >
-                <Text
-                  style={[s.tagChipText, activeTag === "__uncategorized__" && s.tagChipTextActive]}
+                  <SearchIcon size={16} color={colors.mutedForeground} />
+                  <TextInput
+                    ref={searchInputRef}
+                    style={s.searchInput}
+                    placeholder={t("library.searchPlaceholder", "搜索...")}
+                    placeholderTextColor={colors.mutedForeground}
+                    value={filter.search}
+                    onChangeText={(text) => setFilter({ search: text })}
+                    onBlur={() => {
+                      if (!filter.search.trim()) closeSearch();
+                    }}
+                    returnKeyType="search"
+                  />
+                  {filter.search.length > 0 && (
+                    <TouchableOpacity
+                      style={s.searchClearBtn}
+                      onPress={() => {
+                        setFilter({ search: "" });
+                        searchInputRef.current?.focus();
+                      }}
+                      hitSlop={6}
+                    >
+                      <XIcon size={14} color={colors.mutedForeground} />
+                    </TouchableOpacity>
+                  )}
+                </Animated.View>
+              )}
+              {allTags.length > 0 && (
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={[s.tagScroll, layout.isTablet ? s.tagScrollWide : null]}
+                  contentContainerStyle={s.tagScrollContent}
                 >
-                  {t("sidebar.uncategorized", "未分类")}
-                </Text>
-              </TouchableOpacity>
-            </ScrollView>
+                  <TouchableOpacity
+                    style={[s.tagChip, !activeTag && !activeGroupId && s.tagChipActive]}
+                    onPress={() => setActiveTag("")}
+                  >
+                    <Text
+                      style={[s.tagChipText, !activeTag && !activeGroupId && s.tagChipTextActive]}
+                    >
+                      {t("library.all", "全部")}
+                    </Text>
+                  </TouchableOpacity>
+                  {allTags.map((tag) => (
+                    <TouchableOpacity
+                      key={tag}
+                      style={[s.tagChip, activeTag === tag && s.tagChipActive]}
+                      onPress={() => setActiveTag(activeTag === tag ? "" : tag)}
+                    >
+                      <Text style={[s.tagChipText, activeTag === tag && s.tagChipTextActive]}>
+                        {tag}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                  <TouchableOpacity
+                    style={[s.tagChip, activeTag === "__uncategorized__" && s.tagChipActive]}
+                    onPress={() =>
+                      setActiveTag(activeTag === "__uncategorized__" ? "" : "__uncategorized__")
+                    }
+                  >
+                    <Text
+                      style={[
+                        s.tagChipText,
+                        activeTag === "__uncategorized__" && s.tagChipTextActive,
+                      ]}
+                    >
+                      {t("sidebar.uncategorized", "未分类")}
+                    </Text>
+                  </TouchableOpacity>
+                </ScrollView>
+              )}
+            </View>
           )}
         </View>
       </View>
@@ -1128,6 +1125,7 @@ const makeStyles = (
     contentWidth: number;
     gridGap: number;
     gridItemWidth: number;
+    isWideScreen: boolean;
   },
 ) =>
   StyleSheet.create({
@@ -1166,21 +1164,40 @@ const makeStyles = (
       alignItems: "center",
       justifyContent: "center",
     },
-    animatedSearchWrap: {
+    searchTagSection: {
+      flexDirection: layout.isWideScreen ? "row" : "column",
+      alignItems: layout.isWideScreen ? "center" : "stretch",
+      gap: layout.isWideScreen ? 12 : 6,
+      marginBottom: 4,
+    },
+    searchInputContainer: {
       flexDirection: "row",
       alignItems: "center",
       height: 36,
-      overflow: "hidden",
+      paddingHorizontal: 10,
+      gap: 6,
+      borderRadius: radius.full,
+      backgroundColor: colors.muted,
     },
-    searchInputInline: {
+    searchInputContainerWide: {
+      width: 280,
+    },
+    searchInput: {
       flex: 1,
       fontSize: fontSize.sm,
       color: colors.foreground,
       padding: 0,
-      minWidth: 50,
+      minWidth: 0,
     },
-    clearSearchBtn: { width: 24, height: 36, alignItems: "center", justifyContent: "center" },
+    searchClearBtn: {
+      width: 22,
+      height: 22,
+      borderRadius: 11,
+      alignItems: "center",
+      justifyContent: "center",
+    },
     tagScroll: { marginBottom: 4 },
+    tagScrollWide: { flex: 1, minWidth: 0, marginBottom: 0 },
     tagScrollContent: { gap: 6, paddingRight: 8 },
     tagChip: {
       paddingHorizontal: 12,


### PR DESCRIPTION
## Summary

书库 header 右侧塞了 5 个 action（同步 / 搜索 / 排序 / 分组视图 / 导入），其中搜索还是 inline 动画展开 TextInput 的写法 —— 一打开就把后面 3 个按钮推到看不见的地方，挤得很乱。重做了下搜索的交互。

| | 之前 | 现在 |
|---|---|---|
| header 按钮位置 | 搜索展开后挤掉 sort/分组/导入 | **始终不动** |
| 搜索框位置（窄屏） | 在 header 里 inline 展开 | **header 下方独立一行** |
| 搜索框位置（宽屏） | 同上，但更挤 | **与 tag scroll 同一行**（搜索 280px + 标签 flex:1）|
| 视觉 | 透明带下划线 | **pill 形 muted 胶囊** |
| 用到的 magic number | `layout.width - 210` 这种 | **去掉** |

### 实现要点

- header 里搜索按钮变成纯 toggle（激活时图标变 primary 色），不再 inline 展开
- 下方新增 `searchTagSection`，根据 `layout.isTablet` 决定 `flexDirection`：
  - 手机：`column` —— 搜索框全宽 + 标签全宽，分两行
  - 平板（任意方向）：`row` —— 搜索框固定 280px + 标签 `flex:1` 占剩余
- 用 `isTablet` 不是 `isTabletLandscape`，因为 iPad 竖屏（768px+）也完全有空间放在一行
- 选择模式（多选状态）下不显示搜索栏 —— 那个上下文搜索不合理；tag scroll 在选择模式的行为保持不变
- 搜索框样式：pill 形（`radius.full`）muted 底胶囊，左 SearchIcon + TextInput + 右 X 清除按钮（仅有内容时）
- `searchAnim` 仍驱动 opacity + 轻微 translateY 做渐入；关闭时反向动画结束后才 `setShowSearch(false)` 并清空 `filter.search`

### 清理

- 砍掉 `searchExpandedWidth = Math.min(layout.width - 210, ...)` 这种 magic number 计算 —— 在大字号或不规则尺寸下不健壮
- 删掉不再用的样式：`animatedSearchWrap`、`searchInputInline`、`clearSearchBtn`

## Test plan

**手机（iOS + Android）**
- [ ] 默认状态：header 5 个按钮整齐排在右侧，搜索图标灰色
- [ ] 点搜索图标：header 下方滑出全宽搜索胶囊，自动聚焦键盘
- [ ] 输入文字时，胶囊右侧出现 X 圆形清除按钮；点 X 清空但保持聚焦
- [ ] 输入框失焦且为空时：搜索栏自动收起
- [ ] 再点 header 搜索图标：搜索栏直接关闭并收键盘（不需要先清空）
- [ ] 搜索栏与下方 tag scroll 各占一行，互不干扰

**iPad 竖屏 + 横屏**
- [ ] 默认状态：tag scroll 横向占满 header 下方
- [ ] 点搜索图标：搜索框出现在 tag scroll **左侧同一行**，搜索 280px + tags 占剩余
- [ ] 关闭搜索：tag scroll 重新占满整行
- [ ] 横竖屏切换：布局正确响应，无错乱

**回归**
- [ ] 选择模式下 header 切换为多选 toolbar，没有搜索按钮（与之前一致）
- [ ] 没有任何 tag 但 hasBooks 时：只渲染搜索框那一条
- [ ] 没书时：搜索按钮、tag scroll 都不显示
- [ ] 在 group 详情页里搜索行为和书库根目录一致
- [x] `tsc --noEmit` 通过

## Out of scope

- 把次要按钮（同步、分组视图）收进 "..." overflow 菜单 —— 本期没动按钮数量，先解决搜索交互；如果后续还想再清爽可以单独做
- 搜索框出现/消失的 layout shift 平滑过渡（目前 tag scroll 是 instant 收缩，搜索框 fade-in）—— 视觉上能接受就先这样，需要更顺再加 LayoutAnimation

🤖 Generated with [Claude Code](https://claude.com/claude-code)