### PR TITLE
fix(library): 搜索能找到分组里的书 + 移动端搜索后可点击/返回清状态

### DIFF
--- a/packages/app-expo/src/screens/LibraryScreen.tsx
+++ b/packages/app-expo/src/screens/LibraryScreen.tsx
@@ -310,30 +310,32 @@ export function LibraryScreen() {
     [groups, activeGroupId],
   );
 
+  const hasSearch = filter.search.trim().length > 0;
+
   const groupedEntries = useMemo(() => {
-    const query = filter.search.toLowerCase().trim();
+    if (hasSearch) return [];
     return groups
       .map((group) => {
         const groupBooks = filteredBooks.filter((book) => book.groupId === group.id);
         return { type: "group" as const, group, books: groupBooks };
       })
-      .filter(
-        (item) => item.books.length > 0 && (!query || item.group.name.toLowerCase().includes(query)),
-      );
-  }, [filteredBooks, filter.search, groups]);
+      .filter((item) => item.books.length > 0);
+  }, [filteredBooks, groups, hasSearch]);
 
   const visibleBooks = useMemo(
     () =>
-      isGroupView && !activeGroupId ? filteredBooks.filter((book) => !book.groupId) : filteredBooks,
-    [activeGroupId, filteredBooks, isGroupView],
+      isGroupView && !activeGroupId && !hasSearch
+        ? filteredBooks.filter((book) => !book.groupId)
+        : filteredBooks,
+    [activeGroupId, filteredBooks, isGroupView, hasSearch],
   );
 
   const gridItems = useMemo<LibraryGridItem[]>(
     () =>
-      isGroupView && !activeGroupId
+      isGroupView && !activeGroupId && !hasSearch
         ? [...groupedEntries, ...visibleBooks.map((book) => ({ type: "book" as const, book }))]
         : visibleBooks.map((book) => ({ type: "book" as const, book })),
-    [activeGroupId, groupedEntries, isGroupView, visibleBooks],
+    [activeGroupId, groupedEntries, isGroupView, visibleBooks, hasSearch],
   );
 
   const handleLocalImport = useCallback(async () => {
@@ -496,13 +498,19 @@ export function LibraryScreen() {
 
   const handleOpen = useCallback(
     async (book: Book) => {
+      if (showSearch) {
+        searchAnim.setValue(0);
+        setShowSearch(false);
+        setFilter({ search: "" });
+        Keyboard.dismiss();
+      }
       if (book.syncStatus === "remote") {
         await downloadBook(book);
         return;
       }
       await openMobileBook({ bookId: book.id, navigation: nav, t });
     },
-    [downloadBook, nav, t],
+    [downloadBook, nav, t, showSearch, searchAnim, setFilter],
   );
 
   const handleManageTags = useCallback((book: Book) => {
@@ -712,16 +720,6 @@ export function LibraryScreen() {
 
   return (
     <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={["top"]}>
-      {showSearch && (
-        <Pressable
-          style={[StyleSheet.absoluteFill, { zIndex: 10 }]}
-          onPress={() => {
-            Keyboard.dismiss();
-            if (!filter.search.trim()) closeSearch();
-          }}
-        />
-      )}
-
       <ExtractorWebView ref={extractorRef} />
 
       {/* Header */}
@@ -1033,6 +1031,8 @@ export function LibraryScreen() {
               columnWrapperStyle={s.gridRow}
               contentContainerStyle={s.gridContent}
               showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
             />
           )}
         </View>

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -117,25 +117,27 @@ export function HomePage() {
     [groups, activeGroupId],
   );
 
+  const hasSearch = filter.search.trim().length > 0;
+
   const groupedEntries = useMemo(() => {
-    const query = filter.search.toLowerCase().trim();
+    if (hasSearch) return [];
     return groups
       .map((group) => {
         const groupBooks = filtered.filter((book) => book.groupId === group.id);
         return { group, books: groupBooks };
       })
-      .filter(
-        ({ group, books }) =>
-          books.length > 0 && (!query || group.name.toLowerCase().includes(query)),
-      );
-  }, [filtered, filter.search, groups]);
+      .filter(({ books }) => books.length > 0);
+  }, [filtered, groups, hasSearch]);
 
   const visibleBooks = useMemo(
-    () => (isGroupView && !activeGroupId ? filtered.filter((book) => !book.groupId) : filtered),
-    [activeGroupId, filtered, isGroupView],
+    () =>
+      isGroupView && !activeGroupId && !hasSearch
+        ? filtered.filter((book) => !book.groupId)
+        : filtered,
+    [activeGroupId, filtered, isGroupView, hasSearch],
   );
   const visibleItemCount =
-    isGroupView && !activeGroupId
+    isGroupView && !activeGroupId && !hasSearch
       ? groupedEntries.length + visibleBooks.length
       : visibleBooks.length;
 
@@ -144,7 +146,7 @@ export function HomePage() {
     | { type: "book"; book: import("@readany/core/types").Book };
 
   const mixedItems = useMemo((): MixedItem[] => {
-    if (!isGroupView || activeGroupId) return [];
+    if (!isGroupView || activeGroupId || hasSearch) return [];
     const items: MixedItem[] = [];
     for (const { group, books: groupBooks } of groupedEntries) {
       items.push({ type: "group", group, books: groupBooks });
@@ -153,7 +155,7 @@ export function HomePage() {
       items.push({ type: "book", book });
     }
     return items;
-  }, [isGroupView, activeGroupId, groupedEntries, visibleBooks]);
+  }, [isGroupView, activeGroupId, groupedEntries, visibleBooks, hasSearch]);
 
   const handleSortChange = useCallback(
     (field: SortField) => {


### PR DESCRIPTION
## Summary
- **搜索找不到分组内的书**（桌面 + 移动）：搜索时放平结果，不再按 `groupId` 过滤，也不渲染组卡片
- **移动端搜索打开后无法点击书卡**：`LibraryScreen` 里那层 `StyleSheet.absoluteFill + zIndex:10` 的 Pressable 把整页盖住、吞掉 FlatList 的点击。移除后改用 `keyboardShouldPersistTaps="handled"` + `keyboardDismissMode="on-drag"` 处理键盘
- **移动端打开书后从 Reader 返回还停留在搜索状态**：`handleOpen` 打开书前同步清空 `showSearch / filter.search / searchAnim`

## 受影响文件
- `packages/app/src/components/home/HomePage.tsx`
- `packages/app-expo/src/screens/LibraryScreen.tsx`

## Test plan
- [ ] 桌面：在 group view 下搜书名，组里的书能命中并扁平显示；清空搜索后组卡片恢复
- [ ] 移动端：搜书名，命中后点击书卡能正常打开 Reader
- [ ] 移动端：从 Reader 按返回，回到 Library 时搜索栏已关闭、查询为空
- [ ] 桌面 tab 行为不变（多书可从同一搜索会话依次打开）

🤖 Generated with [Claude Code](https://claude.com/claude-code)