### PR TITLE
fix(tts): add fallback selectors when no block elements found

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -550,11 +550,30 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
           const sectionIndex = current?.index ?? 0;
           if (!doc) continue;
 
-          const visibleBlocks = Array.from(doc.querySelectorAll(blockSelector)).filter((block) => {
+          let visibleBlocks = Array.from(doc.querySelectorAll(blockSelector)).filter((block) => {
             if (!block.textContent?.trim()) return false;
             if (block.closest(".readany-translation")) return false;
             return isRectVisibleInReader(block.getBoundingClientRect());
           });
+
+          // Fallback: if no standard block elements found (e.g., epub uses only
+          // <div>/<span> for text), try broader selectors
+          if (visibleBlocks.length === 0) {
+            visibleBlocks = Array.from(doc.querySelectorAll("div, section, article, span")).filter(
+              (el) => {
+                if (!el.textContent?.trim()) return false;
+                if (el.closest(".readany-translation")) return false;
+                // Only leaf-level elements with direct text content
+                if (el.querySelector("div, section, article, p")) return false;
+                return isRectVisibleInReader(el.getBoundingClientRect());
+              },
+            );
+          }
+
+          // Last resort: use body directly if still nothing found
+          if (visibleBlocks.length === 0 && doc.body?.textContent?.trim()) {
+            visibleBlocks = [doc.body];
+          }
 
           for (const block of visibleBlocks) {
             const walker = doc.createTreeWalker(block, NodeFilter.SHOW_TEXT, {

--- a/packages/app/src/components/reader/ReaderView.tsx
+++ b/packages/app/src/components/reader/ReaderView.tsx
@@ -52,6 +52,7 @@ import { SelectionPopover } from "./SelectionPopover";
 import { TOCPanel } from "./TOCPanel";
 import { TTSPage } from "./TTSPage";
 import { TranslationPopover } from "./TranslationPopover";
+import { toast } from "sonner";
 
 const REFLOWABLE_CHARACTERS_PER_LOCATION = 1500;
 const MAX_TRACKED_LOCATION_DELTA = 20;
@@ -1914,7 +1915,10 @@ export function ReaderView({ bookId, tabId }: ReaderViewProps) {
         .map((segment) => segment.text)
         .join(" ")
         .trim();
-      if (!normalized) return;
+      if (!normalized) {
+        toast.error(t("tts.noTextFound", "No readable text found on this page"));
+        return;
+      }
       ttsStartChapterRef.current = readerTab?.chapterTitle ?? "";
       setTtsSourceKind("page");
       setTtsContinuousEnabled(continuous);

--- a/packages/core/src/i18n/locales/en/tts.json
+++ b/packages/core/src/i18n/locales/en/tts.json
@@ -87,7 +87,8 @@
     "nextChapter": "Next Chapter",
     "systemVoiceNote": "Choose the system voice in your device settings",
     "browserVoiceNote": "Choose the system voice in your device settings",
-    "stop": "Stop"
+    "stop": "Stop",
+    "noTextFound": "No readable text found on this page"
   },
   "fonts": {
     "title": "Fonts",

--- a/packages/core/src/i18n/locales/zh/tts.json
+++ b/packages/core/src/i18n/locales/zh/tts.json
@@ -87,7 +87,8 @@
     "nextChapter": "下一章",
     "systemVoiceNote": "系统音色请在设备系统设置中选择",
     "browserVoiceNote": "系统音色请在设备系统设置中选择",
-    "stop": "停止"
+    "stop": "停止",
+    "noTextFound": "当前页面未找到可朗读的文本"
   },
   "fonts": {
     "title": "字体",


### PR DESCRIPTION
## Summary

Fixes TTS "click read aloud, nothing happens, no error" on Windows desktop (#236).

### Root Cause

The TTS segment detection uses `querySelectorAll("p, h1, h2... li, blockquote")` to find text blocks. Some epub files structure content using only `<div>` or `<span>` without standard paragraph elements — resulting in 0 segments found and silent failure.

### Fix

1. **Fallback selectors**: When `blockSelector` finds nothing, try `div, section, article, span` (filtering to leaf-level elements with direct text)
2. **Last resort**: Use `document.body` if still nothing found
3. **User feedback**: Show toast error "No readable text found on this page" when all fallbacks fail

### Before → After
- Before: Click TTS → nothing happens, no error, no feedback
- After: Click TTS → either reads the content (via fallback) or shows clear error message

## Test plan

- [ ] Open an epub with standard `<p>` tags → TTS works as before
- [ ] Open an epub with only `<div>` text wrapping → TTS now reads content
- [ ] Open a page with no text at all (e.g., image page) → toast error shown

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)