### PR TITLE
fix(ios): suppress dev-only TurboModule invalidate timeout redbox

### DIFF
--- a/packages/app-expo/src/App.tsx
+++ b/packages/app-expo/src/App.tsx
@@ -26,7 +26,7 @@ import { DarkTheme, DefaultTheme, NavigationContainer } from "@react-navigation/
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Text, View } from "react-native";
+import { LogBox, Platform, Text, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
@@ -56,6 +56,17 @@ import { ThemeProvider, useTheme } from "@/styles/ThemeContext";
 import { useAutoSync } from "@readany/core/hooks/use-auto-sync";
 
 installFeedbackLogCapture();
+
+// iOS New-Arch + expo-dev-client cold-start: when dev-client swaps its boot
+// RCTInstance for the app's instance, RCTTurboModuleManager waits up to 10s for
+// every TurboModule's invalidate to return. If any module's method queue is slow
+// (e.g. react-native-track-player v4, whose v4 branch is frozen and does not
+// fully support RN 0.81 New Arch), the wait times out and prints RCTLogError —
+// triggering a red-box. State clears correctly afterwards (see
+// RCTTurboModuleManager.mm:1105), so the warning is purely cosmetic dev noise.
+if (Platform.OS === "ios") {
+  LogBox.ignoreLogs([/TurboModuleManager: Timed out waiting for modules to be invalidated/]);
+}
 
 const FEEDBACK_WORKER_FALLBACK = "https://feedback.readany.top";
 const feedbackWorkerUrl = process.env.EXPO_PUBLIC_FEEDBACK_WORKER_URL?.trim() || FEEDBACK_WORKER_FALLBACK;


### PR DESCRIPTION
## Summary

iOS New-Arch + expo-dev-client 冷启动会把 boot 用的 RCTInstance 换成 app 的，之后 `RCTTurboModuleManager` 最多等 10s 让每个 TurboModule 的 invalidate 返回。react-native-track-player v4 分支已冻结、不完全支持 RN 0.81 New Arch，等不到 → `RCTLogError` → 红框。状态在 `RCTTurboModuleManager.mm:1105` 仍能正确清理，所以这条警告纯属 dev 噪音。

通过 `LogBox.ignoreLogs` 在 iOS 上忽略这条匹配文本，红框不再弹，dev 体验恢复。生产环境无影响（LogBox 仅 dev）。

## Test plan

- [ ] iOS 模拟器冷启动：不再看到 "TurboModuleManager: Timed out waiting for modules to be invalidated" 红框
- [ ] Android 不受影响（gated by Platform.OS === "ios"）