### PR TITLE
fix: 修复Windows端自定义AI端点测试连接和获取模型的CORS跨域问题

### DIFF
--- a/packages/core/src/ai/llm-provider.ts
+++ b/packages/core/src/ai/llm-provider.ts
@@ -66,7 +66,7 @@ function sanitizeCustomHeaders(headers?: Headers): Headers | undefined {
   return sanitized;
 }
 
-function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof globalThis.fetch {
+export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof globalThis.fetch {
   const exactUrl = endpoint.useExactRequestUrl ? endpoint.baseUrl?.trim() : "";
   const baseFetch = (_streamingFetch ?? globalThis.fetch).bind(globalThis);
 

--- a/packages/core/src/ai/test-endpoint.ts
+++ b/packages/core/src/ai/test-endpoint.ts
@@ -1,6 +1,7 @@
 import type { AIEndpoint } from "../types";
 import { getDefaultBaseUrl, providerRequiresApiKey } from "../utils";
 import { logAIEndpointDebug, summarizeDebugText } from "./request-debug";
+import { getEndpointFetch } from "./llm-provider";
 import {
   buildOpenAICompatibleUrl,
   buildProviderModelsUrl,
@@ -77,7 +78,9 @@ async function fetchJson(
     });
   }
 
-  const response = await fetch(url, init);
+  // 使用跨域适配fetch，和AI对话逻辑一致
+  const requestFetch = debug ? getEndpointFetch(debug.endpoint, debug.model) : globalThis.fetch;
+  const response = await requestFetch(url, init);
   if (!response.ok) {
     const errorBody = await parseErrorBody(response);
     if (debug) {

--- a/packages/core/src/stores/settings-store.ts
+++ b/packages/core/src/stores/settings-store.ts
@@ -7,6 +7,7 @@ import {
   providerRequiresApiKey,
 } from "../utils";
 import { logAIEndpointDebug, summarizeDebugText } from "../ai/request-debug";
+import { getEndpointFetch } from "../ai/llm-provider";
 import { withPersist } from "./persist";
 
 export interface SettingsState {
@@ -124,7 +125,9 @@ async function fetchOpenAIModels(endpoint: AIEndpoint): Promise<string[]> {
     method: "GET",
     requestUrl,
   });
-  const response = await fetch(requestUrl, {
+  // 使用跨域适配fetch，和AI对话逻辑一致
+  const endpointFetch = getEndpointFetch(endpoint);
+  const response = await endpointFetch(requestUrl, {
     headers: { Authorization: `Bearer ${endpoint.apiKey}` },
   });
   if (!response.ok) {
@@ -292,7 +295,9 @@ async function fetchOllamaModels(endpoint: AIEndpoint): Promise<string[]> {
     endpoint.apiKey,
     endpoint.useExactRequestUrl,
   );
-  const response = await fetch(requestUrl);
+  // 使用跨域适配fetch，和AI对话逻辑一致
+  const endpointFetch = getEndpointFetch(endpoint);
+  const response = await endpointFetch(requestUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch Ollama models: ${response.status} ${response.statusText}`);
   }
@@ -309,7 +314,9 @@ async function fetchLMStudioModels(endpoint: AIEndpoint): Promise<string[]> {
     endpoint.apiKey,
     endpoint.useExactRequestUrl,
   );
-  const response = await fetch(requestUrl);
+  // 使用跨域适配fetch，和AI对话逻辑一致
+  const endpointFetch = getEndpointFetch(endpoint);
+  const response = await endpointFetch(requestUrl);
   if (!response.ok) {
     throw new Error(
       `Failed to fetch LM Studio models: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
 ## Summary
  - 导出 `getEndpointFetch` 函数供外部使用
  - 在 `test-endpoint.ts` 和 `settings-store.ts` 中使用跨域适配fetch
  - 与AI对话功能保持一致的请求处理逻辑

  ## Fixes
  - Fixes #96

  ## Test plan
  - [ ] Windows端添加自定义AI端点，点击测试连接
  - [ ] Windows端获取模型列表
  - [ ] Android端相同操作验证兼容性

  涉及文件 (3个):
  - packages/core/src/ai/llm-provider.ts - 导出 getEndpointFetch
  - packages/core/src/ai/test-endpoint.ts - 测试连接使用跨域fetch
  - packages/core/src/stores/settings-store.ts - 获取模型使用跨域fetch