### PR TITLE
feat(fonts): remove 20MB import size limit

### DIFF
--- a/packages/app-expo/src/screens/settings/FontSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/FontSettingsScreen.tsx
@@ -31,8 +31,6 @@ import { SettingsHeader } from "./SettingsHeader";
 import { useColors, fontSize, fontWeight, radius, spacing } from "@/styles/theme";
 import { PlusIcon, Trash2Icon, TypeIcon, LinkIcon, GlobeIcon } from "@/components/ui/Icon";
 
-const FONT_SIZE_LIMIT = 20 * 1024 * 1024;
-
 export default function FontSettingsScreen() {
   const { t, i18n } = useTranslation();
   const colors = useColors();
@@ -124,18 +122,6 @@ export default function FontSettingsScreen() {
         pendingFontFile.uri,
         fontNameInput.trim(),
       );
-
-      if (size > FONT_SIZE_LIMIT) {
-        const platform = getPlatformService();
-        await platform.deleteFile(filePath);
-        Alert.alert(
-          t("fonts.error", "错误"),
-          t("fonts.tooLarge", "字体文件过大（最大 20MB），建议使用 woff2 格式可显著缩小体积"),
-        );
-        setImporting(false);
-        setPendingFontFile(null);
-        return;
-      }
 
       const fontFamily = `Custom-${fontNameInput.trim().replace(/\s+/g, "-")}`;
       const font: CustomFont = {

--- a/packages/app/src/components/settings/FontSettings.tsx
+++ b/packages/app/src/components/settings/FontSettings.tsx
@@ -3,7 +3,6 @@
  */
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
 import { Download, FileText, Globe, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,8 +20,6 @@ import {
 } from "@readany/core/stores";
 import type { CustomFont } from "@readany/core/types/font";
 import { PRESET_FONTS } from "@readany/core/types/font";
-
-const FONT_SIZE_LIMIT = 20 * 1024 * 1024;
 
 export function FontSettings() {
   const { t, i18n } = useTranslation();
@@ -110,19 +107,6 @@ export function FontSettings() {
         pendingFontFile.path,
         fontNameInput.trim(),
       );
-
-      if (size > FONT_SIZE_LIMIT) {
-        const { remove } = await import("@tauri-apps/plugin-fs");
-        await remove(filePath);
-        // Previously failed silently, leaving the user wondering why nothing
-        // happened. Surface the same message mobile shows.
-        toast.error(
-          t("fonts.tooLarge", "字体文件过大（最大 20MB），建议使用 woff2 格式可显著缩小体积"),
-        );
-        setImporting(false);
-        setPendingFontFile(null);
-        return;
-      }
 
       const fontFamily = `Custom-${fontNameInput.trim().replace(/\s+/g, "-")}`;
       const font: CustomFont = {

--- a/packages/core/src/i18n/locales/en.json
+++ b/packages/core/src/i18n/locales/en.json
@@ -1554,7 +1554,6 @@
     "imported": "Imported",
     "importedDesc": "Font \"{{name}}\" has been imported",
     "fileNotFound": "Font file not found",
-    "tooLarge": "Font file is too large (max 20MB). Tip: woff2 format is significantly smaller.",
     "importHint": "Supports TTF / OTF / WOFF / WOFF2. WOFF2 recommended — about 1/3 the size of TTF.",
     "deleteTitle": "Delete Font",
     "deleteConfirm": "Delete font \"{{name}}\"?",

--- a/packages/core/src/i18n/locales/zh.json
+++ b/packages/core/src/i18n/locales/zh.json
@@ -1554,7 +1554,6 @@
     "imported": "导入成功",
     "importedDesc": "字体 \"{{name}}\" 已导入",
     "fileNotFound": "字体文件不存在",
-    "tooLarge": "字体文件过大（最大 20MB），建议使用 woff2 格式可显著缩小体积",
     "importHint": "支持 TTF / OTF / WOFF / WOFF2，推荐 WOFF2（同款字体体积约为 TTF 的 1/3）",
     "deleteTitle": "删除字体",
     "deleteConfirm": "确定删除字体 \"{{name}}\" 吗？",


### PR DESCRIPTION
## Summary

之前导入字体硬卡 20MB，常见中文字体（如思源黑体 .otf ~40MB）会被拒。用户在字体列表能看到体积、导入提示也已经引导使用 WOFF2（"体积约 TTF 的 1/3"），再加硬上限有点过度干预。

去掉：
- 桌面 `FontSettings.tsx`、移动 `FontSettingsScreen.tsx` 的 `FONT_SIZE_LIMIT` 常量 + size 检查 + Alert/toast + 清理分支
- 桌面里不再用到的 `toast` import
- i18n 的 `fonts.tooLarge` (zh/en)

任意合法字体文件都能导入，体积仍会在列表里展示。

## Test plan

- [x] 桌面导入 .ttf / .otf / .woff / .woff2 ≥ 20MB 字体不再被拒
- [x] 移动端同上
- [x] 列表里 size 列正确显示导入后的体积