### PR TITLE
fix(rag): shrink embedding batch + per-chunk retry on 4xx (#227)

### DIFF
--- a/packages/core/src/rag/vectorize-trigger.ts
+++ b/packages/core/src/rag/vectorize-trigger.ts
@@ -291,15 +291,23 @@ async function generateRemoteEmbeddings(
     headers.Authorization = `Bearer ${selectedModel.apiKey}`;
   }
 
-  const batchSize = 20;
-  for (let i = 0; i < chunks.length; i += batchSize) {
-    const batch = chunks.slice(i, i + batchSize);
-    const texts = batch.map((c) => c.content);
+  // Conservative defaults: many Chinese embedding APIs (Baidu/MiniMax/etc.)
+  // cap single-input tokens at 384–1024 and batch size at 16. Send 8 per
+  // request and keep single chunks ≤ 1800 chars (~ ≤ 1800 tokens for CJK)
+  // so classical-Chinese books with dense unbroken paragraphs don't 400.
+  const batchSize = 8;
+  const MAX_CHARS_PER_CHUNK = 1800;
 
+  const callEmbeddingApi = async (
+    inputTexts: string[],
+  ): Promise<{ ok: true; embeddings: number[][] } | { ok: false; status: number; errorText: string }> => {
+    const safeTexts = inputTexts.map((t) =>
+      t.length > MAX_CHARS_PER_CHUNK ? t.slice(0, MAX_CHARS_PER_CHUNK) : t,
+    );
     const requestBody = isOllama
-      ? { model: selectedModel.modelId, input: texts }
+      ? { model: selectedModel.modelId, input: safeTexts }
       : {
-          input: texts,
+          input: safeTexts,
           model: selectedModel.modelId,
           encoding_format: "float",
         };
@@ -311,8 +319,8 @@ async function generateRemoteEmbeddings(
     });
 
     if (!res.ok) {
-      const errorText = await res.text();
-      throw new Error(`Embedding API error (${res.status}): ${errorText}`);
+      const errorText = await res.text().catch(() => "");
+      return { ok: false, status: res.status, errorText };
     }
 
     const json = await res.json();
@@ -326,9 +334,44 @@ async function generateRemoteEmbeddings(
         )
           .sort((a: any, b: any) => a.index - b.index)
           .map((d: any) => d.embedding);
+    return { ok: true, embeddings };
+  };
 
-    for (let j = 0; j < batch.length; j++) {
-      batch[j].embedding = embeddings[j] ?? [];
+  for (let i = 0; i < chunks.length; i += batchSize) {
+    const batch = chunks.slice(i, i + batchSize);
+    const texts = batch.map((c) => c.content);
+
+    const batchResult = await callEmbeddingApi(texts);
+
+    if (batchResult.ok) {
+      for (let j = 0; j < batch.length; j++) {
+        batch[j].embedding = batchResult.embeddings[j] ?? [];
+      }
+    } else {
+      // 4xx commonly means one chunk in the batch exceeded the API's input
+      // limits (token / encoding constraints). Fall back to per-chunk retry
+      // so one bad chunk doesn't poison the whole batch and the rest of
+      // the book can still be vectorized. Failed chunks get an empty
+      // embedding and a warn-level log; vector search just won't return
+      // them, but the book is otherwise usable.
+      if (batchResult.status >= 400 && batchResult.status < 500) {
+        console.warn(
+          `[Embedding] Batch failed (${batchResult.status}): ${batchResult.errorText.slice(0, 200)}. Retrying per-chunk.`,
+        );
+        for (let j = 0; j < batch.length; j++) {
+          const single = await callEmbeddingApi([batch[j].content]);
+          if (single.ok) {
+            batch[j].embedding = single.embeddings[0] ?? [];
+          } else {
+            console.warn(
+              `[Embedding] Chunk ${i + j} skipped (${single.status}): ${single.errorText.slice(0, 200)}`,
+            );
+            batch[j].embedding = [];
+          }
+        }
+      } else {
+        throw new Error(`Embedding API error (${batchResult.status}): ${batchResult.errorText}`);
+      }
     }
 
     progress.processedChunks = Math.min(i + batchSize, chunks.length);


### PR DESCRIPTION
## Summary

Fixes #227 — 古籍向量化失败（赵翼《廿二史札记》、《读史方舆纪要》400 错误码 1210）。

### 根因
原代码 \`generateRemoteEmbeddings\` 单批 20 条整发，且没有单 chunk 长度上限。古籍单段往往无现代标点、上千字一段，命中国内 embedding API 的 per-input 上限（百度 ERNIE-text-embedding 单条仅 384 tokens）。1210 / "API 调用参数有误" 是国内厂商 400 的统一错误码。

最糟糕的是：批量发，一条 chunk 过大整批 400 → 整本书 vectorize 失败。

### 修复 \`packages/core/src/rag/vectorize-trigger.ts\`
- \`batchSize\` 20 → 8（对齐最严苛国内厂商默认上限）
- 单 input 硬截断 1800 chars（CJK 约 1800 tokens，覆盖 384/512/1024/2048 等常见上限）— 在 API 调用内做，调用端无感
- 4xx 时降级**单条重试**：失败的 chunk 标记 empty embedding + warn log，**不抛错**。整本书继续 vectorize，仅这些 chunk 不可向量搜索
- 5xx 仍抛（瞬时服务问题，不是 chunk 形态问题）

### 行为变化
- 之前：一条坏 chunk → 整本书失败
- 现在：一条坏 chunk → 这条跳过，warn log 一行，其他正常入库

## Test plan

- [ ] \`pnpm --filter @readany/core test\` 通过 (340 case ✓)
- [ ] 测古籍向量化（赵翼《廿二史札记》或类似密排无标点书籍）应该成功
- [ ] 测 Ollama 不受影响（仍走相同分支，只是 batchSize 缩小）