### PR TITLE
fix(mobile-chat): sidebar getting stuck mid-animation on repeated opens

### DIFF
--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -590,9 +590,15 @@ export function BookChatScreen({ route, navigation }: Props) {
         </View>
       </View>
 
-      {showSidebar && !isTabletLandscape && (
-        <View style={[StyleSheet.absoluteFill, { zIndex: 20 }]} pointerEvents="box-none">
-          <Animated.View style={[s.sidebarBackdrop, { opacity: backdropAnim }]}>
+      {!isTabletLandscape && (
+        <View
+          style={[StyleSheet.absoluteFill, { zIndex: 20 }]}
+          pointerEvents={showSidebar ? "box-none" : "none"}
+        >
+          <Animated.View
+            style={[s.sidebarBackdrop, { opacity: backdropAnim }]}
+            pointerEvents={showSidebar ? "auto" : "none"}
+          >
             <Pressable style={StyleSheet.absoluteFill} onPress={closeSidebar} />
           </Animated.View>
           <Animated.View

--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -165,6 +165,10 @@ export function BookChatScreen({ route, navigation }: Props) {
   const [showSidebar, setShowSidebar] = useState(false);
   const sidebarAnim = useRef(new Animated.Value(-sidebarWidth)).current;
   const backdropAnim = useRef(new Animated.Value(0)).current;
+  const showSidebarRef = useRef(showSidebar);
+  useEffect(() => {
+    showSidebarRef.current = showSidebar;
+  }, [showSidebar]);
 
   useEffect(() => {
     if (isTabletLandscape) {
@@ -173,9 +177,10 @@ export function BookChatScreen({ route, navigation }: Props) {
       backdropAnim.setValue(0);
       return;
     }
-
-    sidebarAnim.setValue(showSidebar ? 0 : -sidebarWidth);
-  }, [backdropAnim, isTabletLandscape, showSidebar, sidebarAnim, sidebarWidth]);
+    if (!showSidebarRef.current) {
+      sidebarAnim.setValue(-sidebarWidth);
+    }
+  }, [backdropAnim, isTabletLandscape, sidebarAnim, sidebarWidth]);
 
   const openSidebar = useCallback(() => {
     if (isTabletLandscape) return;

--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -214,7 +214,9 @@ export function BookChatScreen({ route, navigation }: Props) {
         duration: 200,
         useNativeDriver: true,
       }),
-    ]).start(() => setShowSidebar(false));
+    ]).start(({ finished }) => {
+      if (finished) setShowSidebar(false);
+    });
   }, [backdropAnim, isTabletLandscape, sidebarAnim, sidebarWidth]);
 
   // Streaming chat

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -514,9 +514,15 @@ export function ChatScreen() {
       )}
 
       {/* Thread sidebar overlay */}
-      {showSidebar && !isTabletLandscape && (
-        <View style={[StyleSheet.absoluteFill, { zIndex: 20 }]} pointerEvents="box-none">
-          <Animated.View style={[s.sidebarBackdrop, { opacity: backdropAnim }]}>
+      {!isTabletLandscape && (
+        <View
+          style={[StyleSheet.absoluteFill, { zIndex: 20 }]}
+          pointerEvents={showSidebar ? "box-none" : "none"}
+        >
+          <Animated.View
+            style={[s.sidebarBackdrop, { opacity: backdropAnim }]}
+            pointerEvents={showSidebar ? "auto" : "none"}
+          >
             <Pressable style={StyleSheet.absoluteFill} onPress={closeSidebar} />
           </Animated.View>
           <Animated.View

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -98,6 +98,10 @@ export function ChatScreen() {
   const [showSidebar, setShowSidebar] = useState(false);
   const sidebarAnim = useRef(new Animated.Value(-sidebarWidth)).current;
   const backdropAnim = useRef(new Animated.Value(0)).current;
+  const showSidebarRef = useRef(showSidebar);
+  useEffect(() => {
+    showSidebarRef.current = showSidebar;
+  }, [showSidebar]);
 
   useEffect(() => {
     if (isTabletLandscape) {
@@ -106,9 +110,10 @@ export function ChatScreen() {
       backdropAnim.setValue(0);
       return;
     }
-
-    sidebarAnim.setValue(showSidebar ? 0 : -sidebarWidth);
-  }, [backdropAnim, isTabletLandscape, showSidebar, sidebarAnim, sidebarWidth]);
+    if (!showSidebarRef.current) {
+      sidebarAnim.setValue(-sidebarWidth);
+    }
+  }, [backdropAnim, isTabletLandscape, sidebarAnim, sidebarWidth]);
 
   const openSidebar = useCallback(() => {
     if (isTabletLandscape) return;

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -147,7 +147,9 @@ export function ChatScreen() {
         duration: 200,
         useNativeDriver: true,
       }),
-    ]).start(() => setShowSidebar(false));
+    ]).start(({ finished }) => {
+      if (finished) setShowSidebar(false);
+    });
   }, [backdropAnim, isTabletLandscape, sidebarAnim, sidebarWidth]);
 
   // Chat store


### PR DESCRIPTION
## Summary
- AI 历史记录侧栏在移动端第二次起经常「卡一半」
- 根因：`ChatScreen` / `BookChatScreen` 的 layout effect 把 `showSidebar` 放进了依赖数组。`openSidebar` 调用 `setShowSidebar(true)` 触发 re-render，effect 紧接着用 `sidebarAnim.setValue(0)` 把动画值快照设值，正好打断同帧启动的 `Animated.spring` —— 之后 spring 卡在 native 侧那一帧的位置
- 修复：把 `showSidebar` 移出 deps，改用 ref 读取。effect 只在 layout（`isTabletLandscape`、`sidebarWidth`）变化且 sidebar 当前为关闭状态时重置离屏位置，进行中的 spring 不会被打断
- iPad 横屏不受影响（走 `isTabletLandscape` 分支，sidebar 一直内嵌不靠 spring）

Closes #255
Closes #257
Closes #254

## Test plan
- [x] `pnpm --filter @readany/core test` — 35 files / 343 tests 通过
- [ ] iPhone 真机/模拟器：连续打开关闭 5+ 次，每次都丝滑滑入
- [ ] iPad 竖屏：连续打开关闭 5+ 次，不会卡一半
- [ ] iPad 横屏：sidebar 仍然内嵌、不受影响
- [ ] Android：连续打开关闭 5+ 次正常
- [ ] 旋转过程：横屏 → 打开 sidebar → 旋转竖屏，sidebar 应该关闭并回到正确的关闭位置
- [ ] 键盘弹起时不会把已经打开的 sidebar 弹回去（之前的旧 effect 会，新的不会）

🤖 Generated with [Claude Code](https://claude.com/claude-code)