### PR TITLE
fix(ai): auto-prepend http(s):// to scheme-less base URLs (#170)

### DIFF
--- a/packages/core/src/ai/test-endpoint.ts
+++ b/packages/core/src/ai/test-endpoint.ts
@@ -106,7 +106,31 @@ async function fetchJson(
       contentType: response.headers.get("content-type"),
     });
   }
-  return response.json();
+  const rawBody = await response.text();
+  try {
+    return JSON.parse(rawBody);
+  } catch {
+    const contentType = response.headers.get("content-type") || "";
+    if (debug) {
+      logAIEndpointDebug("error", debug.endpoint, {
+        action: debug.action,
+        method: init?.method || "GET",
+        requestUrl: url,
+        model: debug.model,
+        status: response.status,
+        statusText: response.statusText,
+        contentType,
+        responseLength: rawBody.length,
+        responseBodyPreview: summarizeDebugText(rawBody),
+      });
+    }
+    const lookedLikeHtml = /^\s*<(!doctype|html)/i.test(rawBody) || contentType.includes("html");
+    throw new Error(
+      lookedLikeHtml
+        ? `Endpoint returned an HTML page instead of JSON (${url}). Make sure the base URL starts with http:// or https:// and points to the API root.`
+        : `Endpoint did not return JSON (${url}). Make sure the base URL starts with http:// or https:// and points to the API root.`,
+    );
+  }
 }
 
 async function listOpenAICompatibleModels(endpoint: AIEndpoint): Promise<string[]> {

--- a/packages/core/src/stores/settings-store.ts
+++ b/packages/core/src/stores/settings-store.ts
@@ -147,18 +147,22 @@ async function fetchOpenAIModels(endpoint: AIEndpoint): Promise<string[]> {
   try {
     data = JSON.parse(rawBody);
   } catch {
+    const contentType = response.headers.get("content-type") || "";
     logAIEndpointDebug("error", endpoint, {
       action: "fetch-models",
       method: "GET",
       requestUrl,
       status: response.status,
       statusText: response.statusText,
-      contentType: response.headers.get("content-type"),
+      contentType,
       responseLength: rawBody.length,
       responseBodyPreview: summarizeDebugText(rawBody),
     });
+    const lookedLikeHtml = /^\s*<(!doctype|html)/i.test(rawBody) || contentType.includes("html");
     throw new Error(
-      "The endpoint did not return JSON. Check whether the base URL points to the API root instead of a console page.",
+      lookedLikeHtml
+        ? "The endpoint returned an HTML page instead of JSON. Make sure the base URL starts with http:// or https:// and points to the API root, not a console/dashboard page."
+        : "The endpoint did not return JSON. Make sure the base URL starts with http:// or https:// and points to the API root, not a console page.",
     );
   }
 

--- a/packages/core/src/utils/api.test.ts
+++ b/packages/core/src/utils/api.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildOpenAICompatibleUrl,
   buildProviderModelsUrl,
+  ensureUrlProtocol,
+  formatApiHost,
   providerSupportsExactRequestUrl,
   resolveProviderBaseUrl,
 } from "./api";
@@ -79,5 +81,46 @@ describe("AI API URL helpers", () => {
     expect(
       buildProviderModelsUrl("google", "https://generativelanguage.googleapis.com", "AIza-test"),
     ).toBe("https://generativelanguage.googleapis.com/v1beta/models?key=AIza-test");
+  });
+
+  describe("ensureUrlProtocol / scheme-less inputs", () => {
+    it("prepends https:// when a remote URL has no scheme", () => {
+      expect(ensureUrlProtocol("api.openai.com/v1")).toBe("https://api.openai.com/v1");
+      expect(ensureUrlProtocol("openrouter.ai/api/v1")).toBe("https://openrouter.ai/api/v1");
+    });
+
+    it("prepends http:// for localhost / loopback hosts", () => {
+      expect(ensureUrlProtocol("localhost:11434")).toBe("http://localhost:11434");
+      expect(ensureUrlProtocol("127.0.0.1:8080/api")).toBe("http://127.0.0.1:8080/api");
+    });
+
+    it("leaves already-protocoled URLs alone", () => {
+      expect(ensureUrlProtocol("https://api.openai.com")).toBe("https://api.openai.com");
+      expect(ensureUrlProtocol("http://localhost:1234")).toBe("http://localhost:1234");
+      expect(ensureUrlProtocol("  https://api.openai.com  ")).toBe("https://api.openai.com");
+    });
+
+    it("returns empty string for empty / whitespace input", () => {
+      expect(ensureUrlProtocol("")).toBe("");
+      expect(ensureUrlProtocol("   ")).toBe("");
+    });
+
+    it("strips leading slashes that would survive concatenation", () => {
+      expect(ensureUrlProtocol("//api.example.com")).toBe("//api.example.com");
+      expect(ensureUrlProtocol("/api.example.com")).toBe("https://api.example.com");
+    });
+
+    it("flows through the provider URL builders so requests escape the webview", () => {
+      expect(resolveProviderBaseUrl("openai", "api.openai.com")).toBe(
+        "https://api.openai.com/v1",
+      );
+      expect(buildProviderModelsUrl("custom", "api.example.com")).toBe(
+        "https://api.example.com/v1/models",
+      );
+      expect(buildProviderModelsUrl("ollama", "localhost:11434")).toBe(
+        "http://localhost:11434/api/tags",
+      );
+      expect(formatApiHost("api.openai.com")).toBe("https://api.openai.com/v1/");
+    });
   });
 });

