### PR TITLE
fix: handle non-ASCII response headers in WebDAV sync on Windows

### DIFF
--- a/packages/app/src/lib/platform/tauri-platform-service.ts
+++ b/packages/app/src/lib/platform/tauri-platform-service.ts
@@ -191,15 +191,36 @@ export class TauriPlatformService implements IPlatformService {
       allowInsecure,
       timeoutMs: _timeoutMs,
       responseType: _responseType,
+      onDownloadProgress: _onDownloadProgress,
       ...fetchOptions
     } = options ?? {};
-    if (allowInsecure) {
-      return tauriFetch(url, {
-        ...fetchOptions,
-        danger: { acceptInvalidCerts: true, acceptInvalidHostnames: true },
-      } as any);
+    const tauriOptions = allowInsecure
+      ? {
+          ...fetchOptions,
+          danger: { acceptInvalidCerts: true, acceptInvalidHostnames: true },
+        } as any
+      : fetchOptions;
+    try {
+      return await tauriFetch(url, tauriOptions);
+    } catch (error: unknown) {
+      // Tauri's fetch (Chromium-based) rejects when the server sends response
+      // headers containing characters outside the ISO-8859-1 range (e.g.
+      // Chinese filenames in Content-Disposition from WebDAV servers like dufs).
+      // Fall back to the browser's native fetch which is more lenient, aligning
+      // behaviour with the mobile (XHR) implementation.
+      const msg = (error as { message?: string })?.message ?? "";
+      if (
+        msg.includes("ISO-8859-1") ||
+        msg.includes("non ISO") ||
+        msg.includes("Failed to construct 'Headers'")
+      ) {
+        console.warn(
+          "[TauriPlatform] tauriFetch failed due to non-ASCII response headers; falling back to native fetch",
+        );
+        return globalThis.fetch(url, fetchOptions);
+      }
+      throw error;
     }
-    return tauriFetch(url, fetchOptions);
   }
 
   async createWebSocket(url: string, options?: WebSocketOptions): Promise<IWebSocket> {

--- a/packages/core/src/sync/webdav-client.ts
+++ b/packages/core/src/sync/webdav-client.ts
@@ -460,23 +460,43 @@ export class WebDavClient {
     console.log(`[WebDAV] GET ${logPath} (with progress)`);
     const startTime = Date.now();
 
-    const resp = await platform.fetch(url, {
-      method: "GET",
-      headers: { Authorization: this.authHeader },
-      allowInsecure: this.allowInsecure,
-      timeoutMs: TRANSFER_TIMEOUT_MS,
-      responseType: "arraybuffer",
-      onDownloadProgress: onProgress,
-    });
+    try {
+      const resp = await platform.fetch(url, {
+        method: "GET",
+        headers: { Authorization: this.authHeader },
+        allowInsecure: this.allowInsecure,
+        timeoutMs: TRANSFER_TIMEOUT_MS,
+        responseType: "arraybuffer",
+        onDownloadProgress: onProgress,
+      });
 
-    const elapsed = Date.now() - startTime;
-    if (!resp.ok) {
-      console.error(`[WebDAV] GET ${logPath} failed after ${elapsed}ms: ${resp.status}`);
-      throw new Error(`WebDAV GET failed for ${path}: ${resp.status} ${resp.statusText || ""}`);
+      const elapsed = Date.now() - startTime;
+      if (!resp.ok) {
+        console.error(`[WebDAV] GET ${logPath} failed after ${elapsed}ms: ${resp.status}`);
+        throw new Error(`WebDAV GET failed for ${path}: ${resp.status} ${resp.statusText || ""}`);
+      }
+      console.log(`[WebDAV] GET ${logPath} completed in ${elapsed}ms (status: ${resp.status})`);
+      const buffer = await resp.arrayBuffer();
+      return new Uint8Array(buffer);
+    } catch (error: unknown) {
+      const msg = (error as { message?: string })?.message ?? "";
+      // Tauri/Chromium rejects response headers containing non-ISO-8859-1
+      // characters (e.g. Chinese filenames in Content-Disposition). When this
+      // happens, fall back to the regular `get()` which goes through
+      // `request()` and has retry protection. Progress reporting is lost but
+      // the download still succeeds.
+      if (
+        msg.includes("ISO-8859-1") ||
+        msg.includes("non ISO") ||
+        msg.includes("Failed to construct 'Headers'")
+      ) {
+        console.warn(
+          `[WebDAV] GET ${logPath} failed due to non-ASCII response headers; falling back to get() without progress`,
+        );
+        return this.get(path);
+      }
+      throw error;
     }
-    console.log(`[WebDAV] GET ${logPath} completed in ${elapsed}ms (status: ${resp.status})`);
-    const buffer = await resp.arrayBuffer();
-    return new Uint8Array(buffer);
   }
 
   /** Download text content from a path (GET) */


### PR DESCRIPTION
## Problem

Windows desktop fails to sync books with Chinese titles via WebDAV (e.g. dufs server). 

**Root cause**: When the WebDAV server returns response headers containing non-ISO-8859-1 characters (e.g. Chinese filenames in `Content-Disposition`), Tauri's Chromium-based fetch throws:

```
TypeError: Failed to construct 'Headers': String contains non ISO-8859-1 code point.
```

This causes the new-layout book path request to fail, which then falls back to the legacy `/data/file/{id}.epub` path (404), resulting in a sync failure. Mobile (XHR-based) is not affected.

## Fix

**Two-layer defense:**

1. **`tauri-platform-service.ts`** (desktop platform layer): Catch the ISO-8859-1 error from `tauriFetch` and fall back to `globalThis.fetch` which is more lenient — aligning with mobile's XHR behavior.

2. **`webdav-client.ts`** (core sync layer): Catch the same error in `getWithProgress` and fall back to the regular `get()` method which goes through `request()` with retry protection. Progress reporting is lost but the download succeeds.

## Testing

- Books with Chinese titles should now sync correctly on Windows via WebDAV
- Books with ASCII-only titles are unaffected (no code path change)
- Mobile behavior unchanged

Closes #256