### PR TITLE
fix(sync): retry WebDAV throttle 401s + lower concurrency (#195)

### DIFF
--- a/packages/core/src/sync/sync-files.ts
+++ b/packages/core/src/sync/sync-files.ts
@@ -29,6 +29,17 @@ import {
   type SyncProgress,
 } from "./sync-types";
 
+/**
+ * Per-phase parallelism for remote file ops. Tuned conservatively to avoid
+ * triggering 401-throttle responses on consumer WebDAV providers (Jianguoyun,
+ * some NAS) that reject under burst load. See issue #195. Pair with the
+ * WebDavClient retry-on-transient-401 in webdav-client.ts.
+ */
+const UPLOAD_CONCURRENCY = 3;
+const DOWNLOAD_CONCURRENCY = 5;
+const MIGRATION_CONCURRENCY = 3;
+const REMOTE_CLEANUP_CONCURRENCY = 3;
+
 export interface SyncFilesOptions {
   forceUploadAll?: boolean;
   forceDownloadAll?: boolean;
@@ -189,7 +200,7 @@ export async function syncFiles(
     migrationResults.set(info.book.id, result);
   });
   if (migrationTasks.length > 0) {
-    await parallelLimit(migrationTasks, 5);
+    await parallelLimit(migrationTasks, MIGRATION_CONCURRENCY);
   }
 
   // --- Phase 2: build upload/download task lists based on post-migration state ---
@@ -250,7 +261,9 @@ export async function syncFiles(
   );
 
   if (uploadTasks.length > 0) {
-    console.log(`[Sync] 📤 Starting upload of ${uploadTasks.length} files (5 concurrent)...`);
+    console.log(
+      `[Sync] 📤 Starting upload of ${uploadTasks.length} files (${UPLOAD_CONCURRENCY} concurrent)...`,
+    );
     const uploadStart = Date.now();
     let completed = 0;
     const total = uploadTasks.length;
@@ -267,7 +280,7 @@ export async function syncFiles(
       completed++;
       return result;
     });
-    const uploadResults = await parallelLimit(tasksWithProgress, 5);
+    const uploadResults = await parallelLimit(tasksWithProgress, UPLOAD_CONCURRENCY);
     filesUploaded = uploadResults.filter((r) => r).length;
     filesUploadFailed = uploadResults.length - filesUploaded;
     console.log(
@@ -276,7 +289,9 @@ export async function syncFiles(
   }
 
   if (downloadTasks.length > 0) {
-    console.log(`[Sync] 📥 Starting download of ${downloadTasks.length} files (8 concurrent)...`);
+    console.log(
+      `[Sync] 📥 Starting download of ${downloadTasks.length} files (${DOWNLOAD_CONCURRENCY} concurrent)...`,
+    );
     const downloadStart = Date.now();
     let completed = 0;
     const total = downloadTasks.length;
@@ -293,7 +308,7 @@ export async function syncFiles(
       completed++;
       return result;
     });
-    const downloadResults = await parallelLimit(tasksWithProgress, 8);
+    const downloadResults = await parallelLimit(tasksWithProgress, DOWNLOAD_CONCURRENCY);
     filesDownloaded = downloadResults.filter((r) => r).length;
     filesDownloadFailed = downloadResults.length - filesDownloaded;
     console.log(
@@ -642,7 +657,7 @@ async function cleanupRemoteOrphans(
 
   if (tasks.length > 0) {
     console.log(`[Sync] 🧹 Cleaning up ${tasks.length} remote orphans...`);
-    await parallelLimit(tasks, 5);
+    await parallelLimit(tasks, REMOTE_CLEANUP_CONCURRENCY);
   }
 }
 

--- a/packages/core/src/sync/webdav-client.ts
+++ b/packages/core/src/sync/webdav-client.ts
@@ -28,6 +28,16 @@ export function sanitizeWebDavRemoteRoot(remoteRoot: string): string {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const TRANSFER_TIMEOUT_MS = 300_000;
 
+/**
+ * Retry policy for transient HTTP failures (401-after-auth, 429, 5xx).
+ * Backoff: 500ms → 1s → 2s. Network/timeout errors are NOT retried — they may
+ * have consumed the full timeout already, so retrying would amplify latency.
+ * Issue #195 motivated this: Chinese WebDAV providers (Jianguoyun, NAS) reject
+ * with 401 under burst load even though credentials are valid.
+ */
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
 type WebDavErrorKind =
   | "auth"
   | "forbidden"
@@ -217,6 +227,12 @@ export class WebDavClient {
   private baseUrl: string;
   private authHeader: string;
   private allowInsecure: boolean;
+  /**
+   * Flips to true after the first 2xx/207 response. Once true, a 401 is
+   * treated as a server-side throttle (retry-worthy) rather than a credential
+   * failure. Reset per WebDavClient instance.
+   */
+  private hadAuthSuccess = false;
 
   constructor(url: string, username: string, password: string, allowInsecure?: boolean) {
     // Normalize: remove control chars/whitespace and trailing slash
@@ -249,6 +265,48 @@ export class WebDavClient {
     return `${this.baseUrl}${encoded}`;
   }
 
+  /** True if the status code indicates a transient, retry-worthy failure. */
+  private isTransientStatus(status: number): boolean {
+    // 401 BEFORE any successful auth = real credential failure, do not retry.
+    // 401 AFTER a successful response = server is throttling / temporarily
+    // rejecting valid credentials under burst load (Jianguoyun, some NAS).
+    if (status === 401 && this.hadAuthSuccess) return true;
+    if (status === 429) return true;
+    if (status >= 500 && status < 600) return true;
+    return false;
+  }
+
+  private async doFetch(
+    method: string,
+    path: string,
+    options: {
+      body?: string | Uint8Array | ArrayBuffer;
+      headers?: Record<string, string>;
+      contentType?: string;
+      timeoutMs?: number;
+      responseType?: "text" | "arraybuffer";
+    },
+  ): Promise<Response> {
+    const platform = getPlatformService();
+    const url = this.buildUrl(path);
+    const headers: Record<string, string> = {
+      Authorization: this.authHeader,
+      ...options.headers,
+    };
+    if (options.contentType) {
+      headers["Content-Type"] = options.contentType;
+    }
+    const effectiveTimeoutMs = this.getTimeout(method, options.timeoutMs);
+    return await platform.fetch(url, {
+      method,
+      headers,
+      body: options.body as BodyInit | undefined,
+      allowInsecure: this.allowInsecure,
+      timeoutMs: effectiveTimeoutMs,
+      responseType: options.responseType,
+    });
+  }
+
   private async request(
     method: string,
     path: string,
@@ -260,48 +318,47 @@ export class WebDavClient {
       responseType?: "text" | "arraybuffer";
     } = {},
   ): Promise<Response> {
-    const platform = getPlatformService();
-    const url = this.buildUrl(path);
-    const headers: Record<string, string> = {
-      Authorization: this.authHeader,
-      ...options.headers,
-    };
-    if (options.contentType) {
-      headers["Content-Type"] = options.contentType;
-    }
-
     const logPath = path.startsWith("/") ? path : `/${path}`;
     console.log(`[WebDAV] ${method} ${logPath}`);
-    const startTime = Date.now();
 
-    try {
-      const effectiveTimeoutMs = this.getTimeout(method, options.timeoutMs);
-      const response = await platform.fetch(url, {
-        method,
-        headers,
-        body: options.body as BodyInit | undefined,
-        allowInsecure: this.allowInsecure,
-        timeoutMs: effectiveTimeoutMs,
-        responseType: options.responseType,
-      });
-      const elapsed = Date.now() - startTime;
-      console.log(
-        `[WebDAV] ${method} ${logPath} completed in ${elapsed}ms (status: ${response.status})`,
-      );
-      return response;
-    } catch (error: unknown) {
-      const elapsed = Date.now() - startTime;
-      const webDavError = createRequestWebDavError(
-        error,
-        method,
-        url,
-        this.getTimeout(method, options.timeoutMs),
-      );
-      console.error(
-        `[WebDAV] ${method} ${logPath} failed (${webDavError.kind}) after ${elapsed}ms:`,
-        error,
-      );
-      throw webDavError;
+    for (let attempt = 0; ; attempt++) {
+      const startTime = Date.now();
+      try {
+        const response = await this.doFetch(method, path, options);
+        const elapsed = Date.now() - startTime;
+        console.log(
+          `[WebDAV] ${method} ${logPath} completed in ${elapsed}ms (status: ${response.status})`,
+        );
+
+        if (response.ok || response.status === 207) {
+          this.hadAuthSuccess = true;
+          return response;
+        }
+
+        if (attempt < RETRY_MAX_ATTEMPTS && this.isTransientStatus(response.status)) {
+          const delay = RETRY_BASE_DELAY_MS * 2 ** attempt;
+          console.warn(
+            `[WebDAV] ${method} ${logPath} got ${response.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${RETRY_MAX_ATTEMPTS})`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+
+        return response;
+      } catch (error: unknown) {
+        const elapsed = Date.now() - startTime;
+        const webDavError = createRequestWebDavError(
+          error,
+          method,
+          this.buildUrl(path),
+          this.getTimeout(method, options.timeoutMs),
+        );
+        console.error(
+          `[WebDAV] ${method} ${logPath} failed (${webDavError.kind}) after ${elapsed}ms:`,
+          error,
+        );
+        throw webDavError;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #195 — 坚果云 / NAS WebDAV 多文件同步时连环 401 错误。诊断 Gist 日志显示前几个 PROPFIND/MKCOL 成功后 ~5s，相同 URL 开始返回 401。确认是**服务端节流**（部分服务器在突发负载下用 401 而非 429 拒绝），非凭证失效。

### `webdav-client.ts` — 会话感知重试
- 新增 `hadAuthSuccess` 实例字段，首次出现 2xx/207 后翻 true
- `isTransientStatus(status)`：429 / 5xx 无条件重试；401 仅在 `hadAuthSuccess` 之后重试（真正的凭证错误仍单次失败，不掩盖问题）
- 指数退避 500ms → 1s → 2s，最多 3 次
- 抽出 `doFetch()` helper，外层 `request()` 包 retry loop
- 网络/超时错误**不重试**（避免把真实断网或服务宕机放大成 3 次）

### `sync-files.ts` — 降并发，让总在飞请求保持在突发限以下
- `UPLOAD_CONCURRENCY`: 5 → 3
- `DOWNLOAD_CONCURRENCY`: 8 → 5
- `MIGRATION_CONCURRENCY`: 5 → 3
- `REMOTE_CLEANUP_CONCURRENCY`: 5 → 3
- 本地 orphan 清理保持硬编码 5（本地 FS，无节流问题）

## Test plan

- [x] `pnpm --filter @readany/core test` 通过 (35 文件 / 340 case)
- [x] 接坚果云手测：多文件同步不再触发 401 雪崩
- [x] 真正凭证错误（手动改错密码）仍立即返回错误，不被重试掩盖