### PR TITLE
feat(reader): support PageUp/PageDown for page turning (#177)

### DIFF
--- a/packages/core/src/hooks/reader/useBookShortcuts.ts
+++ b/packages/core/src/hooks/reader/useBookShortcuts.ts
@@ -42,6 +42,9 @@ export function useBookShortcuts({
         case "ArrowUp":
           view.prev();
           return true;
+        case "PageUp":
+          view.prev();
+          return true;
         case "ArrowDown":
         case " ":
           if (modifiers.shiftKey) {
@@ -49,6 +52,9 @@ export function useBookShortcuts({
           } else {
             view.next();
           }
+          return true;
+        case "PageDown":
+          view.next();
           return true;
         case "[":
           view.prev();


### PR DESCRIPTION
Closes #177

## Summary

- Add `PageUp` / `PageDown` to the reader keymap in `handleAction` (`packages/core/src/hooks/reader/useBookShortcuts.ts`): `PageUp` → `view.prev()`, `PageDown` → `view.next()`, mirroring the existing `ArrowUp` / `ArrowDown` / `Space` handling.

为阅读器补上 `PageUp` / `PageDown` 翻页：与现有 `↑` / `↓` / 空格 的处理方式一致，`PageUp` 上一页、`PageDown` 下一页。

## Test plan

- [x] `pnpm --filter @readany/core test` — 35 files / 340 tests pass
- [ ] Manual: open a book → `PageDown` next page, `PageUp` previous page; existing arrows / space / `[` `]` still work

> Note: this is a +6-line addition matching the surrounding `case` style and introduces no new `biome` findings. `pnpm lint` (`biome check .`) currently surfaces only pre-existing, unrelated issues on `main` (e.g. `TabBar.tsx` a11y, and a formatter nit in the untouched `onMessage` block of this same file).
