### PR TITLE
Fix remote vector model embedding requests

### DIFF
--- a/packages/app-expo/src/components/onboarding/steps/EmbeddingPage.tsx
+++ b/packages/app-expo/src/components/onboarding/steps/EmbeddingPage.tsx
@@ -4,18 +4,12 @@ import { useVectorModelStore } from "@/stores/vector-model-store";
 import { useTheme } from "@/styles/theme";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { detectRemoteEmbeddingDimension } from "@readany/core/rag";
 import type { VectorModelConfig } from "@readany/core/types";
 import { Check, Cloud, Plus, Trash2, X } from "lucide-react-native";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  ActivityIndicator,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import Animated, { SlideInRight } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import SearchSvg from "../../../../assets/illustrations/search.svg";
@@ -26,15 +20,11 @@ type NavProp = NativeStackNavigationProp<OnboardingStackParamList, "Embedding">;
 export function EmbeddingPage() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavProp>();
-  const { colors, isDark } = useTheme();
+  const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const {
-    vectorModels,
-    addVectorModel,
-    deleteVectorModel,
-    setSelectedVectorModelId,
-  } = useVectorModelStore();
+  const { vectorModels, addVectorModel, deleteVectorModel, setSelectedVectorModelId } =
+    useVectorModelStore();
 
   const [showAddForm, setShowAddForm] = useState(false);
   const [formData, setFormData] = useState({ name: "", url: "", modelId: "", apiKey: "" });
