### PR TITLE
fix(mobile): cap TCP fallback listen with 5s timeout so reader can't silently hang

### DIFF
--- a/packages/app-expo/src/lib/reader/local-file-server.ts
+++ b/packages/app-expo/src/lib/reader/local-file-server.ts
@@ -199,21 +199,45 @@ async function _startTcpFallback(cleanRoot: string): Promise<string> {
       socket.on("error", () => socket.destroy());
     });
 
-    server.on("error", (err: Error) => reject(err));
+    // Without a timeout, if the tcp-socket native module isn't linked into the
+    // dev client, `listen`'s callback never fires and the reader sits on a
+    // spinner forever with no error. Cap it so ReaderScreen can surface a real
+    // failure (Lighttpd already has the same safety net at 8s).
+    let settled = false;
+    const finish = (work: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutHandle);
+      work();
+    };
+    const timeoutHandle = setTimeout(() => {
+      finish(() => {
+        try { server.close(); } catch {}
+        reject(
+          new Error(
+            "TCP fallback listen timeout (5s) — react-native-tcp-socket native module likely not linked into the dev client. Rebuild with `expo run:ios`.",
+          ),
+        );
+      });
+    }, 5000);
+
+    server.on("error", (err: Error) => finish(() => reject(err)));
 
     server.listen({ port: 0, host: "127.0.0.1" }, () => {
-      const addr = server.address();
-      const port = addr && typeof addr === "object" && "port" in addr ? addr.port : null;
-      if (!port) {
-        reject(new Error("Server address unavailable"));
-        return;
-      }
-      const url = `http://127.0.0.1:${port}`;
-      _tcpServer = server;
-      _serverDocRoot = cleanRoot;
-      _serverUrl = url;
-      console.log(`[FileServer] TCP fallback started: ${url} (root: ${cleanRoot})`);
-      resolve(url);
+      finish(() => {
+        const addr = server.address();
+        const port = addr && typeof addr === "object" && "port" in addr ? addr.port : null;
+        if (!port) {
+          reject(new Error("Server address unavailable"));
+          return;
+        }
+        const url = `http://127.0.0.1:${port}`;
+        _tcpServer = server;
+        _serverDocRoot = cleanRoot;
+        _serverUrl = url;
+        console.log(`[FileServer] TCP fallback started: ${url} (root: ${cleanRoot})`);
+        resolve(url);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

**症状**：当 dev client 二进制里两个文件服务器 native 模块（`@dr.pogodin/react-native-static-server` 的 Lighttpd 和 `react-native-tcp-socket`）都没正确链接时，开书后阅读器一直卡在 spinner，Metro 日志在 Lighttpd 8s 超时警告之后**完全没有任何后续输出**。

**根因**：
- `_startNativeServer` 已经给 `Lighttpd.start()` 加了 8s timeout，超时就 catch 并转 `_startTcpFallback`
- 但 `_startTcpFallback` 里 `server.listen(callback)` 在 native binding 缺失时 callback 永不触发，promise 永久 hang
- ReaderScreen 的 `await startFileServer()` 继承这个 hang，错误从未 throw → 用户看到永久 spinner

**修复**：把 `server.listen()` / `server.on("error")` 用一个 settle helper 包起来，5s 超时关 server 并 reject 一个可操作的错误（"rebuild with expo run:ios"）。Lighttpd 已经有同样的保护，TCP 这条路径补齐对称。

正常 build 的环境下两个服务器都在 1s 内返回，这个 timeout 仅在 dev 环境守底，不会误触发。

## Test plan

- [x] 模拟 native 模块未链接：spinner 不再卡死，5s 后 ReaderScreen 弹出明确错误信息
- [x] 正常环境（rebuild 后）：文件服务器正常启动，无回退