### PR TITLE
perf(reader): remove 120ms fade-out before cross-chapter load

### DIFF
--- a/packages/foliate-js/paginator.js
+++ b/packages/foliate-js/paginator.js
@@ -1014,15 +1014,6 @@ export class Paginator extends HTMLElement {
     this.#index = index;
     const hasFocus = this.#view?.document?.hasFocus();
     if (src) {
-      // Fade-out old content when crossing sections (if animated)
-      const container = this.#container;
-      const shouldAnimate = this.hasAttribute("animated") && container;
-      if (shouldAnimate) {
-        container.style.transition = "opacity 120ms ease-out";
-        container.style.opacity = "0";
-        await wait(120);
-      }
-
       const view = this.#createView();
       const afterLoad = (doc) => {
         if (doc.head) {
@@ -1046,12 +1037,6 @@ export class Paginator extends HTMLElement {
         }),
       );
       this.#view = view;
-
-      // Fade-in new content
-      if (shouldAnimate) {
-        container.style.transition = "opacity 200ms ease-in";
-        container.style.opacity = "1";
-      }
     }
     if (this.#view) {
       await this.scrollToAnchor((typeof anchor === "function" ? anchor(this.#view.document) : anchor) ?? 0, select);


### PR DESCRIPTION
## Problem

Cross-chapter page turns feel sluggish compared to readest (same foliate-js engine). The user reported the lag is reproducible and annoying.

## Root cause

\`packages/foliate-js/paginator.js\` (vendored) inserts a hard-coded 120 ms opacity fade-out **before** the next section's \`load()\` starts on every cross-section turn:

\`\`\`js
const shouldAnimate = this.hasAttribute("animated") && container;
if (shouldAnimate) {
  container.style.transition = "opacity 120ms ease-out";
  container.style.opacity = "0";
  await wait(120);   // ← serial wait, blocks the load
}
\`\`\`

readest's vendored foliate-js (`packages/foliate-js/paginator.js:1318-1347` over in `/Users/tuntuntutu/Project/readest`) has no such gate — it goes straight to \`view.load(...)\`. That's at least part of why readest feels instant on the same hardware.

## Fix

Delete the fade-out block, and the matching fade-in (which was only there because we'd set opacity to 0 ourselves). Cross-chapter turn now starts loading immediately, matching readest.

## Tradeoff considered

We lose a subtle visual hint that the chapter is changing. Tried two alternatives mentally:
- Keep the opacity transition but drop the \`await\` — would cause a brief blank flash if load is faster than 120 ms.
- Start the fade in parallel with the load — same problem, plus the fade-in path is now misaligned.

Just dropping it lands us at the same point as readest, which is where the user wants to be.

## Scope

Only the paginator. The other half of the gap — \`handleSectionLoad\` in \`ReaderView.tsx\` re-applying every highlight in the book on every section change — will be a separate PR.

## Test plan

- [ ] Open an EPUB, paginated mode, turn past a chapter boundary repeatedly — should feel instant, comparable to readest.
- [ ] Same in scrolled mode (engine path is the same but \`#display\` is gated by \`shouldAnimate\` only when the animated attribute is set; behavior should be unchanged).
- [ ] No regression on highlight rendering, search-result highlighting, or selection across pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)