### PR TITLE
docs: add afdian sponsor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ If you find ReadAny helpful, consider buying me a coffee to support ongoing deve
   <img src="assets/支付宝收款码.jpg" width="200" alt="支付宝收款码">
 </p>
 
+<p align="center">
+  <a href="https://ifdian.net/a/codedogQBY">Dining Table on Afdian</a>
+</p>
+
 ---
 
 ## Star History

--- a/README_CN.md
+++ b/README_CN.md
@@ -330,6 +330,10 @@ pnpm tauri build
   <img src="assets/支付宝收款码.jpg" width="200" alt="支付宝收款码">
 </p>
 
+<p align="center">
+  <a href="https://ifdian.net/a/codedogQBY">餐桌：爱发电支持</a>
+</p>
+
 ---
 
 ## Star 历史

--- a/website/src/components/Community.astro
+++ b/website/src/components/Community.astro
@@ -38,6 +38,11 @@ const sponsorQrCodes = [
     name: t("community.sponsor.alipay"),
     image: "/ReadAny/images/支付宝收款码.jpg",
   },
+  {
+    name: t("community.sponsor.table"),
+    href: "https://ifdian.net/a/codedogQBY",
+    description: t("community.sponsor.tableDesc"),
+  },
 ];
 ---
 
@@ -98,14 +103,26 @@ const sponsorQrCodes = [
     <div class="mt-16 pt-12 border-t border-border/50">
       <h3 class="text-lg font-semibold mb-2">{t('community.sponsor.title')}</h3>
       <p class="text-sm text-muted-foreground mb-6">{t('community.sponsor.subtitle')}</p>
-      <div class="flex gap-8">
+      <div class="flex flex-wrap gap-8">
         {sponsorQrCodes.map((qr) => (
           <div class="text-center">
-            <img 
-              src={qr.image} 
-              alt={qr.name}
-              class="w-40 h-40 rounded-lg border border-border/50 shadow-md"
-            />
+            {qr.image ? (
+              <img
+                src={qr.image}
+                alt={qr.name}
+                class="w-40 h-40 rounded-lg border border-border/50 shadow-md"
+              />
+            ) : (
+              <a
+                href={qr.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex h-40 w-40 flex-col items-center justify-center rounded-lg border border-border/50 bg-background px-5 text-center shadow-md transition-colors hover:border-foreground/30 hover:bg-muted/50"
+              >
+                <span class="text-lg font-semibold text-foreground">{qr.name}</span>
+                <span class="mt-2 text-xs leading-relaxed text-muted-foreground">{qr.description}</span>
+              </a>
+            )}
             <p class="mt-3 text-sm text-muted-foreground">{qr.name}</p>
           </div>
         ))}

--- a/website/src/i18n/ui.ts
+++ b/website/src/i18n/ui.ts
@@ -68,6 +68,8 @@ export const ui = {
     "community.sponsor.subtitle": "If you find ReadAny helpful, consider buying me a coffee!",
     "community.sponsor.wechat": "WeChat",
     "community.sponsor.alipay": "Alipay",
+    "community.sponsor.table": "Dining Table",
+    "community.sponsor.tableDesc": "Support on Afdian",
     "footer.github": "Star on GitHub",
     "footer.copyright": "© 2025 ReadAny. GPL-3.0 License.",
     
@@ -207,6 +209,8 @@ export const ui = {
     "community.sponsor.subtitle": "如果你觉得 ReadAny 对你有帮助，欢迎支持项目的持续开发！",
     "community.sponsor.wechat": "微信赞赏",
     "community.sponsor.alipay": "支付宝",
+    "community.sponsor.table": "餐桌",
+    "community.sponsor.tableDesc": "前往爱发电支持",
     "footer.github": "Star on GitHub",
     "footer.copyright": "© 2025 ReadAny. GPL-3.0 许可证。",
     


### PR DESCRIPTION
## Summary
- add an Afdian “Dining Table” sponsor option to the website support/community section
- add localized English and Chinese labels for the new sponsor link
- add the same Afdian link to the English and Chinese README sponsor sections

## Verification
- `pnpm --dir website build`
- `git diff --check`

Note: the website build passes with existing Astro route conflict warnings for `/support` and `/zh/support`.
