### PR TITLE
fix: improve Chinese translation prompt

### DIFF
--- a/packages/app-expo/src/components/reader/TranslationPanel.tsx
+++ b/packages/app-expo/src/components/reader/TranslationPanel.tsx
@@ -1,11 +1,12 @@
 import { CheckIcon, ChevronDownIcon, XIcon } from "@/components/ui/Icon";
 import { useSettingsStore } from "@/stores";
 import { type ThemeColors, fontSize, fontWeight, radius, useColors } from "@/styles/theme";
+import { buildAITranslationPrompt } from "@readany/core/translation/providers";
 import { TRANSLATOR_LANGS, type TranslationTargetLang } from "@readany/core/types/translation";
 import { providerRequiresApiKey } from "@readany/core/utils";
+import { buildOpenAICompatibleUrl } from "@readany/core/utils/api";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { buildOpenAICompatibleUrl } from "@readany/core/utils/api";
 import {
   ActivityIndicator,
   Modal,
@@ -82,7 +83,7 @@ export function TranslationPanel({ text, onClose }: TranslationPanelProps) {
           messages: [
             {
               role: "system",
-              content: `You are a translator. Translate the following text to ${TRANSLATOR_LANGS[targetLang]}. Only output the translation, no explanations.`,
+              content: buildAITranslationPrompt("AUTO", targetLang),
             },
             {
               role: "user",
@@ -106,9 +107,9 @@ export function TranslationPanel({ text, onClose }: TranslationPanelProps) {
       } else {
         throw new Error(t("translation.noResult", "翻译失败，请重试"));
       }
-    } catch (err: any) {
+    } catch (err) {
       console.error("[TranslationPanel] Error:", err);
-      setError(err.message || t("translation.error", "翻译出错"));
+      setError(err instanceof Error ? err.message : t("translation.error", "翻译出错"));
     } finally {
       setLoading(false);
     }
@@ -116,7 +117,7 @@ export function TranslationPanel({ text, onClose }: TranslationPanelProps) {
 
   useEffect(() => {
     translate();
-  }, [targetLang]);
+  }, [translate]);
 
   const handleLangChange = useCallback(
     (lang: TranslationTargetLang) => {

--- a/packages/core/src/translation/providers.test.ts
+++ b/packages/core/src/translation/providers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildAITranslationPrompt } from "./providers";
+
+describe("buildAITranslationPrompt", () => {
+  it("asks AI to translate classical Chinese into modern vernacular Chinese", () => {
+    const prompt = buildAITranslationPrompt("AUTO", "zh-CN");
+
+    expect(prompt).toContain("Classical/Literary Chinese");
+    expect(prompt).toContain("modern vernacular Simplified Chinese");
+    expect(prompt).toContain("学而不思则罔，思而不学则殆");
+    expect(prompt).toContain("not the original sentence");
+    expect(prompt).toContain("Do not mention source, author, title");
+    expect(prompt).toContain("most likely modern meaning in context");
+  });
+
+  it("keeps numbered output requirements for batch translation", () => {
+    const prompt = buildAITranslationPrompt("AUTO", "zh-CN", { numbered: true });
+
+    expect(prompt).toContain('keep the same numbering format "N. translation"');
+    expect(prompt).toContain("Do not add any explanation");
+  });
+});

--- a/packages/core/src/translation/providers.ts
+++ b/packages/core/src/translation/providers.ts
@@ -33,17 +33,40 @@ function getLanguageName(code: string): string {
   return langMap[code] || code;
 }
 
+function isChineseLanguage(code: string): boolean {
+  return code === "zh-CN" || code === "zh-TW" || code === "zh";
+}
+
+export function buildAITranslationPrompt(
+  sourceLang: string,
+  targetLang: string,
+  options: { numbered?: boolean } = {},
+): string {
+  const targetLangName = getLanguageName(targetLang);
+  const outputRule = options.numbered
+    ? 'Output translations only, keep the same numbering format "N. translation". Do not add any explanation.'
+    : "Only output the translation, no explanations or additional text.";
+  const chineseRule = isChineseLanguage(targetLang)
+    ? ` When translating to ${targetLangName}, if the source text is Classical/Literary Chinese or archaic Chinese, translate it into modern vernacular ${targetLangName}; for example, "学而不思则罔，思而不学则殆" should become a modern-language rendering of the meaning, not the original sentence. If a same-language literal translation would be identical, output a concise modern paraphrase. Do not mention source, author, title, background, citations, commentary, or analysis. For short Chinese words or single characters, output the most likely modern meaning in context instead of copying the source text.`
+    : "";
+  const conversionRule =
+    isChineseLanguage(sourceLang) || isChineseLanguage(targetLang)
+      ? " Important: Even if the source text appears similar to the target language (e.g. Traditional Chinese to Simplified Chinese), you must still perform the conversion."
+      : "";
+
+  return `You are a professional translator. Translate the following text to ${targetLangName}. ${outputRule}${chineseRule}${conversionRule}`;
+}
+
 /** AI Translation - uses OpenAI-compatible API */
 export async function aiTranslate(
   texts: string[],
-  _sourceLang: string,
+  sourceLang: string,
   targetLang: string,
   apiKey: string,
   baseUrl: string,
   model: string,
   useExactRequestUrl = false,
 ): Promise<string[]> {
-  const targetLangName = getLanguageName(targetLang);
   const requestUrl = buildOpenAICompatibleUrl(
     baseUrl,
     "chat/completions",
@@ -67,7 +90,7 @@ export async function aiTranslate(
         messages: [
           {
             role: "system",
-            content: `You are a professional translator. Translate the following text to ${targetLangName}. Only output the translation, no explanations or additional text. Important: Even if the source text appears similar to the target language (e.g. Traditional Chinese to Simplified Chinese), you must still perform the conversion.`,
+            content: buildAITranslationPrompt(sourceLang, targetLang),
           },
           { role: "user", content: texts[0] },
         ],
@@ -97,7 +120,7 @@ export async function aiTranslate(
             messages: [
               {
                 role: "system",
-                content: `You are a professional translator. Translate the following text to ${targetLangName}. Only output the translation.`,
+                content: buildAITranslationPrompt(sourceLang, targetLang),
               },
               { role: "user", content: text },
             ],
@@ -127,7 +150,7 @@ export async function aiTranslate(
  */
 export async function aiTranslateBatch(
   texts: string[],
-  _sourceLang: string,
+  sourceLang: string,
   targetLang: string,
   apiKey: string,
   baseUrl: string,
@@ -138,7 +161,7 @@ export async function aiTranslateBatch(
   if (texts.length <= 1) {
     return aiTranslate(
       texts,
-      _sourceLang,
+      sourceLang,
       targetLang,
       apiKey,
       baseUrl,
@@ -147,7 +170,6 @@ export async function aiTranslateBatch(
     );
   }
 
-  const targetLangName = getLanguageName(targetLang);
   const requestUrl = buildOpenAICompatibleUrl(
     baseUrl,
     "chat/completions",
@@ -173,7 +195,7 @@ export async function aiTranslateBatch(
         messages: [
           {
             role: "system",
-            content: `You are a professional translator. Translate each numbered paragraph to ${targetLangName}. Output translations only, keep the same numbering format "N. translation". Do not add any explanation. Important: Even if the source text appears similar to the target language (e.g. Traditional Chinese to Simplified Chinese), you must still perform the full conversion.`,
+            content: buildAITranslationPrompt(sourceLang, targetLang, { numbered: true }),
           },
           { role: "user", content: numberedInput },
         ],
@@ -203,7 +225,7 @@ export async function aiTranslateBatch(
   // Fallback to individual
   return aiTranslate(
     texts,
-    _sourceLang,
+    sourceLang,
     targetLang,
     apiKey,
     baseUrl,


### PR DESCRIPTION
## Summary
- centralize the AI translation system prompt in core
- tell AI translation to treat Chinese-to-Chinese, short Chinese words/characters, and classical/literary Chinese as modern Chinese interpretation instead of copying the source text
- reuse the same prompt in the mobile selection translation panel
- add tests covering the Chinese prompt rules and numbered batch prompt

Fixes #275

## Verification
- pnpm --filter @readany/core test
- pnpm --filter app build
- pnpm --filter @readany/app-expo exec tsc --noEmit
- pnpm exec biome check packages/app-expo/src/components/reader/TranslationPanel.tsx packages/core/src/translation/providers.test.ts
- git diff --check