### PR TITLE
fix(feedback): cap log bytes UTF-8-aware so feedback no longer 413s

### DIFF
--- a/packages/core/src/feedback/feedback-service.ts
+++ b/packages/core/src/feedback/feedback-service.ts
@@ -32,6 +32,13 @@ const CONSOLE_LEVELS = ["debug", "info", "log", "warn", "error"] as const;
 const LOG_DIR = "logs";
 const LOG_FLUSH_INTERVAL_MS = 3000; // Flush to file every 3 seconds
 const LOG_MAX_DAYS = 7; // Keep 7 days of logs
+/**
+ * Tail-truncate the collected logs to this UTF-8 byte budget before
+ * submission. Sits below the worker's MAX_BODY_BYTES with room for the
+ * description (≤12_000 chars) + device info + JSON envelope, so a payload
+ * with maxed-out description never trips the worker's 413.
+ */
+const MAX_LOG_BYTES = 60_000;
 
 /** In-memory write buffer — flushed to file periodically */
 let _pendingLines: string[] = [];
@@ -217,6 +224,20 @@ function sanitizeLogLine(line: string): string {
   return line;
 }
 
+/**
+ * Tail-truncate a string to at most `maxBytes` UTF-8 bytes. Diagnostic logs
+ * are most useful at the END — we drop the older lines when oversize. Skips
+ * leading UTF-8 continuation bytes so the cut lands on a code-point boundary.
+ */
+export function truncateUtf8Tail(text: string, maxBytes: number): string {
+  const bytes = new TextEncoder().encode(text);
+  if (bytes.byteLength <= maxBytes) return text;
+  let offset = bytes.byteLength - maxBytes;
+  while (offset < bytes.byteLength && (bytes[offset] & 0xc0) === 0x80) offset++;
+  const dropped = offset;
+  return `[truncated: dropped ${dropped} bytes of older logs]\n${new TextDecoder().decode(bytes.slice(offset))}`;
+}
+
 /** Collect logs for feedback submission. Reads today's + yesterday's log files. */
 export async function collectLogs(options?: { sinceMs?: number }): Promise<string> {
   // First flush any pending lines
@@ -260,8 +281,10 @@ export async function collectLogs(options?: { sinceMs?: number }): Promise<strin
     return match[1] >= sinceTime;
   });
 
-  // Sanitize sensitive data before exposing logs externally
-  return lines.map(sanitizeLogLine).join("\n");
+  // Sanitize sensitive data before exposing logs externally, then tail-truncate
+  // to stay under the worker's MAX_BODY_BYTES (most recent lines are most relevant).
+  const sanitized = lines.map(sanitizeLogLine).join("\n");
+  return truncateUtf8Tail(sanitized, MAX_LOG_BYTES);
 }
 
 /** Clear all log files */

--- a/packages/feedback-worker/src/index.ts
+++ b/packages/feedback-worker/src/index.ts
@@ -50,8 +50,13 @@ interface GitHubCommentResponse {
 
 const MAX_TITLE_LENGTH = 120;
 const MAX_DESCRIPTION_LENGTH = 12_000;
-const MAX_LOG_LENGTH = 50_000;
-const MAX_BODY_BYTES = 80_000;
+/**
+ * Server-side safety net for logs: byte-based and tail-keep (newest lines
+ * matter most for diagnostics). Sized above the client's MAX_LOG_BYTES so
+ * an updated client never gets re-truncated here; old clients still cap.
+ */
+const MAX_LOG_BYTES = 80_000;
+const MAX_BODY_BYTES = 128_000;
 const DEFAULT_SUBMISSIONS_PER_DAY = 20;
 const DEFAULT_STATUS_REQUESTS_PER_HOUR = 120;
 
@@ -104,7 +109,7 @@ async function handleCreateFeedback(request: Request, env: Env): Promise<Respons
   const type = payload.type ?? "other";
   const title = requireText(payload.title, "title", MAX_TITLE_LENGTH);
   const description = requireText(payload.description, "description", MAX_DESCRIPTION_LENGTH);
-  const logs = truncateText(payload.logs?.trim() ?? "", MAX_LOG_LENGTH);
+  const logs = truncateLogTail(payload.logs?.trim() ?? "", MAX_LOG_BYTES);
 
   // Upload logs to Gist if present
   let gistUrl: string | undefined;
@@ -341,6 +346,19 @@ function requireText(value: unknown, name: string, maxLength: number): string {
 function truncateText(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return `${value.slice(0, maxLength)}\n\n[truncated]`;
+}
+
+/**
+ * Tail-truncate logs to at most `maxBytes` UTF-8 bytes. Diagnostic logs
+ * are most useful at the END, so we drop the older lines when oversize.
+ * Skips leading UTF-8 continuation bytes to land on a code-point boundary.
+ */
+function truncateLogTail(value: string, maxBytes: number): string {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.byteLength <= maxBytes) return value;
+  let offset = bytes.byteLength - maxBytes;
+  while (offset < bytes.byteLength && (bytes[offset] & 0xc0) === 0x80) offset++;
+  return `[truncated: dropped ${offset} bytes of older logs]\n${new TextDecoder().decode(bytes.slice(offset))}`;
 }
 
 function parseLabels(raw: string | undefined): string[] | undefined {


### PR DESCRIPTION
## Summary

之前用户反馈大量日志时会 413：客户端截断按字符数算，CJK 多字节 + 累计行多时仍会超 worker `MAX_BODY_BYTES` (80KB)。本 PR 改为字节维度截断：

**客户端 (`feedback-service.ts`)**
- 新增 `MAX_LOG_BYTES = 60_000` 常量
- 新增 `truncateUtf8Tail(text, maxBytes)` — 从头部丢字节（最老日志），自动跳过 UTF-8 continuation byte（`& 0xc0 === 0x80`），保证落在 code-point 边界
- `collectLogs()` 在脱敏之后应用，避免 CJK 切半

**Worker (`feedback-worker/src/index.ts`)**
- `MAX_LOG_LENGTH (50_000 chars) → MAX_LOG_BYTES (80_000 bytes)`，比客户端 cap 略高，新客户端不会被服务端再截一次
- `MAX_BODY_BYTES 80_000 → 128_000` 容纳更大设备信息 + 日志
- 新增 `truncateLogTail()` 给 logs 用（tail-keep，保留最新行做诊断），原 `truncateText()` 留给 title/description 用（head-keep）

## Test plan

- [x] `pnpm --filter @readany/core test` 通过 (340 case)
- [x] worker `tsc --noEmit` 通过
- [x] 手测：模拟大量日志（含 CJK）→ 提交反馈不再 413、Gist 链接里日志不乱码

Fixes 反馈系统在大日志场景下 413 的问题。