### PR TITLE
fix(sync/s3): auto path-style for self-hosted S3 + serialize SDK errors (#193)

### DIFF
--- a/packages/core/src/sync/s3-backend.ts
+++ b/packages/core/src/sync/s3-backend.ts
@@ -96,6 +96,27 @@ class PlatformFetchHttpHandler {
  * S3 backend implementation.
  * Works with any S3-compatible storage service.
  */
+
+/**
+ * Decide whether path-style addressing should be the default for a given
+ * endpoint. Self-hosted S3 servers (rclone serve s3, MinIO, IP/localhost
+ * endpoints) need path-style because the bucket can't ride as a subdomain
+ * on a raw IP or a non-DNS host. AWS S3 supports both, so we leave it on
+ * the SDK default (virtual-hosted) for amazonaws.com.
+ */
+export function shouldDefaultToPathStyle(endpoint?: string): boolean {
+  if (!endpoint) return false; // SDK default endpoints (real AWS S3)
+  try {
+    const url = new URL(endpoint);
+    const host = url.hostname.toLowerCase();
+    if (host.endsWith("amazonaws.com")) return false;
+    return true;
+  } catch {
+    // Endpoint string that doesn't parse as a URL → assume self-hosted.
+    return true;
+  }
+}
+
 export class S3Backend implements ISyncBackend {
   readonly type = "s3" as const;
   private client: S3Client;
@@ -113,6 +134,13 @@ export class S3Backend implements ISyncBackend {
       // Platform service may not be initialized in tests that never touch S3.
     }
 
+    // Auto-detect path-style for non-AWS endpoints. Self-hosted S3-compatible
+    // servers (rclone serve s3, MinIO, IP/localhost endpoints) overwhelmingly
+    // require path-style addressing because their hostname can't carry the
+    // bucket as a subdomain. AWS S3 supports both styles, so leave that alone.
+    // Users can still override via the UI toggle.
+    const pathStyle = config.pathStyle ?? shouldDefaultToPathStyle(config.endpoint);
+
     const clientConfig = {
       endpoint: config.endpoint,
       region: config.region,
@@ -120,7 +148,7 @@ export class S3Backend implements ISyncBackend {
         accessKeyId: config.accessKeyId,
         secretAccessKey,
       },
-      forcePathStyle: config.pathStyle ?? false,
+      forcePathStyle: pathStyle,
       ...(requestHandler ? { requestHandler } : {}),
     };
 
@@ -137,7 +165,24 @@ export class S3Backend implements ISyncBackend {
       );
       return true;
     } catch (error) {
-      console.error("[S3Backend] testConnection failed:", error);
+      // The SDK's Error subclasses don't serialize their useful fields via
+      // default console.error formatting, so the feedback log capture ends
+      // up with just "Error: ..." and the user can't tell what went wrong.
+      // Pull out the fields users actually need to debug.
+      const e = error as {
+        name?: string;
+        message?: string;
+        Code?: string;
+        code?: string;
+        $metadata?: { httpStatusCode?: number; requestId?: string };
+      };
+      console.error("[S3Backend] testConnection failed:", {
+        name: e?.name,
+        message: e?.message,
+        code: e?.Code ?? e?.code,
+        httpStatus: e?.$metadata?.httpStatusCode,
+        requestId: e?.$metadata?.requestId,
+      });
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #193 — rclone serve s3 测试连接失败。

### 根因
\`s3-backend.ts\` 默认 \`forcePathStyle: config.pathStyle ?? false\` → 默认走 virtual-hosted-style。但自建 S3（rclone serve s3 / MinIO / IP / localhost）几乎只支持 path-style，因为 hostname 是 IP 或非 DNS host 时没法把 bucket 作为子域承载。

UI 有手动开关但默认错了 → 大多数自建 S3 用户开箱即不可用。

另外 \`testConnection\` 的 catch 只 \`console.error("...", error)\` raw 对象。aws-sdk-v3 的 Error 子类不会通过默认 console 格式序列化 \`httpStatusCode / Code / requestId\` 这些关键字段，导致 #193 提交的 feedback log 里只有 \`"Error: ..."\` 一句没诊断信息。

### 修复

#### Auto path-style
新增 \`shouldDefaultToPathStyle(endpoint)\` helper：
- endpoint 是 \`*.amazonaws.com\` → \`false\` (virtual-hosted, AWS 习惯)
- 其他（IP / localhost / 自建域名 / 无法 parse）→ \`true\` (path-style)

config 里用户手动开关仍生效（\`config.pathStyle ?? auto\`），仅改默认值。AWS S3 用户无感，自建用户开箱可用。

#### 错误序列化
\`testConnection\` catch 显式提取 SDK 错误的关键字段：
\`\`\`
{ name, message, code, httpStatus, requestId }
\`\`\`
下次类似 issue 的 feedback log 能直接拿到诊断信息。

## Test plan

- [ ] \`pnpm --filter @readany/core test\` 通过 (340 case ✓)
- [ ] rclone serve s3 / MinIO 自建：测试连接通过（不需用户先勾 path-style）
- [ ] 真 AWS S3：行为不变
- [ ] 用户手动设 \`pathStyle: false\` 即使 endpoint 是 IP 也尊重设置