### PR TITLE
fix(reader): skip empty first section on initial book open

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -2020,6 +2020,24 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
             }
           } else {
             await view.goToFraction(0);
+
+            // If the first section is empty (e.g., blank title page with linear="no"),
+            // auto-advance to the first section with actual content
+            try {
+              const sections = bookDoc.sections ?? [];
+              if (sections.length > 1) {
+                const firstDoc = await sections[0].createDocument?.();
+                const textContent = firstDoc?.body?.textContent?.trim() ?? "";
+                if (textContent.length < 10) {
+                  // First section is effectively empty, go to next
+                  console.log("[FoliateViewer] First section is empty, advancing to next section");
+                  await view.next();
+                }
+              }
+            } catch (skipErr) {
+              // Ignore — not critical, user can still navigate manually
+              console.warn("[FoliateViewer] Failed to skip empty first section:", skipErr);
+            }
           }
         } catch (err) {
           console.error("[FoliateViewer] Failed to open book:", err);


### PR DESCRIPTION
## Summary
- When opening a book for the first time (no saved reading position), if the first spine section is effectively empty (< 10 characters of text content), auto-advance to the next section
- Fixes blank page on first open for pandoc-generated EPUBs that have an empty `title_page.xhtml` with `linear="no"`

## Root Cause
The book "美国反对美国.epub" has a spine where the first item is an empty title page (`<section epub:type="titlepage" class="titlepage"></section>`). `goToFraction(0)` lands on this blank page, making it appear as if the book failed to render.

## Test plan
- [ ] Open "美国反对美国.epub" fresh (delete from library first) → should land on chapter content, not blank
- [ ] Open a normal EPUB without empty title page → no behavior change
- [ ] Open a book with saved reading position → still restores to correct position

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)