@@ -54,23 +44,8 @@ export function EmbeddingPage() {
   const testRemoteModel = async (model: VectorModelConfig) => {
     setTestingId(model.id);
     try {
-      const testUrl = model.url.replace(/\/$/, "");
-      const isOllama = testUrl.endsWith("/api/embed");
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
-      if (model.apiKey?.trim()) headers.Authorization = `Bearer ${model.apiKey}`;
-
-      const requestBody = isOllama
-        ? { model: model.modelId, input: "test" }
-        : { input: ["test"], model: model.modelId, encoding_format: "float" };
-
-      const res = await fetch(testUrl, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(requestBody),
-      });
-      if (res.ok) {
-        setSelectedVectorModelId(model.id);
-      }
+      await detectRemoteEmbeddingDimension(model);
+      setSelectedVectorModelId(model.id);
     } catch (err) {
       console.warn("[Onboarding] Embedding model test failed:", err);
     } finally {
@@ -273,9 +248,7 @@ export function EmbeddingPage() {
                 ]}
               >
                 <View style={styles.modelItemInfo}>
-                  <Text style={[styles.modelItemName, { color: colors.foreground }]}>
-                    {m.name}
-                  </Text>
+                  <Text style={[styles.modelItemName, { color: colors.foreground }]}>{m.name}</Text>
                   <Text style={[styles.modelItemMeta, { color: colors.mutedForeground }]}>
                     {m.modelId}
                   </Text>

--- a/packages/app/src/components/onboarding/steps/EmbeddingPage.tsx
+++ b/packages/app/src/components/onboarding/steps/EmbeddingPage.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
-import { Switch } from "@/components/ui/switch";
 import { useVectorModelStore } from "@/stores/vector-model-store";
 import { BUILTIN_EMBEDDING_MODELS } from "@readany/core/ai/builtin-embedding-models";
 import { loadEmbeddingPipeline } from "@readany/core/ai/local-embedding-service";
+import { detectRemoteEmbeddingDimension } from "@readany/core/rag";
 import type { VectorModelConfig } from "@readany/core/types";
 import { Check, Download, Loader2, Plus, Trash2, X } from "lucide-react";
 import { useCallback, useState } from "react";
@@ -12,7 +12,14 @@ import { useTranslation } from "react-i18next";
 
 import { OnboardingLayout } from "../OnboardingLayout";
 
-export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
+interface EmbeddingPageProps {
+  onNext: () => void;
+  onPrev: () => void;
+  step: number;
+  totalSteps: number;
+}
+
+export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: EmbeddingPageProps) {
   const { t } = useTranslation();
   const {
     vectorModelMode,
@@ -70,23 +77,8 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
     async (model: VectorModelConfig) => {
       setTestingId(model.id);
       try {
-        const testUrl = model.url.replace(/\/$/, "");
-        const isOllama = testUrl.endsWith("/api/embed");
-        const headers: Record<string, string> = { "Content-Type": "application/json" };
-        if (model.apiKey?.trim()) headers.Authorization = `Bearer ${model.apiKey}`;
-
-        const requestBody = isOllama
-          ? { model: model.modelId, input: "test" }
-          : { input: ["test"], model: model.modelId, encoding_format: "float" };
-
-        const res = await fetch(testUrl, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(requestBody),
-        });
-        if (res.ok) {
-          setSelectedVectorModelId(model.id);
-        }
+        await detectRemoteEmbeddingDimension(model);
+        setSelectedVectorModelId(model.id);
       } catch (err) {
         console.warn("[Onboarding] Embedding model test failed:", err);
       } finally {
@@ -141,8 +133,9 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
         </div>
 
         <div className="grid grid-cols-2 gap-4 mt-6">
-          <div
-            className={`flex items-center justify-between rounded-lg border p-4 cursor-pointer transition-colors ${vectorModelMode === "remote" ? "border-primary bg-primary/5" : "border-border bg-muted/30"}`}
+          <button
+            type="button"
+            className={`flex items-center justify-between rounded-lg border p-4 cursor-pointer transition-colors text-left ${vectorModelMode === "remote" ? "border-primary bg-primary/5" : "border-border bg-muted/30"}`}
             onClick={() => setVectorModelMode("remote")}
           >
             <div className="flex-1">
@@ -153,14 +146,19 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
                 {t("onboarding.embedding.remoteDesc", "Connect to external embedding API.")}
               </p>
             </div>
-            <Switch
-              checked={vectorModelMode === "remote"}
-              onCheckedChange={(c) => setVectorModelMode(c ? "remote" : "builtin")}
-            />
-          </div>
+            <span
+              aria-hidden="true"
+              className={`inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-sm transition-colors ${vectorModelMode === "remote" ? "bg-primary" : "bg-input"}`}
+            >
+              <span
+                className={`block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${vectorModelMode === "remote" ? "translate-x-4" : "translate-x-0"}`}
+              />
+            </span>
+          </button>
 
-          <div
-            className={`flex items-center justify-between rounded-lg border p-4 cursor-pointer transition-colors ${vectorModelMode === "builtin" ? "border-primary bg-primary/5" : "border-border bg-muted/30"}`}
+          <button
+            type="button"
+            className={`flex items-center justify-between rounded-lg border p-4 cursor-pointer transition-colors text-left ${vectorModelMode === "builtin" ? "border-primary bg-primary/5" : "border-border bg-muted/30"}`}
             onClick={() => setVectorModelMode("builtin")}
           >
             <div className="flex-1">
@@ -171,11 +169,15 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
                 {t("onboarding.embedding.localDesc", "Run embeddings safely on your device.")}
               </p>
             </div>
-            <Switch
-              checked={vectorModelMode === "builtin"}
-              onCheckedChange={(c) => setVectorModelMode(c ? "builtin" : "remote")}
-            />
-          </div>
+            <span
+              aria-hidden="true"
+              className={`inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-sm transition-colors ${vectorModelMode === "builtin" ? "bg-primary" : "bg-input"}`}
+            >
+              <span
+                className={`block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${vectorModelMode === "builtin" ? "translate-x-4" : "translate-x-0"}`}
+              />
+            </span>
+          </button>
         </div>
 
         {vectorModelMode === "remote" && (
@@ -204,20 +206,28 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
 
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">
+                    <label
+                      className="text-xs text-muted-foreground mb-1 block"
+                      htmlFor="onboarding-embedding-name"
+                    >
                       {t("settings.vm_name", "Name")} *
                     </label>
                     <Input
+                      id="onboarding-embedding-name"
                       value={formData.name}
                       onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                       placeholder="OpenAI Embedding"
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-muted-foreground mb-1 block">
+                    <label
+                      className="text-xs text-muted-foreground mb-1 block"
+                      htmlFor="onboarding-embedding-model-id"
+                    >
                       {t("settings.vm_modelId", "Model ID")} *
                     </label>
                     <Input
+                      id="onboarding-embedding-model-id"
                       value={formData.modelId}
                       onChange={(e) => setFormData({ ...formData, modelId: e.target.value })}
                       placeholder="text-embedding-3-small"
@@ -226,10 +236,14 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
                 </div>
 
                 <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">
+                  <label
+                    className="text-xs text-muted-foreground mb-1 block"
+                    htmlFor="onboarding-embedding-url"
+                  >
                     {t("settings.vm_url", "URL")} *
                   </label>
                   <Input
+                    id="onboarding-embedding-url"
                     value={formData.url}
                     onChange={(e) => setFormData({ ...formData, url: e.target.value })}
                     placeholder="https://api.openai.com/v1/embeddings"
@@ -237,10 +251,14 @@ export function EmbeddingPage({ onNext, onPrev, step, totalSteps }: any) {
                 </div>
 
                 <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">
+                  <label
+                    className="text-xs text-muted-foreground mb-1 block"
+                    htmlFor="onboarding-embedding-api-key"
+                  >
                     {t("settings.vm_apiKey", "API Key")}
                   </label>
                   <PasswordInput
+                    id="onboarding-embedding-api-key"
                     value={formData.apiKey}
                     onChange={(e) => setFormData({ ...formData, apiKey: e.target.value })}
                     placeholder="sk-..."

--- a/packages/app/src/components/settings/VectorModelSettings.tsx
+++ b/packages/app/src/components/settings/VectorModelSettings.tsx
@@ -8,18 +8,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Switch } from "@/components/ui/switch";
-import { ConfigTransfer } from "./ConfigTransfer";
 import { useVectorModelStore } from "@/stores/vector-model-store";
 import { BUILTIN_EMBEDDING_MODELS } from "@readany/core/ai/builtin-embedding-models";
 import { clearModelCache, loadEmbeddingPipeline } from "@readany/core/ai/local-embedding-service";
+import { detectRemoteEmbeddingDimension } from "@readany/core/rag";
 import type { VectorModelConfig } from "@readany/core/types";
 import { Check, Download, Edit2, Loader2, Plus, Trash2, X } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-
-function normalizeEmbeddingsUrl(url: string): string {
-  return url.replace(/\/$/, "");
-}
+import { ConfigTransfer } from "./ConfigTransfer";
 
 /* ------------------------------------------------------------------ */
 /*  Built-in Models Section                                           */
@@ -266,26 +263,7 @@ function RemoteModelsSection() {
       setTestingId(model.id);
       setTestResults((prev) => ({ ...prev, [model.id]: t("settings.vm_testing") }));
       try {
-        const testUrl = normalizeEmbeddingsUrl(model.url);
-        const isOllama = testUrl.endsWith("/api/embed");
-        const headers: Record<string, string> = { "Content-Type": "application/json" };
-        if (model.apiKey.trim()) headers.Authorization = `Bearer ${model.apiKey}`;
-
-        const requestBody = isOllama
-          ? { model: model.modelId, input: "test" }
-          : { input: ["test"], model: model.modelId, encoding_format: "float" };
-
-        const res = await fetch(testUrl, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(requestBody),
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        const json = await res.json();
-        const len = isOllama
-          ? (json?.embeddings?.[0]?.length ?? 0)
-          : (json?.data?.[0]?.embedding?.length ?? 0);
-
+        const len = await detectRemoteEmbeddingDimension(model);
         updateVectorModel(model.id, { dimension: len });
         setTestResults((prev) => ({
           ...prev,
@@ -432,10 +410,11 @@ function RemoteModelsSection() {
 
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="mb-1 block text-xs text-muted-foreground">
+              <label className="mb-1 block text-xs text-muted-foreground" htmlFor="vm-name">
                 {t("settings.vm_name")} *
               </label>
               <Input
+                id="vm-name"
                 value={formData.name}
                 onChange={(e) => setFormData((p) => ({ ...p, name: e.target.value }))}
                 placeholder="OpenAI Embedding"
@@ -443,10 +422,11 @@ function RemoteModelsSection() {
               />
             </div>
             <div>
-              <label className="mb-1 block text-xs text-muted-foreground">
+              <label className="mb-1 block text-xs text-muted-foreground" htmlFor="vm-model-id">
                 {t("settings.vm_modelId")} *
               </label>
               <Input
+                id="vm-model-id"
                 value={formData.modelId}
                 onChange={(e) => setFormData((p) => ({ ...p, modelId: e.target.value }))}
                 placeholder="text-embedding-3-small"
@@ -456,10 +436,11 @@ function RemoteModelsSection() {
           </div>
 
           <div>
-            <label className="mb-1 block text-xs text-muted-foreground">
+            <label className="mb-1 block text-xs text-muted-foreground" htmlFor="vm-url">
               {t("settings.vm_url")} *
             </label>
             <Input
+              id="vm-url"
               value={formData.url}
               onChange={(e) => setFormData((p) => ({ ...p, url: e.target.value }))}
               placeholder="https://api.openai.com/v1/embeddings"
@@ -469,10 +450,11 @@ function RemoteModelsSection() {
           </div>
 
           <div>
-            <label className="mb-1 block text-xs text-muted-foreground">
+            <label className="mb-1 block text-xs text-muted-foreground" htmlFor="vm-api-key">
               {t("settings.vm_apiKey")}
             </label>
             <PasswordInput
+              id="vm-api-key"
               value={formData.apiKey}
               onChange={(e) => setFormData((p) => ({ ...p, apiKey: e.target.value }))}
               placeholder="sk-..."
@@ -481,10 +463,11 @@ function RemoteModelsSection() {
           </div>
 
           <div>
-            <label className="mb-1 block text-xs text-muted-foreground">
+            <label className="mb-1 block text-xs text-muted-foreground" htmlFor="vm-description">
               {t("settings.vm_description")}
             </label>
             <Input
+              id="vm-description"
               value={formData.description}
               onChange={(e) => setFormData((p) => ({ ...p, description: e.target.value }))}
               placeholder={t("settings.vm_descriptionPlaceholder")}
@@ -603,14 +586,16 @@ export function VectorModelSettings() {
                 store.addVectorModel(m);
               }
             }
-            if (d.selectedVectorModelId) store.setSelectedVectorModelId(d.selectedVectorModelId as string);
-            if (typeof d.vectorModelEnabled === "boolean") store.setVectorModelEnabled(d.vectorModelEnabled);
-            if (d.vectorModelMode === "remote" || d.vectorModelMode === "builtin") store.setVectorModelMode(d.vectorModelMode);
-            if (d.selectedBuiltinModelId) store.setSelectedBuiltinModelId(d.selectedBuiltinModelId as string);
+            if (d.selectedVectorModelId)
+              store.setSelectedVectorModelId(d.selectedVectorModelId as string);
+            if (typeof d.vectorModelEnabled === "boolean")
+              store.setVectorModelEnabled(d.vectorModelEnabled);
+            if (d.vectorModelMode === "remote" || d.vectorModelMode === "builtin")
+              store.setVectorModelMode(d.vectorModelMode);
+            if (d.selectedBuiltinModelId)
+              store.setSelectedBuiltinModelId(d.selectedBuiltinModelId as string);
           }}
-          validate={(d) =>
-            typeof d === "object" && d !== null && "vectorModels" in d
-          }
+          validate={(d) => typeof d === "object" && d !== null && "vectorModels" in d}
         />
       </section>
     </div>

--- a/packages/core/src/rag/embedding-request.ts
+++ b/packages/core/src/rag/embedding-request.ts
@@ -1,0 +1,115 @@
+import { getPlatformService } from "../services";
+
+export interface RemoteEmbeddingModel {
+  url: string;
+  apiKey?: string;
+  modelId: string;
+}
+
+interface OpenAIEmbeddingItem {
+  embedding: number[];
+  index?: number;
+}
+
+export function normalizeEmbeddingsUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function isOllamaEmbeddingUrl(url: string): boolean {
+  return url.endsWith("/api/embed");
+}
+
+function getAuthHeader(apiKey?: string): Record<string, string> {
+  const trimmedApiKey = apiKey?.trim();
+  return trimmedApiKey ? { Authorization: `Bearer ${trimmedApiKey}` } : {};
+}
+
+function getRecordValue(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return (value as Record<string, unknown>)[key];
+}
+
+async function fetchEmbeddingEndpoint(url: string, init: RequestInit): Promise<Response> {
+  try {
+    return await getPlatformService().fetch(url, {
+      ...init,
+      timeoutMs: 60000,
+      responseType: "text",
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("PlatformService not initialized")) {
+      return fetch(url, init);
+    }
+    throw error;
+  }
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  const text = await response.text();
+  return text || response.statusText;
+}
+
+function parseRemoteEmbeddingResponse(json: unknown, isOllama: boolean): number[][] {
+  if (isOllama) {
+    const embeddings = getRecordValue(json, "embeddings");
+    if (Array.isArray(embeddings)) {
+      return embeddings as number[][];
+    }
+    const embedding = getRecordValue(json, "embedding");
+    if (Array.isArray(embedding)) {
+      return [embedding as number[]];
+    }
+    return [];
+  }
+
+  const data = getRecordValue(json, "data");
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return (data as OpenAIEmbeddingItem[])
+    .slice()
+    .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+    .map((item) => item.embedding);
+}
+
+export async function requestRemoteEmbeddings(
+  model: RemoteEmbeddingModel,
+  input: string | string[],
+): Promise<number[][]> {
+  const requestUrl = normalizeEmbeddingsUrl(model.url);
+  const isOllama = isOllamaEmbeddingUrl(requestUrl);
+  const requestBody = isOllama
+    ? { model: model.modelId, input }
+    : {
+        input: Array.isArray(input) ? input : [input],
+        model: model.modelId,
+        encoding_format: "float",
+      };
+
+  const response = await fetchEmbeddingEndpoint(requestUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthHeader(model.apiKey),
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Embedding API error (${response.status}): ${await readErrorBody(response)}`);
+  }
+
+  return parseRemoteEmbeddingResponse(await response.json(), isOllama);
+}
+
+export async function detectRemoteEmbeddingDimension(model: RemoteEmbeddingModel): Promise<number> {
+  const embeddings = await requestRemoteEmbeddings(model, "test");
+  const dimension = embeddings[0]?.length ?? 0;
+  if (dimension <= 0) {
+    throw new Error("Embedding API returned an empty embedding.");
+  }
+  return dimension;
+}

--- a/packages/core/src/rag/embedding-service.ts
+++ b/packages/core/src/rag/embedding-service.ts
@@ -3,6 +3,7 @@
  */
 import type { EmbeddingModel } from "../types";
 
+import { getPlatformService } from "../services";
 import { buildOpenAICompatibleUrl } from "../utils/api";
 
 export interface EmbeddingConfig {
@@ -67,7 +68,7 @@ export class EmbeddingService {
 
     for (let attempt = 0; attempt <= retries; attempt++) {
       try {
-        const response = await fetch(url, options);
+        const response = await this.performFetch(url, options);
         return response;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
@@ -89,6 +90,21 @@ export class EmbeddingService {
     }
 
     throw lastError || new Error("Fetch failed");
+  }
+
+  private async performFetch(url: string, options: RequestInit): Promise<Response> {
+    try {
+      return await getPlatformService().fetch(url, {
+        ...options,
+        timeoutMs: 60000,
+        responseType: "text",
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("PlatformService not initialized")) {
+        return fetch(url, options);
+      }
+      throw error;
+    }
   }
 
   private async callOpenAI(texts: string[]): Promise<number[][]> {

--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -7,6 +7,13 @@ export { EmbeddingService } from "./embedding-service";
 export type { EmbeddingConfig } from "./embedding-service";
 
 export {
+  detectRemoteEmbeddingDimension,
+  normalizeEmbeddingsUrl,
+  requestRemoteEmbeddings,
+} from "./embedding-request";
+export type { RemoteEmbeddingModel } from "./embedding-request";
+
+export {
   getEmbeddingModels,
   getDefaultModel,
   getEmbedding,

--- a/packages/core/src/rag/vectorize-trigger.ts
+++ b/packages/core/src/rag/vectorize-trigger.ts
@@ -13,6 +13,7 @@ import type { VectorizeProgress } from "../types";
  */
 import { eventBus } from "../utils/event-bus";
 import { chunkContent } from "./chunker";
+import { requestRemoteEmbeddings } from "./embedding-request";
 import type { ChapterData } from "./rag-types";
 import { invalidateChunkCache } from "./search";
 import { getVectorDB, hasVectorDB } from "./vector-db";
@@ -167,11 +168,14 @@ export async function triggerVectorizeBook(
           await vectorDB.deleteByBookId(bookId);
 
           const vectorRecords: VectorRecord[] = allChunks
-            .filter((c) => c.embedding && c.embedding.length > 0)
+            .filter(
+              (c): c is typeof c & { embedding: number[] } =>
+                Array.isArray(c.embedding) && c.embedding.length > 0,
+            )
             .map((c) => ({
               id: c.id,
               bookId: c.bookId,
-              embedding: c.embedding!,
+              embedding: c.embedding,
             }));
 
           if (vectorRecords.length > 0) {
@@ -283,49 +287,12 @@ async function generateRemoteEmbeddings(
     );
   }
 
-  const isOllama = selectedModel.url.endsWith("/api/embed");
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (selectedModel.apiKey.trim()) {
-    headers.Authorization = `Bearer ${selectedModel.apiKey}`;
-  }
-
   const batchSize = 20;
   for (let i = 0; i < chunks.length; i += batchSize) {
     const batch = chunks.slice(i, i + batchSize);
     const texts = batch.map((c) => c.content);
 
-    const requestBody = isOllama
-      ? { model: selectedModel.modelId, input: texts }
-      : {
-          input: texts,
-          model: selectedModel.modelId,
-          encoding_format: "float",
-        };
-
-    const res = await fetch(selectedModel.url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(requestBody),
-    });
-
-    if (!res.ok) {
-      const errorText = await res.text();
-      throw new Error(`Embedding API error (${res.status}): ${errorText}`);
-    }
-
-    const json = await res.json();
-    const embeddings: number[][] = isOllama
-      ? (json?.embeddings ?? [])
-      : (
-          (json?.data ?? []) as Array<{
-            embedding: number[];
-            index: number;
-          }>
-        )
-          .sort((a: any, b: any) => a.index - b.index)
-          .map((d: any) => d.embedding);
+    const embeddings = await requestRemoteEmbeddings(selectedModel, texts);
 
     for (let j = 0; j < batch.length; j++) {
       batch[j].embedding = embeddings[j] ?? [];


### PR DESCRIPTION
## Summary
- Route remote embedding API requests through the platform fetch layer so desktop uses Tauri HTTP instead of WebView fetch.
- Share remote embedding request parsing/dimension detection across settings, onboarding, and vectorization.
- Keep OpenAI-compatible and Ollama embedding response handling in one core helper.

Fixes #217

## Test plan
- pnpm exec biome check packages/core/src/rag/embedding-request.ts packages/core/src/rag/index.ts packages/core/src/rag/vectorize-trigger.ts packages/core/src/rag/embedding-service.ts packages/app/src/components/settings/VectorModelSettings.tsx packages/app/src/components/onboarding/steps/EmbeddingPage.tsx packages/app-expo/src/components/onboarding/steps/EmbeddingPage.tsx
- pnpm --filter @readany/core exec tsc --noEmit
- pnpm --filter app exec tsc --noEmit
- pnpm --filter @readany/app-expo exec tsc --noEmit
- pnpm --filter @readany/core test

Fixes #165
