### PR TITLE
Fix annotation ordering by book position

### DIFF
--- a/packages/app-expo/src/screens/NotesView.tsx
+++ b/packages/app-expo/src/screens/NotesView.tsx
@@ -1,5 +1,3 @@
-import { MarkdownRenderer } from "@/components/chat/MarkdownRenderer";
-import { SyncButton } from "@/components/ui/SyncButton";
 import {
   BookOpenIcon,
   ChevronLeftIcon,
@@ -9,16 +7,16 @@ import {
   ShareIcon,
   XIcon,
 } from "@/components/ui/Icon";
+import { SyncButton } from "@/components/ui/SyncButton";
+import { openMobileBook } from "@/lib/library/open-mobile-book";
 import type { RootStackParamList } from "@/navigation/RootNavigator";
-import type { TabParamList } from "@/navigation/TabNavigator";
 import { useAnnotationStore, useLibraryStore } from "@/stores";
 import { useColors, useTheme } from "@/styles/theme";
-import type { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { HighlightWithBook } from "@readany/core/db/database";
 import { AnnotationExporter, type ExportFormat } from "@readany/core/export";
-import { HIGHLIGHT_COLOR_HEX } from "@readany/core/types";
+import { sortAnnotationsByPosition } from "@readany/core/reader";
 import type { Highlight } from "@readany/core/types";
 import { eventBus } from "@readany/core/utils/event-bus";
 /**
@@ -28,7 +26,6 @@ import { eventBus } from "@readany/core/utils/event-bus";
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { openMobileBook } from "@/lib/library/open-mobile-book";
 import {
   Alert,
   FlatList,
@@ -44,8 +41,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { HighlightCard } from "./notes/HighlightCard";
-import { NotebookCard } from "./notes/NotebookCard";
 import { NoteCard } from "./notes/NoteCard";
+import { NotebookCard } from "./notes/NotebookCard";
 import { makeStyles } from "./notes/notes-styles";
 import { useResolvedCovers } from "./notes/useResolvedCovers";
 
@@ -54,7 +51,6 @@ const NOTE_DARK_PNG = require("../../assets/note-dark.png");
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
 type DetailTab = "notes" | "highlights";
-type Props = BottomTabScreenProps<TabParamList, "Notes">;
 
 export function NotesView({
   initialBookId,
@@ -185,7 +181,7 @@ export function NotesView({
           h.chapterTitle?.toLowerCase().includes(q),
       );
     }
-    const sorted = all.sort((a, b) => b.createdAt - a.createdAt);
+    const sorted = sortAnnotationsByPosition(all);
     return {
       notesList: sorted.filter((h) => h.note),
       highlightsList: sorted.filter((h) => !h.note),

--- a/packages/app/src/components/notes/NotesPage.tsx
+++ b/packages/app/src/components/notes/NotesPage.tsx
@@ -4,16 +4,17 @@ import { Input } from "@/components/ui/input";
 import { MarkdownEditor } from "@/components/ui/markdown-editor";
 import { useResolvedSrc, useSyncVersion } from "@/hooks/use-resolved-src";
 import type { HighlightWithBook } from "@/lib/db/database";
-import { openDesktopBook } from "@/lib/library/open-book";
 import { getBook as getBookRecord } from "@/lib/db/database";
+import { openDesktopBook } from "@/lib/library/open-book";
 import { useAnnotationStore } from "@/stores/annotation-store";
 import { useAppStore } from "@/stores/app-store";
 import { useLibraryStore } from "@/stores/library-store";
 import { type ExportFormat, annotationExporter } from "@readany/core/export";
+import { sortAnnotationsByPosition } from "@readany/core/reader";
 import type { Highlight, Note } from "@readany/core/types";
-import { eventBus } from "@readany/core/utils/event-bus";
 import { HIGHLIGHT_COLOR_HEX } from "@readany/core/types";
 import { cn } from "@readany/core/utils";
+import { eventBus } from "@readany/core/utils/event-bus";
 import {
   BookOpen,
   Check,
@@ -58,7 +59,14 @@ function CoverImage({ url, fallback, ...imgProps }: CoverImageProps) {
     return <>{fallback}</>;
   }
 
-  return <img key={`${resolvedSrc}-${syncVersion}`} src={resolvedSrc} onError={() => setHasError(true)} {...imgProps} />;
+  return (
+    <img
+      key={`${resolvedSrc}-${syncVersion}`}
+      src={resolvedSrc}
+      onError={() => setHasError(true)}
+      {...imgProps}
+    />
+  );
 }
 
 export function NotesPage() {
@@ -157,7 +165,7 @@ export function NotesPage() {
           h.chapterTitle?.toLowerCase().includes(q),
       );
     }
-    const sorted = all.sort((a, b) => b.createdAt - a.createdAt);
+    const sorted = sortAnnotationsByPosition(all);
     return {
       notes: sorted.filter((h) => h.note),
       highlightsOnly: sorted.filter((h) => !h.note),
@@ -181,7 +189,10 @@ export function NotesPage() {
   const handleOpenBook = async (bookId: string, _title: string, cfi?: string) => {
     const book =
       books.find((item) => item.id === bookId) ??
-      (await getBookRecord(bookId, { includeDeleted: true }).catch((err) => { console.warn("[Notes] Failed to get book record:", err); return null; }));
+      (await getBookRecord(bookId, { includeDeleted: true }).catch((err) => {
+        console.warn("[Notes] Failed to get book record:", err);
+        return null;
+      }));
     if (!book) return;
 
     await openDesktopBook({

--- a/packages/core/src/db/__tests__/bookmark-queries.test.ts
+++ b/packages/core/src/db/__tests__/bookmark-queries.test.ts
@@ -70,6 +70,30 @@ describe("bookmark-queries", () => {
       expect(bookmarks).toEqual([]);
     });
 
+    it("returns bookmarks sorted by book position", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "bm-10",
+          book_id: "book-1",
+          cfi: "epubcfi(/6/10!/4/2)",
+          label: null,
+          chapter_title: null,
+          created_at: 3000,
+        },
+        {
+          id: "bm-2",
+          book_id: "book-1",
+          cfi: "epubcfi(/6/2!/4/2)",
+          label: null,
+          chapter_title: null,
+          created_at: 1000,
+        },
+      ]);
+
+      const bookmarks = await getBookmarks("book-1");
+      expect(bookmarks.map((bookmark) => bookmark.id)).toEqual(["bm-2", "bm-10"]);
+    });
+
     it("handles null label and chapter_title", async () => {
       mockSelect.mockResolvedValue([
         {

--- a/packages/core/src/db/__tests__/highlight-queries.test.ts
+++ b/packages/core/src/db/__tests__/highlight-queries.test.ts
@@ -1,5 +1,5 @@
-import type { Highlight } from "../../types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Highlight } from "../../types";
 
 const mockExecute = vi.fn();
 const mockSelect = vi.fn();
@@ -71,6 +71,36 @@ describe("highlight-queries", () => {
       expect(highlights[0].id).toBe("hl-1");
       expect(highlights[0].bookId).toBe("book-1");
       expect(highlights[0].color).toBe("yellow");
+    });
+
+    it("returns highlights sorted by book position", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "hl-10",
+          book_id: "book-1",
+          cfi: "epubcfi(/6/10!/4/2)",
+          text: "Later text",
+          color: "yellow",
+          note: null,
+          chapter_title: null,
+          created_at: 3000,
+          updated_at: 3000,
+        },
+        {
+          id: "hl-2",
+          book_id: "book-1",
+          cfi: "epubcfi(/6/2!/4/2)",
+          text: "Earlier text",
+          color: "yellow",
+          note: null,
+          chapter_title: null,
+          created_at: 1000,
+          updated_at: 1000,
+        },
+      ]);
+
+      const highlights = await getHighlights("book-1");
+      expect(highlights.map((highlight) => highlight.id)).toEqual(["hl-2", "hl-10"]);
     });
   });
 
@@ -144,14 +174,15 @@ describe("highlight-queries", () => {
   describe("getHighlightStats", () => {
     it("returns aggregated statistics", async () => {
       mockSelect
-        .mockResolvedValueOnce([{ count: 10 }])  // total
-        .mockResolvedValueOnce([{ count: 3 }])   // with notes
-        .mockResolvedValueOnce([{ count: 5 }])   // distinct books
-        .mockResolvedValueOnce([               // color distribution
+        .mockResolvedValueOnce([{ count: 10 }]) // total
+        .mockResolvedValueOnce([{ count: 3 }]) // with notes
+        .mockResolvedValueOnce([{ count: 5 }]) // distinct books
+        .mockResolvedValueOnce([
+          // color distribution
           { color: "yellow", count: 6 },
           { color: "blue", count: 4 },
         ])
-        .mockResolvedValueOnce([{ count: 2 }]);  // recent
+        .mockResolvedValueOnce([{ count: 2 }]); // recent
 
       const stats = await getHighlightStats();
       expect(stats.totalHighlights).toBe(10);

--- a/packages/core/src/db/__tests__/note-queries.test.ts
+++ b/packages/core/src/db/__tests__/note-queries.test.ts
@@ -1,5 +1,5 @@
-import type { Note } from "../../types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Note } from "../../types";
 
 const mockExecute = vi.fn();
 const mockSelect = vi.fn();
@@ -13,19 +13,19 @@ const coreMocks = vi.hoisted(() => ({
   insertTombstone: vi.fn(),
   parseJSON: vi.fn((str: string | null | undefined, fallback: unknown) => {
     if (!str) return fallback;
-    try { return JSON.parse(str); } catch { return fallback; }
+    try {
+      return JSON.parse(str);
+    } catch {
+      return fallback;
+    }
   }),
 }));
 
 vi.mock("../db-core", () => coreMocks);
 
-const {
-  getNotes,
-  getAllNotes,
-  insertNote,
-  updateNote,
-  deleteNote,
-} = await import("../note-queries");
+const { getNotes, getAllNotes, insertNote, updateNote, deleteNote } = await import(
+  "../note-queries"
+);
 
 const sampleNote: Note = {
   id: "note-1",
@@ -105,6 +105,38 @@ describe("note-queries", () => {
       expect(notes[0].cfi).toBeUndefined();
       expect(notes[0].chapterTitle).toBeUndefined();
     });
+
+    it("returns notes sorted by book position", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "note-10",
+          book_id: "book-1",
+          highlight_id: null,
+          cfi: "epubcfi(/6/10!/4/2)",
+          title: "Later",
+          content: "Later content",
+          chapter_title: null,
+          tags: "[]",
+          created_at: 3000,
+          updated_at: 3000,
+        },
+        {
+          id: "note-2",
+          book_id: "book-1",
+          highlight_id: null,
+          cfi: "epubcfi(/6/2!/4/2)",
+          title: "Earlier",
+          content: "Earlier content",
+          chapter_title: null,
+          tags: "[]",
+          created_at: 1000,
+          updated_at: 1000,
+        },
+      ]);
+
+      const notes = await getNotes("book-1");
+      expect(notes.map((note) => note.id)).toEqual(["note-2", "note-10"]);
+    });
   });
 
   describe("getAllNotes", () => {
@@ -142,7 +174,7 @@ describe("note-queries", () => {
       expect(sql).toContain("INSERT INTO notes");
       expect(params[0]).toBe("note-1");
       expect(params[1]).toBe("book-1");
-      expect(params[2]).toBe("hl-1");  // highlightId
+      expect(params[2]).toBe("hl-1"); // highlightId
       expect(params[4]).toBe("My Note"); // title
       expect(params[7]).toBe('["important","review"]'); // tags serialized
     });

--- a/packages/core/src/db/bookmark-queries.ts
+++ b/packages/core/src/db/bookmark-queries.ts
@@ -1,3 +1,4 @@
+import { sortAnnotationsByPosition } from "../reader/annotation-order";
 import type { Bookmark } from "../types";
 import { getDB, getDeviceId, insertTombstone, nextSyncVersion } from "./db-core";
 
@@ -11,14 +12,16 @@ export async function getBookmarks(bookId: string): Promise<Bookmark[]> {
     chapter_title: string | null;
     created_at: number;
   }>("SELECT * FROM bookmarks WHERE book_id = ? ORDER BY created_at DESC", [bookId]);
-  return rows.map((r) => ({
-    id: r.id,
-    bookId: r.book_id,
-    cfi: r.cfi,
-    label: r.label || undefined,
-    chapterTitle: r.chapter_title || undefined,
-    createdAt: r.created_at,
-  }));
+  return sortAnnotationsByPosition(
+    rows.map((r) => ({
+      id: r.id,
+      bookId: r.book_id,
+      cfi: r.cfi,
+      label: r.label || undefined,
+      chapterTitle: r.chapter_title || undefined,
+      createdAt: r.created_at,
+    })),
+  );
 }
 
 export async function insertBookmark(bookmark: Bookmark): Promise<void> {

--- a/packages/core/src/db/highlight-queries.ts
+++ b/packages/core/src/db/highlight-queries.ts
@@ -1,5 +1,6 @@
+import { sortAnnotationsByPosition } from "../reader/annotation-order";
 import type { Highlight } from "../types";
-import { getDB, getDeviceId, nextSyncVersion, nextUpdatedAt, insertTombstone } from "./db-core";
+import { getDB, getDeviceId, insertTombstone, nextSyncVersion, nextUpdatedAt } from "./db-core";
 
 /** Extended highlight with book info for notes page */
 export interface HighlightWithBook extends Highlight {
@@ -20,21 +21,20 @@ export async function getHighlights(bookId: string): Promise<Highlight[]> {
     chapter_title: string | null;
     created_at: number;
     updated_at: number;
-  }>(
-    "SELECT * FROM highlights WHERE book_id = ? ORDER BY created_at DESC",
-    [bookId],
+  }>("SELECT * FROM highlights WHERE book_id = ? ORDER BY created_at DESC", [bookId]);
+  return sortAnnotationsByPosition(
+    rows.map((r) => ({
+      id: r.id,
+      bookId: r.book_id,
+      cfi: r.cfi,
+      text: r.text,
+      color: r.color as Highlight["color"],
+      note: r.note || undefined,
+      chapterTitle: r.chapter_title || undefined,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    })),
   );
-  return rows.map((r) => ({
-    id: r.id,
-    bookId: r.book_id,
-    cfi: r.cfi,
-    text: r.text,
-    color: r.color as Highlight["color"],
-    note: r.note || undefined,
-    chapterTitle: r.chapter_title || undefined,
-    createdAt: r.created_at,
-    updatedAt: r.updated_at,
-  }));
 }
 
 /** Get all highlights across all books (for general chat without bookId) */
@@ -50,10 +50,7 @@ export async function getAllHighlights(limit = 50): Promise<Highlight[]> {
     chapter_title: string | null;
     created_at: number;
     updated_at: number;
-  }>(
-    "SELECT * FROM highlights ORDER BY created_at DESC LIMIT ?",
-    [limit],
-  );
+  }>("SELECT * FROM highlights ORDER BY created_at DESC LIMIT ?", [limit]);
   return rows.map((r) => ({
     id: r.id,
     bookId: r.book_id,

--- a/packages/core/src/db/note-queries.ts
+++ b/packages/core/src/db/note-queries.ts
@@ -1,5 +1,13 @@
+import { sortAnnotationsByPosition } from "../reader/annotation-order";
 import type { Note } from "../types";
-import { getDB, getDeviceId, nextSyncVersion, nextUpdatedAt, insertTombstone, parseJSON } from "./db-core";
+import {
+  getDB,
+  getDeviceId,
+  insertTombstone,
+  nextSyncVersion,
+  nextUpdatedAt,
+  parseJSON,
+} from "./db-core";
 
 export async function getNotes(bookId: string): Promise<Note[]> {
   const database = await getDB();
@@ -15,18 +23,20 @@ export async function getNotes(bookId: string): Promise<Note[]> {
     created_at: number;
     updated_at: number;
   }>("SELECT * FROM notes WHERE book_id = ? ORDER BY created_at DESC", [bookId]);
-  return rows.map((r) => ({
-    id: r.id,
-    bookId: r.book_id,
-    highlightId: r.highlight_id || undefined,
-    cfi: r.cfi || undefined,
-    title: r.title,
-    content: r.content,
-    chapterTitle: r.chapter_title || undefined,
-    tags: parseJSON(r.tags, []),
-    createdAt: r.created_at,
-    updatedAt: r.updated_at,
-  }));
+  return sortAnnotationsByPosition(
+    rows.map((r) => ({
+      id: r.id,
+      bookId: r.book_id,
+      highlightId: r.highlight_id || undefined,
+      cfi: r.cfi || undefined,
+      title: r.title,
+      content: r.content,
+      chapterTitle: r.chapter_title || undefined,
+      tags: parseJSON(r.tags, []),
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    })),
+  );
 }
 
 /** Get all notes across all books (for general chat without bookId) */

--- a/packages/core/src/reader/annotation-order.test.ts
+++ b/packages/core/src/reader/annotation-order.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { compareCfiPosition, sortAnnotationsByPosition } from "./annotation-order";
+
+describe("annotation-order", () => {
+  it("sorts EPUB CFIs by numeric book position", () => {
+    const sorted = sortAnnotationsByPosition([
+      { id: "third", cfi: "epubcfi(/6/10!/4/2)", createdAt: 1 },
+      { id: "first", cfi: "epubcfi(/6/2!/4/2)", createdAt: 3 },
+      { id: "second", cfi: "epubcfi(/6/4!/4/2)", createdAt: 2 },
+    ]);
+
+    expect(sorted.map((item) => item.id)).toEqual(["first", "second", "third"]);
+  });
+
+  it("sorts page CFIs numerically", () => {
+    expect(compareCfiPosition("page:2", "page:10")).toBeLessThan(0);
+  });
+
+  it("uses created time as a stable tie-breaker for the same position", () => {
+    const sorted = sortAnnotationsByPosition([
+      { id: "newer", cfi: "epubcfi(/6/2!/4/2)", createdAt: 200 },
+      { id: "older", cfi: "epubcfi(/6/2!/4/2)", createdAt: 100 },
+    ]);
+
+    expect(sorted.map((item) => item.id)).toEqual(["older", "newer"]);
+  });
+
+  it("places annotations without a usable position after positioned annotations", () => {
+    const sorted = sortAnnotationsByPosition([
+      { id: "missing", createdAt: 1 },
+      { id: "blank", cfi: " ", createdAt: 2 },
+      { id: "positioned", cfi: "epubcfi(/6/2!/4/2)", createdAt: 3 },
+    ]);
+
+    expect(sorted.map((item) => item.id)).toEqual(["positioned", "missing", "blank"]);
+  });
+});

--- a/packages/core/src/reader/annotation-order.ts
+++ b/packages/core/src/reader/annotation-order.ts
@@ -1,0 +1,48 @@
+type PositionedAnnotation = {
+  cfi?: string;
+  createdAt: number;
+};
+
+function parsePageCfi(cfi: string): number[] | null {
+  const match = cfi.match(/^page:(\d+)$/i);
+  return match ? [Number.parseInt(match[1], 10)] : null;
+}
+
+function parseEpubCfi(cfi: string): number[] {
+  const inner = cfi.startsWith("epubcfi(") && cfi.endsWith(")") ? cfi.slice(8, -1) : cfi;
+  return [...inner.matchAll(/\d+/g)].map((match) => Number.parseInt(match[0], 10));
+}
+
+function getCfiSortKey(cfi?: string): number[] {
+  if (!cfi) return [Number.POSITIVE_INFINITY];
+  const trimmed = cfi.trim();
+  if (!trimmed) return [Number.POSITIVE_INFINITY];
+
+  const parsed = parsePageCfi(trimmed) ?? parseEpubCfi(trimmed);
+  return parsed.length > 0 ? parsed : [Number.POSITIVE_INFINITY];
+}
+
+export function compareCfiPosition(leftCfi?: string, rightCfi?: string): number {
+  const left = getCfiSortKey(leftCfi);
+  const right = getCfiSortKey(rightCfi);
+  const length = Math.max(left.length, right.length);
+
+  for (let i = 0; i < length; i++) {
+    const leftPart = left[i] ?? -1;
+    const rightPart = right[i] ?? -1;
+    if (leftPart !== rightPart) return leftPart - rightPart;
+  }
+
+  return (leftCfi ?? "").localeCompare(rightCfi ?? "");
+}
+
+export function compareAnnotationPosition(
+  left: PositionedAnnotation,
+  right: PositionedAnnotation,
+): number {
+  return compareCfiPosition(left.cfi, right.cfi) || left.createdAt - right.createdAt;
+}
+
+export function sortAnnotationsByPosition<T extends PositionedAnnotation>(items: T[]): T[] {
+  return [...items].sort(compareAnnotationPosition);
+}

--- a/packages/core/src/reader/index.ts
+++ b/packages/core/src/reader/index.ts
@@ -25,3 +25,8 @@ export type { SessionEvent, SessionDetector } from "./session-detector";
 // Annotation mutations
 export { createSelectionNoteMutation } from "./selection-note";
 export type { SelectionNoteMutation, SelectionNoteMutationInput } from "./selection-note";
+export {
+  compareAnnotationPosition,
+  compareCfiPosition,
+  sortAnnotationsByPosition,
+} from "./annotation-order";

--- a/packages/core/src/stores/annotation-store.ts
+++ b/packages/core/src/stores/annotation-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { HighlightWithBook } from "../db/database";
 import * as db from "../db/database";
+import { sortAnnotationsByPosition } from "../reader/annotation-order";
 /**
  * Annotation store — highlights, notes, bookmarks management
  * Connected to SQLite for persistence via core db module
@@ -67,9 +68,9 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
   bookmarks: [],
   stats: null,
 
-  setHighlights: (highlights) => set({ highlights }),
+  setHighlights: (highlights) => set({ highlights: sortAnnotationsByPosition(highlights) }),
   addHighlight: (highlight) => {
-    set((state) => ({ highlights: [...state.highlights, highlight] }));
+    set((state) => ({ highlights: sortAnnotationsByPosition([...state.highlights, highlight]) }));
     db.insertHighlight(highlight)
       .then(async () => {
         eventBus.emit("annotation:added", {
@@ -83,7 +84,9 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
   },
   updateHighlight: (id, updates) => {
     set((state) => ({
-      highlights: state.highlights.map((h) => (h.id === id ? { ...h, ...updates } : h)),
+      highlights: sortAnnotationsByPosition(
+        state.highlights.map((h) => (h.id === id ? { ...h, ...updates } : h)),
+      ),
       highlightsWithBooks: state.highlightsWithBooks.map((h) =>
         h.id === id ? { ...h, ...updates } : h,
       ),
@@ -108,8 +111,8 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
   },
   changeHighlightColor: (id, color) => {
     set((state) => ({
-      highlights: state.highlights.map((h) =>
-        h.id === id ? { ...h, color, updatedAt: Date.now() } : h,
+      highlights: sortAnnotationsByPosition(
+        state.highlights.map((h) => (h.id === id ? { ...h, color, updatedAt: Date.now() } : h)),
       ),
       highlightsWithBooks: state.highlightsWithBooks.map((h) =>
         h.id === id ? { ...h, color, updatedAt: Date.now() } : h,
@@ -122,15 +125,15 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
       .catch((err) => console.error("Failed to update highlight color:", err));
   },
 
-  setNotes: (notes) => set({ notes }),
+  setNotes: (notes) => set({ notes: sortAnnotationsByPosition(notes) }),
   addNote: (note) => {
-    set((state) => ({ notes: [...state.notes, note] }));
+    set((state) => ({ notes: sortAnnotationsByPosition([...state.notes, note]) }));
     db.insertNote(note).catch((err) => console.error("Failed to insert note:", err));
   },
   updateNote: (id, updates) => {
     set((state) => ({
-      notes: state.notes.map((n) =>
-        n.id === id ? { ...n, ...updates, updatedAt: Date.now() } : n,
+      notes: sortAnnotationsByPosition(
+        state.notes.map((n) => (n.id === id ? { ...n, ...updates, updatedAt: Date.now() } : n)),
       ),
     }));
     db.updateNote(id, updates).catch((err) => console.error("Failed to update note:", err));
@@ -140,9 +143,9 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
     db.deleteNote(id).catch((err) => console.error("Failed to delete note:", err));
   },
 
-  setBookmarks: (bookmarks) => set({ bookmarks }),
+  setBookmarks: (bookmarks) => set({ bookmarks: sortAnnotationsByPosition(bookmarks) }),
   addBookmark: (bookmark) => {
-    set((state) => ({ bookmarks: [...state.bookmarks, bookmark] }));
+    set((state) => ({ bookmarks: sortAnnotationsByPosition([...state.bookmarks, bookmark]) }));
     db.insertBookmark(bookmark).catch((err) => console.error("Failed to insert bookmark:", err));
   },
   removeBookmark: (id) => {
@@ -159,7 +162,11 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
         db.getNotes(bookId),
         db.getBookmarks(bookId),
       ]);
-      set({ highlights, notes, bookmarks });
+      set({
+        highlights: sortAnnotationsByPosition(highlights),
+        notes: sortAnnotationsByPosition(notes),
+        bookmarks: sortAnnotationsByPosition(bookmarks),
+      });
     } catch (err) {
       console.error("Failed to load annotations:", err);
     }
@@ -168,7 +175,7 @@ export const useAnnotationStore = create<AnnotationState>((set) => ({
   loadAllHighlights: async (limit = 500) => {
     try {
       const highlights = await db.getAllHighlights(limit);
-      set({ highlights });
+      set({ highlights: sortAnnotationsByPosition(highlights) });
     } catch (err) {
       console.error("Failed to load all highlights:", err);
     }


### PR DESCRIPTION
## Summary
- Add a shared annotation position sorter for EPUB CFI and page CFI values
- Sort per-book highlights, bookmarks, and notes by book position across DB queries, stores, and notes detail views
- Add focused tests for numeric CFI ordering and query-level position ordering

## Tests
- pnpm --filter @readany/core test -- annotation-store highlight-queries bookmark-queries note-queries annotation-order
- pnpm --filter @readany/core exec tsc --noEmit
- pnpm exec biome check packages/core/src/reader/annotation-order.ts packages/core/src/reader/annotation-order.test.ts packages/core/src/reader/index.ts packages/core/src/db/highlight-queries.ts packages/core/src/db/bookmark-queries.ts packages/core/src/db/note-queries.ts packages/core/src/db/__tests__/highlight-queries.test.ts packages/core/src/db/__tests__/bookmark-queries.test.ts packages/core/src/db/__tests__/note-queries.test.ts packages/core/src/stores/annotation-store.ts packages/app-expo/src/screens/NotesView.tsx

Fixes #268