### PR TITLE
fix(tts): fix Android background playback stopping

### DIFF
--- a/packages/app-expo/app.config.js
+++ b/packages/app-expo/app.config.js
@@ -39,7 +39,9 @@ module.exports = {
       permissions: [
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
+        "android.permission.FOREGROUND_SERVICE",
         "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
+        "android.permission.WAKE_LOCK",
         "android.permission.MODIFY_AUDIO_SETTINGS",
       ],
     },

--- a/packages/app-expo/src/lib/platform/expo-speech-player.ts
+++ b/packages/app-expo/src/lib/platform/expo-speech-player.ts
@@ -7,7 +7,7 @@ import type { ITTSPlayer, TTSConfig } from "@readany/core/tts";
  * the system kills it.
  */
 import * as Speech from "expo-speech";
-import { AppState, type AppStateStatus, type NativeEventSubscription } from "react-native";
+import { AppState, type AppStateStatus, type NativeEventSubscription, Platform } from "react-native";
 
 export class ExpoSpeechTTSPlayer implements ITTSPlayer {
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
@@ -20,7 +20,9 @@ export class ExpoSpeechTTSPlayer implements ITTSPlayer {
   private _appStateSubscription: NativeEventSubscription | null = null;
 
   private _handleAppStateChange = (nextAppState: AppStateStatus): void => {
-    if (nextAppState === "background") {
+    // Only stop on iOS — Apple's TextToSpeech.framework crashes if speech is
+    // active when backgrounded. Android handles background speech fine.
+    if (Platform.OS === "ios" && nextAppState === "background") {
       if (!this._stopped) {
         this.stop();
       }

--- a/packages/app-expo/src/lib/platform/track-player-dashscope-player.ts
+++ b/packages/app-expo/src/lib/platform/track-player-dashscope-player.ts
@@ -519,10 +519,9 @@ export class TrackPlayerDashScopeTTSPlayer implements ITTSPlayer {
       },
     );
 
-    // On iOS, keep the audio session alive by inserting a silent track.
-    if (Platform.OS === "ios") {
-      void this._insertSilenceKeepAlive();
-    }
+    // Keep the audio session alive by inserting a silent track.
+    // Prevents OS from killing playback during network stalls on both platforms.
+    void this._insertSilenceKeepAlive();
   }
 
   private async _insertSilenceKeepAlive(): Promise<void> {

--- a/packages/app-expo/src/lib/platform/track-player-edge-player.ts
+++ b/packages/app-expo/src/lib/platform/track-player-edge-player.ts
@@ -531,11 +531,10 @@ export class TrackPlayerEdgeTTSPlayer implements ITTSPlayer {
       total: this._chunks.length,
     });
 
-    // On iOS, keep the audio session alive by inserting a silent track.
-    // This prevents the OS from suspending JS when audio stops between real tracks.
-    if (Platform.OS === "ios") {
-      void this._insertSilenceKeepAlive();
-    }
+    // Keep the audio session alive by inserting a silent track.
+    // iOS: Prevents OS from suspending JS when audio stops between real tracks.
+    // Android: Maintains audio focus and prevents system from killing playback during network stalls.
+    void this._insertSilenceKeepAlive();
   }
 
   private async _insertSilenceKeepAlive(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes TTS audio stopping when Android app goes to background or screen locks. Three root causes:

### 1. Missing Android permissions
Added `FOREGROUND_SERVICE` and `WAKE_LOCK` to prevent system from killing the audio process.

### 2. ExpoSpeechTTSPlayer stops unconditionally on background
The AppState handler called `this.stop()` on **all platforms** when going to background. This was only needed for iOS (Apple's TextToSpeech crashes if active when backgrounded). Android handles background speech fine.

### 3. Silent keep-alive track only on iOS
When the TTS audio queue starves (network delay between chunks), a 1-second silent track keeps the audio session alive. This was iOS-only but Android has the same need — without it, the system reclaims the audio focus.

## Changes

| File | Change |
|------|--------|
| `app.config.js` | Add `FOREGROUND_SERVICE` + `WAKE_LOCK` permissions |
| `expo-speech-player.ts` | Only stop on `Platform.OS === "ios"` |
| `track-player-edge-player.ts` | Remove iOS-only gate on silence keep-alive |
| `track-player-dashscope-player.ts` | Same |

## Test plan

- [ ] Android: Start TTS → lock screen → audio continues playing
- [ ] Android: Start TTS → switch to another app → audio continues
- [ ] Android: Notification bar shows playback controls that work
- [ ] iOS: TTS still stops when backgrounded (intentional, prevents crash)
- [ ] No TypeScript errors (verified)

Closes #60
Closes #228
Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)