### PR TITLE
fix(import): 修复带路径 WebDAV 地址列不出内容、连接测试误报 (#174)

### DIFF
--- a/packages/core/src/import/webdav-import-service.test.ts
+++ b/packages/core/src/import/webdav-import-service.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { type IPlatformService, setPlatformService } from "../services/platform";
 import {
+  WebDavImportService,
   getWebDavImportRootPrefix,
   resolveWebDavImportServerPath,
   toWebDavImportRelativePath,
@@ -73,5 +75,80 @@ describe("webdav import path helpers", () => {
     expect(resolveWebDavImportServerPath(source, "/fiction/book.epub")).toBe(
       "/library/fiction/book.epub",
     );
+  });
+});
+
+const PROPFIND_BOOKS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/home/Books/</D:href>
+    <D:propstat><D:prop><D:resourcetype><D:collection/></D:resourcetype></D:prop></D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/home/Books/novel.epub</D:href>
+    <D:propstat><D:prop><D:resourcetype/><D:getcontentlength>123</D:getcontentlength></D:prop></D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+/**
+ * Minimal platform stub: the import paths only use platform.fetch, so we record
+ * the requested URL and answer with a canned response (cast — other methods unused).
+ */
+function installFetchCapture(): { requests: Array<{ method: string; url: string }> } {
+  const requests: Array<{ method: string; url: string }> = [];
+  setPlatformService({
+    async fetch(url, options) {
+      const method = options?.method ?? "GET";
+      requests.push({ method, url });
+      if (method === "PROPFIND") {
+        return new Response(PROPFIND_BOOKS_XML, { status: 207 });
+      }
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    },
+  } as unknown as IPlatformService);
+  return { requests };
+}
+
+describe("WebDavImportService request paths (issue #174)", () => {
+  it("lists a path-bearing WebDAV URL without duplicating the pathname", async () => {
+    const { requests } = installFetchCapture();
+    const service = new WebDavImportService(
+      createSource({ url: "http://host:5005/home/Books", remoteRoot: "" }),
+    );
+
+    const listing = await service.list("/");
+
+    expect(requests.map((r) => r.url)).toContain("http://host:5005/home/Books");
+    expect(requests.some((r) => r.url.includes("/home/Books/home/Books"))).toBe(false);
+
+    expect(listing.entries.map((e) => e.relativePath)).toEqual(["/novel.epub"]);
+    expect(listing.importableCount).toBe(1);
+  });
+
+  it("downloads a file using the origin-based base url", async () => {
+    const { requests } = installFetchCapture();
+    const service = new WebDavImportService(
+      createSource({ url: "http://host:5005/home/Books", remoteRoot: "" }),
+    );
+
+    await service.downloadFile("/novel.epub");
+
+    expect(
+      requests.some(
+        (r) => r.method === "GET" && r.url === "http://host:5005/home/Books/novel.epub",
+      ),
+    ).toBe(true);
+  });
+
+  it("tests the connection against the resolved root prefix, not the bare origin root", async () => {
+    const { requests } = installFetchCapture();
+    const service = new WebDavImportService(
+      createSource({ url: "http://host:5005/home/Books", remoteRoot: "" }),
+    );
+
+    await service.testConnection();
+
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.every((r) => r.url === "http://host:5005/home/Books")).toBe(true);
   });
 });

--- a/packages/core/src/import/webdav-import-service.ts
+++ b/packages/core/src/import/webdav-import-service.ts
@@ -13,6 +13,14 @@ function splitPathSegments(path: string): string[] {
   return path.split("/").filter(Boolean);
 }
 
