### PR TITLE
fix(desktop): drag-and-drop import + auto-vectorize progress

### DIFF
--- a/packages/app/src/components/home/BookCard.tsx
+++ b/packages/app/src/components/home/BookCard.tsx
@@ -166,11 +166,14 @@ export const BookCard = memo(function BookCard({
   const hasVisibleCover = Boolean(coverSrc && imageLoaded && !imageError);
 
   // Vectorize progress percentage for display
+  // Use local state (from manual trigger) OR store progress (from auto-vectorize after import)
   const vecPct = vectorProgress
     ? vectorProgress.totalChunks > 0
       ? Math.round((vectorProgress.processedChunks / vectorProgress.totalChunks) * 100)
       : 0
-    : 0;
+    : book.vectorizeProgress > 0 && book.vectorizeProgress < 1
+      ? Math.round(book.vectorizeProgress * 100)
+      : 0;
 
   return (
     <div
@@ -250,7 +253,7 @@ export const BookCard = memo(function BookCard({
         )}
 
         {/* Vectorization progress overlay */}
-        {vectorizing && (
+        {(vectorizing || (book.vectorizeProgress > 0 && book.vectorizeProgress < 1)) && (
           <div className="absolute inset-0 z-15 flex flex-col items-center justify-center rounded bg-black/50 backdrop-blur-sm">
             <Loader2 className="h-6 w-6 animate-spin text-white" />
             <span className="mt-1.5 text-xs font-medium text-white">
@@ -260,7 +263,9 @@ export const BookCard = memo(function BookCard({
                   ? `${vecPct}%`
                   : vectorProgress?.status === "indexing"
                     ? t("home.vec_indexing")
-                    : t("home.vec_processing")}
+                    : vecPct > 0
+                      ? `${vecPct}%`
+                      : t("home.vec_processing")}
             </span>
           </div>
         )}

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -24,8 +24,9 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { BookCard } from "./BookCard";
 import { BookGrid } from "./BookGrid";
 import { GroupCard } from "./GroupCard";
@@ -70,6 +71,91 @@ export function HomePage() {
   const [showGroupMenu, setShowGroupMenu] = useState(false);
   const sortBtnRef = useRef<HTMLButtonElement>(null);
   const groupBtnRef = useRef<HTMLButtonElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const importBooks = useLibraryStore((s) => s.importBooks);
+  const lastDropTime = useRef(0);
+  const importBooksRef = useRef(importBooks);
+  importBooksRef.current = importBooks;
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  const SUPPORTED_EXTS = new Set(["epub", "pdf", "mobi", "azw", "azw3", "fb2", "fbz", "txt", "umd", "cbz"]);
+
+  // Use Tauri's native drag-drop event (HTML5 dataTransfer.files doesn't have paths in Tauri v2)
+  // Register ONCE — use refs to avoid re-subscribing on every render
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    (async () => {
+      try {
+        const { getCurrentWebview } = await import("@tauri-apps/api/webview");
+        const webview = getCurrentWebview();
+        unlisten = await webview.onDragDropEvent((event) => {
+          if (event.payload.type === "over") {
+            setIsDragOver(true);
+          } else if (event.payload.type === "leave") {
+            setIsDragOver(false);
+          } else if (event.payload.type === "drop") {
+            setIsDragOver(false);
+            // Guard against duplicate drop events firing within 2s
+            const now = Date.now();
+            if (now - lastDropTime.current < 2000) return;
+            lastDropTime.current = now;
+
+            const paths = (event.payload.paths || []).filter((p: string) => {
+              const ext = p.split(".").pop()?.toLowerCase() || "";
+              return SUPPORTED_EXTS.has(ext);
+            });
+            if (paths.length > 0) {
+              importBooksRef.current(paths).then((result) => {
+                toast.success(
+                  tRef.current("library.importResultSummary", {
+                    imported: result.imported.length,
+                    skipped: result.skippedDuplicates.length,
+                    failed: result.failures.length,
+                  }),
+                );
+              });
+            }
+          }
+        });
+      } catch {
+        // Not in Tauri environment (browser dev mode) — HTML5 fallback handled below
+      }
+    })();
+
+    return () => { unlisten?.(); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — refs keep values fresh
+
+  // HTML5 fallback for browser dev mode (Tauri provides paths via its own event)
+  const handleFileDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const files = e.dataTransfer.files;
+      const paths: string[] = [];
+      for (let i = 0; i < files.length; i++) {
+        const f = files[i] as File & { path?: string };
+        if (f.path) {
+          const ext = f.name.split(".").pop()?.toLowerCase() || "";
+          if (SUPPORTED_EXTS.has(ext)) {
+            paths.push(f.path);
+          }
+        }
+      }
+      if (paths.length > 0) {
+        const result = await importBooks(paths);
+        toast.success(
+          t("library.importResultSummary", {
+            imported: result.imported.length,
+            skipped: result.skippedDuplicates.length,
+            failed: result.failures.length,
+          }),
+        );
+      }
+    },
+    [importBooks, t],
+  );
 
   const filtered = useMemo(() => {
     let result = books.filter((b) => {
@@ -272,7 +358,20 @@ export function HomePage() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div
+      className="relative flex h-full flex-col"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleFileDrop}
+    >
+      {/* Drop overlay */}
+      {isDragOver && (
+        <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-xl border-2 border-dashed border-primary bg-primary/5 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-2">
+            <Plus className="size-10 text-primary" />
+            <p className="text-sm font-medium text-primary">{t("home.dropToUpload")}</p>
+          </div>
+        </div>
+      )}
       {/* Header */}
       <div className="flex shrink-0 items-center justify-between px-6 pt-5 pb-2">
         {selectionMode ? (

--- a/packages/app/src/stores/library-store.ts
+++ b/packages/app/src/stores/library-store.ts
@@ -1093,7 +1093,13 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
           // Auto-vectorize if enabled
           const vmState = useVectorModelStore.getState();
           if (vmState.vectorModelEnabled && vmState.hasVectorCapability()) {
-            triggerVectorizeBook(book.id, relativePath).catch((err) => {
+            triggerVectorizeBook(book.id, relativePath, (progress) => {
+              // Update book's vectorizeProgress so BookCard can show it
+              const pct = progress.totalChunks > 0
+                ? progress.processedChunks / progress.totalChunks
+                : 0;
+              get().updateBook(book.id, { vectorizeProgress: pct });
+            }).catch((err) => {
               console.warn(`[importBooks] Auto-vectorize failed for ${title}:`, err);
             });
           }


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Drag-and-drop book import (Closes #250)

Previously, drag-and-drop only worked on the empty library state. When users had books, dragging files onto the window did nothing.

**Root cause:** Tauri v2 intercepts native file drops and does NOT pass file paths to HTML5 `dataTransfer.files`. Paths are only available through Tauri's `onDragDropEvent` API.

**Fix:**
- Listen to Tauri native `webview.onDragDropEvent` for drag/drop/leave
- Show drop overlay on "over" event, hide on "leave"
- On "drop", filter by supported extensions and import
- 2s dedup guard prevents double-import from duplicate events
- Stable useEffect (refs) — registers once, no re-subscribing

### 2. Auto-vectorize progress display

When importing with a vector model configured, auto-vectorize ran silently — no progress shown on BookCard.

**Fix:**
- Pass `onProgress` callback to auto-vectorize that updates `book.vectorizeProgress` in store
- BookCard reads store's `vectorizeProgress` (not just local state) to show overlay
- Progress overlay now appears for both manual and auto vectorize

## Test plan

- [ ] Drag epub/pdf onto window with books → overlay appears → drop → imported (no duplicates)
- [ ] Import with vector model enabled → BookCard shows spinning loader + percentage
- [ ] Manual vectorize click still works with progress as before
- [ ] Drag non-supported file → overlay shows but nothing imported

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)