### PR TITLE
fix: getSurroundingContext returns visible page text instead of chapter start

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -1421,16 +1421,78 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
 
         // Update reading context service
         if (detail.tocItem?.label && detail.fraction !== undefined) {
-          // Extract visible text from the current page
+          // Extract visible text from the current page using precise viewport detection
           let surroundingText = "";
           try {
-            const view = viewRef.current;
-            const contents = view?.renderer?.getContents?.();
+            const renderer = viewRef.current?.renderer;
+            const contents = renderer?.getContents?.();
             if (contents?.[0]?.doc) {
               const doc = contents[0].doc as Document;
-              const rawText = doc.body?.textContent || "";
-              // Trim and limit to ~2000 chars to avoid overly large context
-              surroundingText = rawText.replace(/\s+/g, " ").trim().slice(0, 2000);
+              const isPaginated = !renderer.scrolled;
+              const pSize = renderer.size;
+              const pStart = renderer.start;
+
+              if (isPaginated && pSize > 0) {
+                const visibleLeft = pStart - pSize;
+                const visibleRight = pStart;
+                const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+                  acceptNode: (node: Node) => {
+                    if (!node.nodeValue?.trim()) return NodeFilter.FILTER_SKIP;
+                    const parent = (node as Text).parentElement;
+                    const tag = parent?.tagName?.toLowerCase();
+                    if (tag === "script" || tag === "style" || tag === "rt" || tag === "rp") return NodeFilter.FILTER_REJECT;
+                    if (parent?.closest?.(".readany-translation")) return NodeFilter.FILTER_REJECT;
+                    return NodeFilter.FILTER_ACCEPT;
+                  },
+                });
+                const visibleTexts: string[] = [];
+                let textNode = walker.nextNode();
+                while (textNode) {
+                  const range = doc.createRange();
+                  range.selectNodeContents(textNode);
+                  const rect = range.getBoundingClientRect();
+                  if (rect.right > visibleLeft && rect.left < visibleRight && rect.width > 0) {
+                    const text = textNode.nodeValue?.trim();
+                    if (text) visibleTexts.push(text);
+                  }
+                  textNode = walker.nextNode();
+                }
+                surroundingText = visibleTexts.join(" ").trim().slice(0, 2000);
+              } else {
+                const win = doc.defaultView;
+                if (win) {
+                  const vw = win.innerWidth;
+                  const vh = win.innerHeight;
+                  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+                    acceptNode: (node: Node) => {
+                      if (!node.nodeValue?.trim()) return NodeFilter.FILTER_SKIP;
+                      const parent = (node as Text).parentElement;
+                      const tag = parent?.tagName?.toLowerCase();
+                      if (tag === "script" || tag === "style" || tag === "rt" || tag === "rp") return NodeFilter.FILTER_REJECT;
+                      return NodeFilter.FILTER_ACCEPT;
+                    },
+                  });
+                  const visibleTexts: string[] = [];
+                  let textNode = walker.nextNode();
+                  while (textNode) {
+                    const range = doc.createRange();
+                    range.selectNodeContents(textNode);
+                    const rect = range.getBoundingClientRect();
+                    if (rect.right > 0 && rect.left < vw && rect.bottom > 0 && rect.top < vh && rect.width > 0) {
+                      const text = textNode.nodeValue?.trim();
+                      if (text) visibleTexts.push(text);
+                    }
+                    textNode = walker.nextNode();
+                  }
+                  surroundingText = visibleTexts.join(" ").trim().slice(0, 2000);
+                }
+              }
+
+              // Fallback: if no visible text detected, use section text
+              if (!surroundingText) {
+                const rawText = doc.body?.textContent || "";
+                surroundingText = rawText.replace(/\s+/g, " ").trim().slice(0, 2000);
+              }
             }
           } catch {
             // Ignore extraction errors


### PR DESCRIPTION
## Problem

The `getSurroundingContext` tool ("Getting Context") always returned the **first 2000 characters of the current section/chapter**, regardless of the user's actual reading position. 

When a user selected text at e.g. 2% into a chapter and asked AI about it, the `surroundingText` field contained the chapter opening instead of the text around the selection — making AI unable to understand the context.

**Reported in**: #260

## Root Cause

In `FoliateViewer.tsx`'s `relocateHandler`:
```typescript
const rawText = doc.body?.textContent || "";
surroundingText = rawText.replace(/\s+/g, " ").trim().slice(0, 2000);
```

`doc.body.textContent` returns the **entire section's text**, and `.slice(0, 2000)` always takes the beginning.

## Fix

Replace with the same viewport-aware detection logic used by `getVisibleText()` (already working correctly for TTS):

- **Paginated mode**: Uses `renderer.start/size` to compute visible column range, then `TreeWalker` + `getBoundingClientRect()` to collect only visible text nodes
- **Scroll mode**: Uses `innerWidth/innerHeight` as viewport bounds
- **Fallback**: If viewport detection returns empty (e.g. renderer not ready), falls back to the old `body.textContent.slice(0, 2000)` behavior

Now AI gets the text from the **page the user is actually looking at**.

## Testing

- Open a long EPUB chapter, navigate to the middle
- Select text and ask AI about it
- Verify `surroundingText` in the tool response matches the current visible page