+function webDavOriginFromUrl(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return sanitizeWebDavUrl(url);
+  }
+}
+
 function safeDecodeWebDavPath(path: string): string {
   try {
     return decodeURIComponent(path);
@@ -127,8 +135,10 @@ export class WebDavImportService {
       username: source.username.trim(),
       remoteRoot: normalizeWebDavImportRoot(source.remoteRoot),
     };
+    // Construct from origin only: the path helpers already include the URL's
+    // pathname, so a full-URL baseUrl would make buildUrl duplicate the path.
     this.client = new WebDavClient(
-      this.source.url,
+      webDavOriginFromUrl(this.source.url),
       this.source.username,
       this.source.password,
       this.source.allowInsecure,
@@ -136,8 +146,10 @@ export class WebDavImportService {
   }
 
   async testConnection(): Promise<boolean> {
-    await this.client.ping();
-    await this.client.propfind(resolveWebDavImportServerPath(this.source, "/"));
+    // Probe the resolved prefix, not the bare origin root (see WebDavClient.ping).
+    const rootPath = resolveWebDavImportServerPath(this.source, "/");
+    await this.client.ping(rootPath);
+    await this.client.propfind(rootPath);
     return true;
   }
 

--- a/packages/core/src/sync/webdav-client.ts
+++ b/packages/core/src/sync/webdav-client.ts
@@ -305,9 +305,13 @@ export class WebDavClient {
     }
   }
 
-  /** Test if the server is reachable and credentials are valid */
-  async ping(): Promise<void> {
-    const resp = await this.request("PROPFIND", "/", {
+  /**
+   * Test if the server is reachable and credentials are valid. Pass `path` when
+   * baseUrl is the bare origin; the default "/" probes the root, which
+   * subpath-only servers (e.g. Jianguoyun /dav/) reject.
+   */
+  async ping(path = "/"): Promise<void> {
+    const resp = await this.request("PROPFIND", path, {
       headers: { Depth: "0" },
       body: '<?xml version="1.0"?><D:propfind xmlns:D="DAV:"><D:prop><D:resourcetype/></D:prop></D:propfind>',
       contentType: "application/xml",
@@ -316,7 +320,7 @@ export class WebDavClient {
     if (resp.ok || resp.status === 207) {
       return;
     }
-    throw createHttpWebDavError(resp.status, resp.statusText, "PROPFIND", this.buildUrl("/"));
+    throw createHttpWebDavError(resp.status, resp.statusText, "PROPFIND", this.buildUrl(path));
   }
 
   /** Test connection, returns true if successful */


### PR DESCRIPTION
Closes #174

## 根因

「书库 → 导入 → 连接 WebDAV」在地址带路径时（如 NAS `http://host:5005/home/Books`、
坚果云 `https://dav.jianguoyun.com/dav/`）连接显示成功但列不出任何内容；同一地址在
「设置 → 同步」完全正常。

- 路径助手（`getWebDavImportRootPrefix` / `resolveWebDavImportServerPath`）从 URL 的
  pathname 算出**绝对服务器路径**（如 `/home/Books`）。
- 但 `WebDavImportService` 把**完整 URL**（已含 pathname）作为 `WebDavClient` 的
  baseUrl，`buildUrl()` 再拼一次 → `PROPFIND /home/Books/home/Books` → 404。
- `propfind()` 在 404 时返回 `[]`，浏览器静默空列表、不报错。
- 同步后端走相对路径且有去重逻辑，故不受影响。

## 修复

- **origin 构造**：改用 `new URL(url).origin` 构造导入用的 `WebDavClient`，绝对服务器
  路径即可正确拼接；不动路径助手，行为保持一致。
- **连接测试**：baseUrl 改为 origin 后，原 `ping()` 探测的是裸根 `/`，对仅在子路径
  提供 WebDAV 的服务器（坚果云、NAS 子路径）会被拒而误报失败。给 `WebDavClient.ping`
  增加可选 `path` 参数（默认 `/`，同步端不受影响），`testConnection` 改为探测解析后的根前缀。

## 测试

- [x] `pnpm --filter @readany/core test` — 35 files / 343 tests 通过，新增 3 个回归用例（列目录、下载、连接测试）
- [x] NAS 子路径地址（带 path）→ 连接测试通过、正确列出目录与文件（含中文名子目录嵌套）
- [x] 纯主机根地址（无 path）→ 行为不变，请求只打 origin 根、不翻倍
- [ ] 坚果云 `https://dav.jianguoyun.com/dav/` → 连接测试通过、能列目录（需账号现网确认）