--- a/packages/core/src/utils/api.ts
+++ b/packages/core/src/utils/api.ts
@@ -214,7 +214,7 @@ const VERSION_PATTERN = /\/(v[1-9]\d*|api\/v[1-9]\d*|api\/paas\/v[1-9]\d*|compat
 export function formatApiHost(host: string): string {
   if (!host) return host;
 
-  host = host.trim();
+  host = ensureUrlProtocol(host.trim());
 
   if (host.endsWith("/")) {
     return host;
@@ -235,6 +235,24 @@ export function formatApiHost(host: string): string {
 
 export function trimApiUrl(url: string): string {
   return url.replace(/\/+$/, "");
+}
+
+/**
+ * If the URL has no scheme, prepend https:// (or http:// for localhost / loopback).
+ * Without this, scheme-less inputs like "api.openai.com/v1" get resolved by the
+ * Tauri webview as relative paths against tauri://localhost and fall through to
+ * the SPA's own index.html, producing the confusing "Unexpected token '<'" /
+ * "endpoint did not return JSON" error chain on connect.
+ */
+export function ensureUrlProtocol(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return trimmed;
+  if (/^[a-z][a-z0-9+\-.]*:\/\//i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith("//")) return trimmed;
+  const stripped = trimmed.replace(/^\/+/, "");
+  const isLoopback =
+    /^(localhost(?:[:/]|$)|127\.\d+\.\d+\.\d+|0\.0\.0\.0(?:[:/]|$)|\[::1?\])/i.test(stripped);
+  return `${isLoopback ? "http://" : "https://"}${stripped}`;
 }
 
 function sanitizeOpenAICompatibleBaseUrl(url: string): string {
@@ -271,7 +289,7 @@ export function resolveProviderBaseUrl(
   baseUrl?: string,
   exactRequestUrl = false,
 ): string {
-  const rawBaseUrl = (baseUrl || getDefaultBaseUrl(providerId) || "").trim();
+  const rawBaseUrl = ensureUrlProtocol((baseUrl || getDefaultBaseUrl(providerId) || "").trim());
   if (!rawBaseUrl) return "";
   const providerConfig = getProviderConfig(providerId);
   const trimmedRawBaseUrl = trimApiUrl(rawBaseUrl);
@@ -298,7 +316,7 @@ export function buildProviderModelsUrl(
   apiKey?: string,
   exactRequestUrl = false,
 ): string {
-  const rawBaseUrl = (baseUrl || getDefaultBaseUrl(providerId) || "").trim();
+  const rawBaseUrl = ensureUrlProtocol((baseUrl || getDefaultBaseUrl(providerId) || "").trim());
   if (!rawBaseUrl) return "";
 
   if (exactRequestUrl && providerSupportsExactRequestUrl(providerId)) {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -29,6 +29,7 @@ export type { TimeGroup, GroupedThreads } from "./time-group";
 export {
   formatApiHost,
   trimApiUrl,
+  ensureUrlProtocol,
   providerSupportsExactRequestUrl,
   resolveProviderBaseUrl,
   buildProviderModelsUrl,


### PR DESCRIPTION
Closes #170

## Root cause

When the user pastes an AI endpoint base URL without a protocol — e.g. `api.openai.com/v1` or `openrouter.ai/api/v1` — `fetch()` inside the Tauri webview resolves it relative to the current origin (`tauri://localhost`). The request never leaves the app: it hits the bundled SPA's own static server and falls through to `index.html` (HTTP 200, `content-type: text/html`). The JSON parser then throws \`Unexpected token '<'\`, surfaced to the user as "endpoint did not return JSON".

Evidence from the reporter's diagnostic logs:
\`\`\`
contentType: "text/html"
responseBodyPreview: "<!doctype html>... <title>ReadAny</title> <script ... src=\"/assets/index-CbV...\""
\`\`\`
That's literally the app's own bundle being returned.

## Fix

- New \`ensureUrlProtocol()\` helper in \`packages/core/src/utils/api.ts\`. If the input has no scheme, prepends \`https://\`. Detects loopback hosts (\`localhost\`, \`127.x.x.x\`, \`0.0.0.0\`, \`[::1]\`) and prefers \`http://\` for them so local Ollama / LM Studio keep working.
- Wired into the three places the base URL fans out from:
  - \`formatApiHost\` — used by \`llm-provider.ts\` for the chat-completion request path.
  - \`resolveProviderBaseUrl\` — used by every provider's URL builder.
  - \`buildProviderModelsUrl\` — used by the model-list fetch (including the Ollama tags path that bypasses \`resolveProviderBaseUrl\`).
- When the endpoint still returns HTML (e.g. URL points to a dashboard rather than the API root), \`test-endpoint.fetchJson\` and \`settings-store\` now surface a clear error mentioning the protocol and "API root, not console page" instead of letting the JSON parser throw \`Unexpected token '<'\`.

## Test plan

- [x] \`pnpm --filter @readany/core test\` — 35 files / 340 tests pass, 5 new cases for \`ensureUrlProtocol\` (no-scheme, loopback, idempotent on already-protocoled, empty input, end-to-end through provider URL builders).
- [x] \`tsc --noEmit\` clean for \`packages/app\` and \`packages/app-expo\`.
- [ ] Manual: paste \`api.openai.com\` (no scheme) → fetch models / test connection → request actually leaves the app and hits api.openai.com over HTTPS.
- [ ] Manual: paste a deliberately wrong URL pointing at an HTML page → user sees the new "starts with http(s):// and points to API root" message rather than the JSON parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)