### PR TITLE
perf(reader): instant page turn — disable animation + reduce chapter switch delay

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -2239,8 +2239,8 @@ function applyRendererSettings(
     applyReflowLayoutSettings(view, settings);
   }
 
-  // Enable page turn animation
-  renderer.setAttribute("animated", "");
+  // Disable page turn animation for instant response
+  // renderer.setAttribute("animated", "");
 
   // Apply CSS styles (skip font overrides for fixed layout)
   applyRendererStyles(view, settings, isFixedLayout, theme);

--- a/packages/foliate-js/paginator.js
+++ b/packages/foliate-js/paginator.js
@@ -939,7 +939,7 @@ export class Paginator extends HTMLElement {
     // FIXME: vertical-rl only, not -lr
     if (this.scrolled && this.#vertical) offset = -offset;
     if ((reason === "snap" || smooth) && this.hasAttribute("animated"))
-      return animate(element[scrollProp], offset, 400, easeOutCubic, (x) => (element[scrollProp] = x)).then(() => {
+      return animate(element[scrollProp], offset, 250, easeOutCubic, (x) => (element[scrollProp] = x)).then(() => {
         this.#scrollBounds = [offset, this.atStart ? 0 : size, this.atEnd ? 0 : size];
         this.#afterScroll(reason);
       });
@@ -1113,7 +1113,7 @@ export class Paginator extends HTMLElement {
         index: this.#adjacentIndex(dir),
         anchor: prev ? () => 1 : () => 0,
       });
-    if (shouldGo || !this.hasAttribute("animated")) await wait(100);
+    if (shouldGo || !this.hasAttribute("animated")) await wait(16);
     this.#locked = false;
   }
   prev(distance) {


### PR DESCRIPTION
## Summary
- Disable foliate-js page turn animation (was 400ms slide, now instant)
- Reduce cross-chapter section switch delay from 100ms to 16ms (one frame)

## Why
Users reported noticeable lag when turning pages compared to Readest. Root causes:
1. `renderer.setAttribute('animated', '')` enabled a 400ms CSS-animated scroll between pages
2. Cross-chapter transitions had a fixed `await wait(100)` after loading the new section

## Changes
- `FoliateViewer.tsx`: Comment out `renderer.setAttribute("animated", "")` 
- `paginator.js`: `wait(100)` → `wait(16)`, animation duration `400` → `250` (fallback if animated is re-enabled)

## Test plan
- [x] Turn pages within a chapter → instant, no slide animation
- [x] Turn page at chapter boundary → loads new chapter with minimal delay
- [ ] Long books with many highlights → highlights still render after chapter switch
- [ ] PDF/fixed layout → still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)