### PR TITLE
Fix mobile local custom fonts

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -1266,7 +1266,7 @@
 
         let fontFamily;
         if (currentCustomFontFamily) {
-          fontFamily = currentCustomFontFamily;
+          fontFamily = cssString(currentCustomFontFamily);
         } else {
           const theme = fontThemes[currentFontTheme] || fontThemes.default;
           // For themes with multi-value font stacks (like system default), use as-is
@@ -1368,6 +1368,10 @@
         importUrls,
         fontFaceCSS: fontFaceLines.join('\n').trim(),
       };
+    }
+
+    function cssString(value) {
+      return JSON.stringify(String(value || ''));
     }
 
     function syncCustomFontStylesForDoc(doc, css) {

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1266,7 +1266,7 @@
 
         let fontFamily;
         if (currentCustomFontFamily) {
-          fontFamily = currentCustomFontFamily;
+          fontFamily = cssString(currentCustomFontFamily);
         } else {
           const theme = fontThemes[currentFontTheme] || fontThemes.default;
           // For themes with multi-value font stacks (like system default), use as-is
@@ -1368,6 +1368,10 @@
         importUrls,
         fontFaceCSS: fontFaceLines.join('\n').trim(),
       };
+    }
+
+    function cssString(value) {
+      return JSON.stringify(String(value || ''));
     }
 
     function syncCustomFontStylesForDoc(doc, css) {

--- a/packages/app-expo/src/lib/reader/local-file-server.ts
+++ b/packages/app-expo/src/lib/reader/local-file-server.ts
@@ -254,6 +254,10 @@ const EXT_MIME: Record<string, string> = {
   ".cbz": "application/vnd.comicbook+zip",
   ".fb2": "application/x-fictionbook+xml",
   ".txt": "text/plain",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
 };
 
 function _guessMime(filePath: string): string {

--- a/packages/app-expo/src/screens/ReaderScreen.tsx
+++ b/packages/app-expo/src/screens/ReaderScreen.tsx
@@ -162,6 +162,7 @@ import { useVolumeButtonPaging } from "./reader/useVolumeButtonPaging";
 import { useRubyStore } from "@readany/core/stores/ruby-store";
 
 const READER_HTML_ASSET = Asset.fromModule(require("../../assets/reader/reader.html"));
+const LOCAL_FONT_SERVER_DIR = "readany-fonts";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Reader">;
 type TTSSegment = VisibleTTSSegment;
@@ -171,6 +172,7 @@ type TTSSegment = VisibleTTSSegment;
 function buildCustomFontFaceCSS(
   fonts: import("@readany/core/types/font").CustomFont[],
   selectedFontId: string | null,
+  localServerUrl?: string | null,
 ): string {
   if (!selectedFontId) return "";
   const platform = getPlatformService();
@@ -183,7 +185,9 @@ function buildCustomFontFaceCSS(
       }
       if (f.source === "remote") return getCSSFontFace(f);
       if (!f.filePath) return "";
-      const fileUrl = platform.convertFileSrc(f.filePath);
+      const fileUrl = localServerUrl
+        ? `${localServerUrl.replace(/\/$/, "")}/${LOCAL_FONT_SERVER_DIR}/${encodeURIComponent(f.fileName)}`
+        : platform.convertFileSrc(f.filePath);
       const cssFormat =
         f.format === "otf"
           ? "opentype"
@@ -192,7 +196,7 @@ function buildCustomFontFaceCSS(
             : f.format === "woff2"
               ? "woff2"
               : "truetype";
-      return `@font-face {\n  font-family: '${f.fontFamily}';\n  src: url('${fileUrl}') format('${cssFormat}');\n  font-weight: normal;\n  font-style: normal;\n}`;
+      return `@font-face {\n  font-family: ${JSON.stringify(f.fontFamily)};\n  src: url('${fileUrl}') format('${cssFormat}');\n  font-weight: normal;\n  font-style: normal;\n}`;
     })
     .filter(Boolean)
     .join("\n");
@@ -236,6 +240,7 @@ export function ReaderScreen({ route, navigation }: Props) {
   const [readerHtmlUri, setReaderHtmlUri] = useState<string | null>(null);
   const [currentCfi, setCurrentCfi] = useState("");
   const [selection, setSelection] = useState<SelectionEvent | null>(null);
+  const [fontServerUrl, setFontServerUrl] = useState<string | null>(null);
   const [noteViewHighlight, setNoteViewHighlight] = useState<{
     id: string;
     text: string;
@@ -332,8 +337,8 @@ export function ReaderScreen({ route, navigation }: Props) {
     return customFonts.find((f) => f.id === selectedFontId)?.fontFamily;
   }, [customFonts, selectedFontId]);
   const customFontFaceCSS = useMemo(
-    () => buildCustomFontFaceCSS(customFonts, selectedFontId),
-    [customFonts, selectedFontId],
+    () => buildCustomFontFaceCSS(customFonts, selectedFontId, fontServerUrl),
+    [customFonts, selectedFontId, fontServerUrl],
   );
 
   const controlsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -565,7 +570,7 @@ export function ReaderScreen({ route, navigation }: Props) {
       setLoading(false);
       const settings = useSettingsStore.getState().readSettings;
       const { fonts, selectedFontId: selId } = useFontStore.getState();
-      const fontCSS = buildCustomFontFaceCSS(fonts, selId);
+      const fontCSS = buildCustomFontFaceCSS(fonts, selId, fileServerRef.current);
       const fontFamily = selId ? fonts.find((f) => f.id === selId)?.fontFamily : undefined;
       console.log("[ReaderScreen][Font] selection", {
         selectedFontId: selId,
@@ -955,7 +960,7 @@ export function ReaderScreen({ route, navigation }: Props) {
       updateReadSettings(updates);
       const currentSettings = useSettingsStore.getState().readSettings;
       const { fonts, selectedFontId: selId } = useFontStore.getState();
-      const fontCSS = buildCustomFontFaceCSS(fonts, selId);
+      const fontCSS = buildCustomFontFaceCSS(fonts, selId, fileServerRef.current);
       const fontFamily = selId ? fonts.find((f) => f.id === selId)?.fontFamily : undefined;
       // Recompute effective fontSize after every settings change — covers
       // both stepper changes and toggling followSystemFontScale on/off.
@@ -1069,6 +1074,7 @@ export function ReaderScreen({ route, navigation }: Props) {
         // and the massive JSON serialization through injectJavaScript.
         const serverUrl = await startFileServer(appData);
         fileServerRef.current = serverUrl;
+        setFontServerUrl(serverUrl);
         const encodedPath = book.filePath
           .split("/")
           .map((s) => encodeURIComponent(s))


### PR DESCRIPTION
## Summary
- Serve imported local font files through the existing mobile local HTTP server instead of injecting file:// URLs into the WebView
- Add font MIME types to the local file server
- Quote custom font-family values in the mobile reader so names with Chinese characters or parentheses, such as 白桃乌龙甜茶(1), remain valid CSS
- Rebuild the mobile reader.html asset from the template

## Test
- pnpm --filter @readany/app-expo build:reader
- pnpm --filter @readany/app-expo exec tsc --noEmit
- git diff --check

Note: a focused biome check still reports existing lint debt in ReaderScreen/local-file-server unrelated to this change.