### PR TITLE
fix(reader): defer style updates for hidden tabs to prevent font-change freeze

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -384,6 +384,7 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
 
     // Track app theme for reader styling
     const [appTheme, setAppTheme] = useState<AppTheme>(() => getAppTheme());
+    const pendingStyleUpdateRef = useRef(false);
     const ttsHighlightStateRef = useRef<{ cfi: string | null; color: string }>({
       cfi: null,
       color: "rgba(96, 165, 250, 0.35)",
@@ -2070,6 +2071,12 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
       if (!view?.renderer) return;
       // Fixed layout (PDF/CBZ): don't override font/size/lineHeight
       if (isFixedLayout) return;
+      // Skip if container is hidden (inactive tab) to avoid blocking main thread
+      // with expensive iframe re-layout. Styles will be applied when tab becomes visible.
+      if (containerRef.current && containerRef.current.offsetParent === null) {
+        pendingStyleUpdateRef.current = true;
+        return;
+      }
       applyRendererStyles(view, viewSettings, false, appTheme);
     }, [
       viewSettings.fontSize,
@@ -2082,6 +2089,25 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
       isFixedLayout,
       appTheme,
     ]);
+
+    // --- Apply pending style updates when tab becomes visible ---
+    useEffect(() => {
+      if (!containerRef.current) return;
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting && pendingStyleUpdateRef.current) {
+            pendingStyleUpdateRef.current = false;
+            const view = viewRef.current;
+            if (view?.renderer && !isFixedLayout) {
+              applyRendererStyles(view, viewSettings, false, appTheme);
+            }
+          }
+        },
+        { threshold: 0.1 },
+      );
+      observer.observe(containerRef.current);
+      return () => observer.disconnect();
+    }, [viewSettings, isFixedLayout, appTheme]);
 
     // --- Apply reflow layout changes ---
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Skip `applyRendererStyles()` for hidden/inactive reader tabs when font or style settings change
- Apply pending styles via `IntersectionObserver` when the tab becomes visible

## Root Cause
All reader tabs stay mounted (hidden via `display:none`). When a user changes font in settings, **every open reader tab** simultaneously triggers `applyRendererStyles()` → iframe CSS columns re-layout → main thread blocked → UI freezes.

## How to reproduce
1. Open 2-3 books in separate tabs
2. Go to Settings → Reading → change font
3. Go back to main screen → **app freezes** (before this fix)

## Fix
- Check `containerRef.current.offsetParent === null` (standard way to detect `display:none`)
- If hidden → set `pendingStyleUpdateRef = true`, skip the expensive work
- `IntersectionObserver` watches for visibility change → applies deferred styles

## Test plan
- [ ] Open 3 books → change font → no freeze, return to home is smooth
- [ ] Switch to a reader tab that had pending update → font should be applied
- [ ] Change font while actively reading → immediate effect (no regression)

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)