### PR TITLE
fix(home): align book cards consistently regardless of author info

### DIFF
--- a/packages/app/src/components/home/BookCard.tsx
+++ b/packages/app/src/components/home/BookCard.tsx
@@ -174,7 +174,7 @@ export const BookCard = memo(function BookCard({
 
   return (
     <div
-      className="group relative flex h-full cursor-pointer flex-col justify-end"
+      className="group relative flex h-full cursor-pointer flex-col"
       onClick={handleOpen}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {


### PR DESCRIPTION
## Summary
- 移除 `BookCard` 容器上的 `justify-end`，使无作者信息的卡片与有作者信息的卡片在同一行内底部对齐保持一致

Closes #246

## Test plan
- [x] 在首页同时存在有作者信息和无作者信息的图书时，卡片整体布局对齐一致
- [x] 桌面端与移动端均正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)