### PR TITLE
feat(sync): improve file transfer progress

### DIFF
--- a/packages/app-expo/src/lib/platform/expo-platform-service.ts
+++ b/packages/app-expo/src/lib/platform/expo-platform-service.ts
@@ -13,6 +13,7 @@ import i18n from "@readany/core/i18n";
 import type {
   FetchOptions,
   FilePickerOptions,
+  FileTransferOptions,
   IDatabase,
   IPlatformService,
   IWebSocket,
@@ -273,7 +274,8 @@ export class ExpoPlatformService implements IPlatformService {
   // ---- Network ----
 
   async fetch(url: string, options?: FetchOptions): Promise<Response> {
-    const { allowInsecure, timeoutMs, responseType, onDownloadProgress, ...fetchOptions } = options ?? {};
+    const { allowInsecure, timeoutMs, responseType, onDownloadProgress, ...fetchOptions } =
+      options ?? {};
     const effectiveUrl = allowInsecure ? url.replace(/^https:\/\//i, "http://") : url;
     const method = fetchOptions?.method?.toUpperCase() || "GET";
 
@@ -281,7 +283,64 @@ export class ExpoPlatformService implements IPlatformService {
     // React Native's fetch has issues with large arrayBuffer responses
     const resolvedResponseType = responseType ?? (method === "GET" ? "arraybuffer" : "text");
     const effectiveTimeoutMs = timeoutMs ?? (method === "GET" ? 120000 : 15000);
-    return this._fetchWithXHR(effectiveUrl, fetchOptions, resolvedResponseType, effectiveTimeoutMs, onDownloadProgress);
+    return this._fetchWithXHR(
+      effectiveUrl,
+      fetchOptions,
+      resolvedResponseType,
+      effectiveTimeoutMs,
+      onDownloadProgress,
+    );
+  }
+
+  async downloadFile(url: string, filePath: string, options?: FileTransferOptions): Promise<void> {
+    const effectiveUrl = options?.allowInsecure ? url.replace(/^https:\/\//i, "http://") : url;
+    const task = LegacyFS.createDownloadResumable(
+      effectiveUrl,
+      filePath,
+      {
+        headers: options?.headers,
+        sessionType: LegacyFS.FileSystemSessionType.FOREGROUND,
+      },
+      (progress) => {
+        options?.onProgress?.(
+          progress.totalBytesWritten,
+          progress.totalBytesExpectedToWrite > 0 ? progress.totalBytesExpectedToWrite : 0,
+        );
+      },
+    );
+
+    const result = await task.downloadAsync();
+    if (!result) {
+      throw new Error(`File download cancelled: ${effectiveUrl}`);
+    }
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error(`File download failed: ${result.status}`);
+    }
+  }
+
+  async uploadFile(url: string, filePath: string, options?: FileTransferOptions): Promise<void> {
+    const effectiveUrl = options?.allowInsecure ? url.replace(/^https:\/\//i, "http://") : url;
+    const task = LegacyFS.createUploadTask(
+      effectiveUrl,
+      filePath,
+      {
+        headers: options?.headers,
+        httpMethod: "PUT",
+        uploadType: LegacyFS.FileSystemUploadType.BINARY_CONTENT,
+        sessionType: LegacyFS.FileSystemSessionType.FOREGROUND,
+      },
+      (progress) => {
+        options?.onProgress?.(progress.totalBytesSent, progress.totalBytesExpectedToSend);
+      },
+    );
+
+    const result = await task.uploadAsync();
+    if (!result) {
+      throw new Error(`File upload cancelled: ${effectiveUrl}`);
+    }
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error(`File upload failed: ${result.status}`);
+    }
   }
 
   private _fetchWithXHR(

--- a/packages/app-expo/src/lib/sync/sync-adapter-mobile.ts
+++ b/packages/app-expo/src/lib/sync/sync-adapter-mobile.ts
@@ -95,6 +95,15 @@ export class MobileSyncAdapter implements ISyncAdapter {
     return file.bytes();
   }
 
+  async getFileSize(filePath: string): Promise<number | null> {
+    try {
+      const file = new File(filePath);
+      return file.exists && Number.isFinite(file.size) ? file.size : null;
+    } catch {
+      return null;
+    }
+  }
+
   async writeFileBytes(filePath: string, data: Uint8Array): Promise<void> {
     const file = new File(filePath);
     file.write(data);

--- a/packages/app-expo/src/screens/settings/SyncSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/SyncSettingsScreen.tsx
@@ -1,16 +1,14 @@
-import { ConfigTransfer } from "../../components/settings/ConfigTransfer";
+import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
 import { getPlatformService } from "@readany/core/services";
 import { useSyncStore } from "@readany/core/stores";
-import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
-import type { S3Config, WebDavConfig } from "@readany/core/sync/sync-backend";
 import { SYNC_SECRET_KEYS } from "@readany/core/sync/sync-backend";
+import Constants from "expo-constants";
 /**
  * SyncSettingsScreen — Multi-backend sync configuration and status panel (mobile).
  * Supports WebDAV, S3, and LAN sync.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import Constants from "expo-constants";
 import {
   ActivityIndicator,
   Alert,
@@ -24,27 +22,31 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { ConfigTransfer } from "../../components/settings/ConfigTransfer";
 import { spacing, useColors } from "../../styles/theme";
 import { SettingsHeader } from "./SettingsHeader";
-import { makeStyles } from "./sync/sync-styles";
-import { WebDavForm } from "./sync/WebDavForm";
-import { S3Form } from "./sync/S3Form";
 import { LanSection } from "./sync/LanSection";
+import { S3Form } from "./sync/S3Form";
+import { WebDavForm } from "./sync/WebDavForm";
+import { makeStyles } from "./sync/sync-styles";
 
 type BackendType = "webdav" | "s3" | "lan";
 
-function isWebDavConfig(config: unknown): config is WebDavConfig {
-  return (
-    typeof config === "object" && config !== null && (config as WebDavConfig).type === "webdav"
-  );
-}
-
-function isS3Config(config: unknown): config is S3Config {
-  return typeof config === "object" && config !== null && (config as S3Config).type === "s3";
-}
-
 function hasAutoSync(config: unknown): config is { autoSync: boolean; syncIntervalMins?: number } {
   return typeof config === "object" && config !== null && "autoSync" in config;
+}
+
+function formatSyncBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  const precision = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
 }
 
 export default function SyncSettingsScreen() {
@@ -180,9 +182,20 @@ export default function SyncSettingsScreen() {
       setTesting(false);
     }
   }, [
-    selectedBackend, url, username, password, allowInsecure, remoteRoot,
-    s3Endpoint, s3Region, s3Bucket, s3AccessKeyId, s3SecretAccessKey,
-    testWebDavConnection, testS3Connection, t,
+    selectedBackend,
+    url,
+    username,
+    password,
+    allowInsecure,
+    remoteRoot,
+    s3Endpoint,
+    s3Region,
+    s3Bucket,
+    s3AccessKeyId,
+    s3SecretAccessKey,
+    testWebDavConnection,
+    testS3Connection,
+    t,
   ]);
 
   const handleSave = useCallback(async () => {
@@ -200,9 +213,19 @@ export default function SyncSettingsScreen() {
       setSaving(false);
     }
   }, [
-    selectedBackend, url, username, password, allowInsecure, remoteRoot,
-    s3Endpoint, s3Region, s3Bucket, s3AccessKeyId, s3SecretAccessKey,
-    saveWebDavConfig, saveS3Config,
+    selectedBackend,
+    url,
+    username,
+    password,
+    allowInsecure,
+    remoteRoot,
+    s3Endpoint,
+    s3Region,
+    s3Bucket,
+    s3AccessKeyId,
+    s3SecretAccessKey,
+    saveWebDavConfig,
+    saveS3Config,
   ]);
 
   const handleSync = useCallback(async () => {
@@ -219,7 +242,9 @@ export default function SyncSettingsScreen() {
   }, [syncNow, t]);
 
   const handleConflict = useCallback(
-    (direction: "upload" | "download") => { syncNow(direction); },
+    (direction: "upload" | "download") => {
+      syncNow(direction);
+    },
     [syncNow],
   );
 
@@ -258,7 +283,9 @@ export default function SyncSettingsScreen() {
           {
             text: t("common.confirm"),
             style: "destructive",
-            onPress: () => { void forceFullSync(direction); },
+            onPress: () => {
+              void forceFullSync(direction);
+            },
           },
         ],
       );
@@ -274,49 +301,86 @@ export default function SyncSettingsScreen() {
   const statusLabel = () => {
     if (isLanContext) {
       switch (status) {
-        case "checking": return t("settings.syncLANPreparingImport");
-        case "downloading": return t("settings.syncLANImporting");
-        case "syncing-files": return t("settings.syncLANImportingFiles");
-        case "error": return t("settings.syncError");
-        default: return null;
+        case "checking":
+          return t("settings.syncLANPreparingImport");
+        case "downloading":
+          return t("settings.syncLANImporting");
+        case "syncing-files":
+          return t("settings.syncLANImportingFiles");
+        case "error":
+          return t("settings.syncError");
+        default:
+          return null;
       }
     }
     switch (status) {
-      case "checking": return t("settings.syncChecking");
-      case "uploading": return t("settings.syncUploading");
-      case "downloading": return t("settings.syncDownloading");
-      case "syncing-files": return t("settings.syncSyncingFiles");
-      case "error": return t("settings.syncError");
-      default: return null;
+      case "checking":
+        return t("settings.syncChecking");
+      case "uploading":
+        return t("settings.syncUploading");
+      case "downloading":
+        return t("settings.syncDownloading");
+      case "syncing-files":
+        return t("settings.syncSyncingFiles");
+      case "error":
+        return t("settings.syncError");
+      default:
+        return null;
     }
   };
 
   const autoSyncEnabled = hasAutoSync(config) ? config.autoSync : false;
   const showScheduledSyncSettings = hasAutoSync(config);
 
+  const progressPercent = () => {
+    if (!progress || progress.phase === "database") return null;
+    if (progress.totalTransferBytes && progress.totalTransferBytes > 0) {
+      const ratio = (progress.totalCurrentBytes ?? 0) / progress.totalTransferBytes;
+      return Math.round(Math.max(0, Math.min(1, ratio)) * 100);
+    }
+    const totalFiles = Math.max(progress.totalFiles, 1);
+    if (progress.totalBytes && progress.totalBytes > 0) {
+      const currentBytes = progress.currentBytes ?? 0;
+      const fileRatio = Math.max(0, Math.min(1, currentBytes / progress.totalBytes));
+      return Math.round(((progress.completedFiles + fileRatio) / totalFiles) * 100);
+    }
+    return progress.totalFiles > 0
+      ? Math.round((progress.completedFiles / progress.totalFiles) * 100)
+      : 0;
+  };
+
   const progressLabel = () => {
     if (!progress) return null;
+    const byteProgress =
+      progress.phase === "files" && progress.totalTransferBytes && progress.totalTransferBytes > 0
+        ? ` - ${formatSyncBytes(progress.totalCurrentBytes ?? 0)} / ${formatSyncBytes(progress.totalTransferBytes)}`
+        : progress.phase === "files" && progress.totalBytes && progress.totalBytes > 0
+          ? ` - ${formatSyncBytes(progress.currentBytes ?? 0)} / ${formatSyncBytes(progress.totalBytes)}`
+          : "";
+
     if (isLanContext) {
       return progress.phase === "database"
         ? t("settings.syncLANImportProgressDatabase")
-        : t("settings.syncLANImportProgressFiles", {
+        : `${t("settings.syncLANImportProgressFiles", {
             completed: progress.completedFiles,
             total: progress.totalFiles,
-          });
+          })}${byteProgress}`;
     }
     return progress.phase === "database"
       ? t("settings.syncProgressDatabase", {
-          operation: progress.operation === "upload"
-            ? t("settings.syncUploading")
-            : t("settings.syncDownloading"),
+          operation:
+            progress.operation === "upload"
+              ? t("settings.syncUploading")
+              : t("settings.syncDownloading"),
         })
-      : t("settings.syncProgressFiles", {
-          operation: progress.operation === "upload"
-            ? t("settings.syncUploading")
-            : t("settings.syncDownloading"),
+      : `${t("settings.syncProgressFiles", {
+          operation:
+            progress.operation === "upload"
+              ? t("settings.syncUploading")
+              : t("settings.syncDownloading"),
           completed: progress.completedFiles,
           total: progress.totalFiles,
-        });
+        })}${byteProgress}`;
   };
 
   const handleSyncIntervalBlur = useCallback(async () => {
@@ -343,7 +407,9 @@ export default function SyncSettingsScreen() {
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
         >
-          <View style={[styles.contentColumn, { width: "100%", maxWidth: layout.centeredContentWidth }]}>
+          <View
+            style={[styles.contentColumn, { width: "100%", maxWidth: layout.centeredContentWidth }]}
+          >
             <Text style={styles.layoutNotice}>{t("settings.syncLayoutMigrationNotice")}</Text>
 
             {/* Backend Type Selector */}
@@ -353,7 +419,10 @@ export default function SyncSettingsScreen() {
                 {(["webdav", "s3", "lan"] as const).map((backend) => (
                   <TouchableOpacity
                     key={backend}
-                    style={[styles.backendBtn, selectedBackend === backend && styles.backendBtnActive]}
+                    style={[
+                      styles.backendBtn,
+                      selectedBackend === backend && styles.backendBtnActive,
+                    ]}
                     onPress={() => setSelectedBackend(backend)}
                   >
                     <Text
@@ -423,209 +492,223 @@ export default function SyncSettingsScreen() {
 
             {/* Conflict Resolution */}
             {pendingDirection === "conflict" && (
-            <View style={[styles.section, styles.sectionSpaced]}>
-              <View style={styles.conflictCard}>
-                <Text style={styles.conflictTitle}>{t("settings.syncConflictTitle")}</Text>
-                <Text style={styles.conflictDesc}>{t("settings.syncConflictDesc")}</Text>
-                <View style={styles.btnRow}>
-                  <TouchableOpacity
-                    style={styles.uploadBtn}
-                    onPress={() => handleConflict("upload")}
-                    activeOpacity={0.7}
-                  >
-                    <Text style={styles.uploadBtnText}>{t("settings.syncConflictUpload")}</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={styles.downloadBtn}
-                    onPress={() => handleConflict("download")}
-                    activeOpacity={0.7}
-                  >
-                    <Text style={styles.downloadBtnText}>{t("settings.syncConflictDownload")}</Text>
-                  </TouchableOpacity>
+              <View style={[styles.section, styles.sectionSpaced]}>
+                <View style={styles.conflictCard}>
+                  <Text style={styles.conflictTitle}>{t("settings.syncConflictTitle")}</Text>
+                  <Text style={styles.conflictDesc}>{t("settings.syncConflictDesc")}</Text>
+                  <View style={styles.btnRow}>
+                    <TouchableOpacity
+                      style={styles.uploadBtn}
+                      onPress={() => handleConflict("upload")}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={styles.uploadBtnText}>{t("settings.syncConflictUpload")}</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.downloadBtn}
+                      onPress={() => handleConflict("download")}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={styles.downloadBtnText}>
+                        {t("settings.syncConflictDownload")}
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
                 </View>
               </View>
-            </View>
             )}
 
             {/* Sync Status */}
             {selectedBackend !== "lan" && (isConfigured || isBusy || lastSyncAt) && (
-            <View style={[styles.section, styles.sectionSpaced]}>
-              <Text style={styles.sectionTitle}>
-                {isLanContext ? t("settings.syncLANImportStatus") : t("settings.syncStatus")}
-              </Text>
-              <View style={styles.card}>
-                <View style={styles.syncRow}>
-                  <View>
-                    <Text style={styles.syncLabel}>
-                      {isLanContext ? t("settings.syncLANLastImport") : t("settings.syncLastSync")}
-                    </Text>
-                    <Text style={styles.syncValue}>{formatLastSync(lastSyncAt)}</Text>
-                    {statusLabel() && <Text style={styles.statusText}>{statusLabel()}</Text>}
-                    {isBusy && progress && (
-                      <View style={styles.progressContainer}>
-                        <View style={styles.progressTrack}>
-                          {progress.phase === "database" ? (
-                            <Animated.View
-                              style={[styles.progressFill, { width: "100%", opacity: pulseAnim }]}
-                            />
-                          ) : (
-                            <View
-                              style={[
-                                styles.progressFill,
-                                {
-                                  width: `${progress.totalFiles > 0 ? Math.round((progress.completedFiles / progress.totalFiles) * 100) : 0}%`,
-                                },
-                              ]}
-                            />
-                          )}
-                        </View>
-                        <Text style={styles.progressText}>{progressLabel()}</Text>
-                      </View>
+              <View style={[styles.section, styles.sectionSpaced]}>
+                <Text style={styles.sectionTitle}>
+                  {isLanContext ? t("settings.syncLANImportStatus") : t("settings.syncStatus")}
+                </Text>
+                <View style={styles.card}>
+                  <View style={styles.syncRow}>
+                    <View style={styles.syncInfo}>
+                      <Text style={styles.syncLabel}>
+                        {isLanContext
+                          ? t("settings.syncLANLastImport")
+                          : t("settings.syncLastSync")}
+                      </Text>
+                      <Text style={styles.syncValue}>{formatLastSync(lastSyncAt)}</Text>
+                      {statusLabel() && <Text style={styles.statusText}>{statusLabel()}</Text>}
+                    </View>
+                    {!isLanContext && (
+                      <TouchableOpacity
+                        style={[styles.syncBtn, isBusy && styles.btnDisabled]}
+                        onPress={handleSync}
+                        disabled={isBusy}
+                        activeOpacity={0.7}
+                      >
+                        {isBusy && (
+                          <ActivityIndicator size="small" color={colors.primaryForeground} />
+                        )}
+                        <Text style={styles.syncBtnText}>
+                          {isBusy ? t("settings.syncSyncing") : t("settings.syncNow")}
+                        </Text>
+                      </TouchableOpacity>
                     )}
                   </View>
-                  {!isLanContext && (
-                    <TouchableOpacity
-                      style={[styles.syncBtn, isBusy && styles.btnDisabled]}
-                      onPress={handleSync}
-                      disabled={isBusy}
-                      activeOpacity={0.7}
-                    >
-                      {isBusy && <ActivityIndicator size="small" color={colors.primaryForeground} />}
-                      <Text style={styles.syncBtnText}>
-                        {isBusy ? t("settings.syncSyncing") : t("settings.syncNow")}
-                      </Text>
-                    </TouchableOpacity>
-                  )}
-                </View>
-
-                {lastResult && (
-                  <View style={styles.resultCard}>
-                    {lastResult.success ? (
-                      <>
-                        <Text style={styles.resultText}>
-                          {isLanContext
-                            ? t("settings.syncLANImportComplete")
-                            : t("settings.syncDirection", { direction: lastResult.direction })}
-                        </Text>
-                        {lastResult.filesUploaded > 0 && (
-                          <Text style={styles.resultText}>
-                            {t("settings.syncFilesUp", { count: lastResult.filesUploaded })}
-                          </Text>
+                  {isBusy && progress && (
+                    <View style={styles.progressContainer}>
+                      <View style={styles.progressTrack}>
+                        {progress.phase === "database" ? (
+                          <Animated.View
+                            style={[styles.progressFill, { width: "100%", opacity: pulseAnim }]}
+                          />
+                        ) : (
+                          <View
+                            style={[
+                              styles.progressFill,
+                              {
+                                width: `${progressPercent() ?? 0}%`,
+                              },
+                            ]}
+                          />
                         )}
-                        {lastResult.filesDownloaded > 0 && (
+                      </View>
+                      <Text style={styles.progressText}>{progressLabel()}</Text>
+                    </View>
+                  )}
+
+                  {lastResult && (
+                    <View style={styles.resultCard}>
+                      {lastResult.success ? (
+                        <>
                           <Text style={styles.resultText}>
                             {isLanContext
-                              ? t("settings.syncLANImportedFiles", { count: lastResult.filesDownloaded })
-                              : t("settings.syncFilesDown", { count: lastResult.filesDownloaded })}
+                              ? t("settings.syncLANImportComplete")
+                              : t("settings.syncDirection", { direction: lastResult.direction })}
                           </Text>
-                        )}
-                        {(lastResult.filesUploadFailed > 0 || lastResult.filesDownloadFailed > 0) && (
-                          <Text style={styles.errorText}>
-                            {t("settings.syncFilesPartialFailed", {
-                              uploadFailed: lastResult.filesUploadFailed,
-                              downloadFailed: lastResult.filesDownloadFailed,
+                          {lastResult.filesUploaded > 0 && (
+                            <Text style={styles.resultText}>
+                              {t("settings.syncFilesUp", { count: lastResult.filesUploaded })}
+                            </Text>
+                          )}
+                          {lastResult.filesDownloaded > 0 && (
+                            <Text style={styles.resultText}>
+                              {isLanContext
+                                ? t("settings.syncLANImportedFiles", {
+                                    count: lastResult.filesDownloaded,
+                                  })
+                                : t("settings.syncFilesDown", {
+                                    count: lastResult.filesDownloaded,
+                                  })}
+                            </Text>
+                          )}
+                          {(lastResult.filesUploadFailed > 0 ||
+                            lastResult.filesDownloadFailed > 0) && (
+                            <Text style={styles.errorText}>
+                              {t("settings.syncFilesPartialFailed", {
+                                uploadFailed: lastResult.filesUploadFailed,
+                                downloadFailed: lastResult.filesDownloadFailed,
+                              })}
+                            </Text>
+                          )}
+                        </>
+                      ) : (
+                        <Text style={styles.errorText}>
+                          {t("settings.syncFailed", { error: lastResult.error })}
+                        </Text>
+                      )}
+                    </View>
+                  )}
+
+                  {error && !lastResult && <Text style={styles.errorText}>{error}</Text>}
+
+                  {showScheduledSyncSettings && (
+                    <>
+                      <View style={styles.autoSyncRow}>
+                        <View style={{ flex: 1 }}>
+                          <Text style={styles.autoSyncLabel}>{t("settings.syncAutoSync")}</Text>
+                          <Text style={styles.autoSyncDesc}>{t("settings.syncAutoSyncDesc")}</Text>
+                        </View>
+                        <TouchableOpacity
+                          style={[styles.toggle, autoSyncEnabled && styles.toggleActive]}
+                          onPress={() => setAutoSync(!autoSyncEnabled)}
+                        >
+                          <View
+                            style={[
+                              styles.toggleThumb,
+                              autoSyncEnabled && styles.toggleThumbActive,
+                            ]}
+                          />
+                        </TouchableOpacity>
+                      </View>
+                      <View style={styles.intervalRow}>
+                        <View style={{ flex: 1 }}>
+                          <Text style={styles.autoSyncLabel}>{t("settings.syncInterval")}</Text>
+                          <Text style={styles.autoSyncDesc}>{t("settings.syncIntervalDesc")}</Text>
+                        </View>
+                        <View style={styles.intervalInputWrap}>
+                          <TextInput
+                            style={styles.intervalInput}
+                            value={syncIntervalInput}
+                            onChangeText={setSyncIntervalInput}
+                            onBlur={() => void handleSyncIntervalBlur()}
+                            keyboardType="number-pad"
+                            returnKeyType="done"
+                          />
+                          <Text style={styles.intervalSuffix}>
+                            {t("settings.syncIntervalMinutes", {
+                              count: Number.parseInt(syncIntervalInput || "30", 10) || 30,
                             })}
                           </Text>
-                        )}
-                      </>
-                    ) : (
-                      <Text style={styles.errorText}>
-                        {t("settings.syncFailed", { error: lastResult.error })}
-                      </Text>
-                    )}
-                  </View>
-                )}
-
-                {error && !lastResult && <Text style={styles.errorText}>{error}</Text>}
-
-                {showScheduledSyncSettings && (
-                  <>
-                    <View style={styles.autoSyncRow}>
-                      <View style={{ flex: 1 }}>
-                        <Text style={styles.autoSyncLabel}>{t("settings.syncAutoSync")}</Text>
-                        <Text style={styles.autoSyncDesc}>{t("settings.syncAutoSyncDesc")}</Text>
+                        </View>
                       </View>
-                      <TouchableOpacity
-                        style={[styles.toggle, autoSyncEnabled && styles.toggleActive]}
-                        onPress={() => setAutoSync(!autoSyncEnabled)}
-                      >
-                        <View
-                          style={[styles.toggleThumb, autoSyncEnabled && styles.toggleThumbActive]}
-                        />
-                      </TouchableOpacity>
-                    </View>
-                    <View style={styles.intervalRow}>
-                      <View style={{ flex: 1 }}>
-                        <Text style={styles.autoSyncLabel}>{t("settings.syncInterval")}</Text>
-                        <Text style={styles.autoSyncDesc}>{t("settings.syncIntervalDesc")}</Text>
-                      </View>
-                      <View style={styles.intervalInputWrap}>
-                        <TextInput
-                          style={styles.intervalInput}
-                          value={syncIntervalInput}
-                          onChangeText={setSyncIntervalInput}
-                          onBlur={() => void handleSyncIntervalBlur()}
-                          keyboardType="number-pad"
-                          returnKeyType="done"
-                        />
-                        <Text style={styles.intervalSuffix}>
-                          {t("settings.syncIntervalMinutes", {
-                            count: Number.parseInt(syncIntervalInput || "30", 10) || 30,
-                          })}
-                        </Text>
-                      </View>
-                    </View>
-                  </>
-                )}
+                    </>
+                  )}
+                </View>
               </View>
-            </View>
             )}
 
             {/* Advanced */}
             {isConfigured && selectedBackend !== "lan" && (
-            <View style={[styles.section, styles.sectionSpaced]}>
-              <TouchableOpacity
-                style={styles.advancedHeader}
-                onPress={() => setShowAdvanced(!showAdvanced)}
-              >
-                <Text style={styles.sectionTitle}>{t("settings.syncAdvanced")}</Text>
-                <Text style={styles.chevron}>{showAdvanced ? "▲" : "▼"}</Text>
-              </TouchableOpacity>
-              {showAdvanced && (
-                <View style={styles.card}>
-                  <View style={styles.btnRow}>
+              <View style={[styles.section, styles.sectionSpaced]}>
+                <TouchableOpacity
+                  style={styles.advancedHeader}
+                  onPress={() => setShowAdvanced(!showAdvanced)}
+                >
+                  <Text style={styles.sectionTitle}>{t("settings.syncAdvanced")}</Text>
+                  <Text style={styles.chevron}>{showAdvanced ? "▲" : "▼"}</Text>
+                </TouchableOpacity>
+                {showAdvanced && (
+                  <View style={styles.card}>
+                    <View style={styles.btnRow}>
+                      <TouchableOpacity
+                        style={[styles.uploadBtn, isBusy && styles.btnDisabled]}
+                        onPress={() => handleForceFullSync("upload")}
+                        disabled={isBusy}
+                        activeOpacity={0.7}
+                      >
+                        <Text style={styles.uploadBtnText}>{t("settings.syncForceUpload")}</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[styles.downloadBtn, isBusy && styles.btnDisabled]}
+                        onPress={() => handleForceFullSync("download")}
+                        disabled={isBusy}
+                        activeOpacity={0.7}
+                      >
+                        <Text style={styles.downloadBtnText}>
+                          {t("settings.syncForceDownload")}
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+                    <Text style={styles.resetDesc}>{t("settings.syncForceUploadDesc")}</Text>
+                    <Text style={styles.resetDesc}>{t("settings.syncForceDownloadDesc")}</Text>
                     <TouchableOpacity
-                      style={[styles.uploadBtn, isBusy && styles.btnDisabled]}
-                      onPress={() => handleForceFullSync("upload")}
-                      disabled={isBusy}
+                      style={styles.resetBtn}
+                      onPress={handleReset}
                       activeOpacity={0.7}
                     >
-                      <Text style={styles.uploadBtnText}>{t("settings.syncForceUpload")}</Text>
+                      <Text style={styles.resetBtnText}>{t("settings.syncReset")}</Text>
                     </TouchableOpacity>
-                    <TouchableOpacity
-                      style={[styles.downloadBtn, isBusy && styles.btnDisabled]}
-                      onPress={() => handleForceFullSync("download")}
-                      disabled={isBusy}
-                      activeOpacity={0.7}
-                    >
-                      <Text style={styles.downloadBtnText}>
-                        {t("settings.syncForceDownload")}
-                      </Text>
-                    </TouchableOpacity>
+                    <Text style={styles.resetDesc}>{t("settings.syncResetDesc")}</Text>
                   </View>
-                  <Text style={styles.resetDesc}>{t("settings.syncForceUploadDesc")}</Text>
-                  <Text style={styles.resetDesc}>{t("settings.syncForceDownloadDesc")}</Text>
-                  <TouchableOpacity
-                    style={styles.resetBtn}
-                    onPress={handleReset}
-                    activeOpacity={0.7}
-                  >
-                    <Text style={styles.resetBtnText}>{t("settings.syncReset")}</Text>
-                  </TouchableOpacity>
-                  <Text style={styles.resetDesc}>{t("settings.syncResetDesc")}</Text>
-                </View>
-              )}
-            </View>
+                )}
+              </View>
             )}
 
             {/* Transfer sync config */}

--- a/packages/app-expo/src/screens/settings/sync/LanSection.tsx
+++ b/packages/app-expo/src/screens/settings/sync/LanSection.tsx
@@ -1,13 +1,13 @@
 import { type LANQRData, createLANServer } from "@readany/core/sync/lan-server";
 import type { ISyncBackend } from "@readany/core/sync/sync-backend";
-import QRCode from "react-native-qrcode-svg";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import Constants from "expo-constants";
+import { Scan } from "lucide-react-native";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import Constants from "expo-constants";
-import { CameraView, useCameraPermissions } from "expo-camera";
 import {
-  Animated,
   Alert,
+  Animated,
   Modal,
   StyleSheet,
   Text,
@@ -15,7 +15,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Scan } from "lucide-react-native";
+import QRCode from "react-native-qrcode-svg";
 import { useColors } from "../../../styles/theme";
 import { makeStyles } from "./sync-styles";
 
@@ -25,11 +25,17 @@ interface LanSectionProps {
     phase: string;
     completedFiles: number;
     totalFiles: number;
+    currentBytes?: number;
+    totalBytes?: number;
+    totalCurrentBytes?: number;
+    totalTransferBytes?: number;
     message?: string;
   } | null;
   pulseAnim: Animated.Value;
   progressLabel: () => string | null;
-  onSyncWithBackend: (backend: ISyncBackend) => Promise<{ success: boolean; error?: string } | null>;
+  onSyncWithBackend: (
+    backend: ISyncBackend,
+  ) => Promise<{ success: boolean; error?: string } | null>;
 }
 
 export function LanSection({
@@ -58,6 +64,23 @@ export function LanSection({
   const [permission, requestPermission] = useCameraPermissions();
   const scannerHandledRef = useRef(false);
   const [scannerLocked, setScannerLocked] = useState(false);
+
+  const progressPercent = () => {
+    if (!progress || progress.phase === "database") return null;
+    if (progress.totalTransferBytes && progress.totalTransferBytes > 0) {
+      const ratio = (progress.totalCurrentBytes ?? 0) / progress.totalTransferBytes;
+      return Math.round(Math.max(0, Math.min(1, ratio)) * 100);
+    }
+    const totalFiles = Math.max(progress.totalFiles, 1);
+    if (progress.totalBytes && progress.totalBytes > 0) {
+      const currentBytes = progress.currentBytes ?? 0;
+      const fileRatio = Math.max(0, Math.min(1, currentBytes / progress.totalBytes));
+      return Math.round(((progress.completedFiles + fileRatio) / totalFiles) * 100);
+    }
+    return progress.totalFiles > 0
+      ? Math.round((progress.completedFiles / progress.totalFiles) * 100)
+      : 0;
+  };
 
   const handleStartLanServer = useCallback(async () => {
     setLanError("");
@@ -133,37 +156,33 @@ export function LanSection({
       return;
     }
     setLanError("");
-    Alert.alert(
-      t("settings.syncLANImportWarningTitle"),
-      t("settings.syncLANImportWarning"),
-      [
-        { text: t("common.cancel"), style: "cancel" },
-        {
-          text: t("common.confirm"),
-          style: "destructive",
-          onPress: async () => {
-            setLanConnectionState("connecting");
-            try {
-              const { createLANBackend } = require("@readany/core/sync/lan-backend");
-              const serverUrl = `http://${lanManualIP}:${lanManualPort}`;
-              const deviceName = Constants.deviceName || "Mobile";
-              const backend = createLANBackend(serverUrl, lanManualPairCode, deviceName);
-              const connected = await backend.testConnection();
-              if (!connected) throw new Error(t("settings.syncLANConnectionFailed"));
-              setLanConnectionState("connected");
-              const result = await onSyncWithBackend(backend);
-              if (!result || !result.success) {
-                throw new Error(result?.error || t("settings.syncLANConnectionFailed"));
-              }
-              setLanConnectionState("idle");
-            } catch (e) {
-              setLanError(e instanceof Error ? e.message : String(e));
-              setLanConnectionState("error");
+    Alert.alert(t("settings.syncLANImportWarningTitle"), t("settings.syncLANImportWarning"), [
+      { text: t("common.cancel"), style: "cancel" },
+      {
+        text: t("common.confirm"),
+        style: "destructive",
+        onPress: async () => {
+          setLanConnectionState("connecting");
+          try {
+            const { createLANBackend } = require("@readany/core/sync/lan-backend");
+            const serverUrl = `http://${lanManualIP}:${lanManualPort}`;
+            const deviceName = Constants.deviceName || "Mobile";
+            const backend = createLANBackend(serverUrl, lanManualPairCode, deviceName);
+            const connected = await backend.testConnection();
+            if (!connected) throw new Error(t("settings.syncLANConnectionFailed"));
+            setLanConnectionState("connected");
+            const result = await onSyncWithBackend(backend);
+            if (!result || !result.success) {
+              throw new Error(result?.error || t("settings.syncLANConnectionFailed"));
             }
-          },
+            setLanConnectionState("idle");
+          } catch (e) {
+            setLanError(e instanceof Error ? e.message : String(e));
+            setLanConnectionState("error");
+          }
         },
-      ],
-    );
+      },
+    ]);
   }, [lanManualIP, lanManualPort, lanManualPairCode, onSyncWithBackend, t]);
 
   const handleScanQRCode = useCallback(async () => {
@@ -187,16 +206,13 @@ export function LanSection({
       setScannerLocked(true);
       setShowScanner(false);
       try {
-      const { parseLANQRData, createLANBackend } = require("@readany/core/sync/lan-backend");
-      const qrData = parseLANQRData(data);
-      if (qrData) {
-        setLanManualIP(qrData.ip);
-        setLanManualPort(qrData.port.toString());
-        setLanManualPairCode(qrData.pairCode);
-        Alert.alert(
-          t("settings.syncLANImportWarningTitle"),
-          t("settings.syncLANImportWarning"),
-          [
+        const { parseLANQRData, createLANBackend } = require("@readany/core/sync/lan-backend");
+        const qrData = parseLANQRData(data);
+        if (qrData) {
+          setLanManualIP(qrData.ip);
+          setLanManualPort(qrData.port.toString());
+          setLanManualPairCode(qrData.pairCode);
+          Alert.alert(t("settings.syncLANImportWarningTitle"), t("settings.syncLANImportWarning"), [
             { text: t("common.cancel"), style: "cancel" },
             {
               text: t("common.confirm"),
@@ -224,11 +240,10 @@ export function LanSection({
                 }, 500);
               },
             },
-          ],
-        );
-      } else {
-        setLanError(t("settings.syncLANInvalidQR"));
-      }
+          ]);
+        } else {
+          setLanError(t("settings.syncLANInvalidQR"));
+        }
       } catch (e) {
         setLanError(e instanceof Error ? e.message : String(e));
       }
@@ -250,10 +265,7 @@ export function LanSection({
               onPress={() => setLanMode("server")}
             >
               <Text
-                style={[
-                  styles.lanModeBtnText,
-                  lanMode === "server" && styles.lanModeBtnTextActive,
-                ]}
+                style={[styles.lanModeBtnText, lanMode === "server" && styles.lanModeBtnTextActive]}
               >
                 {t("settings.syncLANServer")}
               </Text>
@@ -263,10 +275,7 @@ export function LanSection({
               onPress={() => setLanMode("client")}
             >
               <Text
-                style={[
-                  styles.lanModeBtnText,
-                  lanMode === "client" && styles.lanModeBtnTextActive,
-                ]}
+                style={[styles.lanModeBtnText, lanMode === "client" && styles.lanModeBtnTextActive]}
               >
                 {t("settings.syncLANClient")}
               </Text>
@@ -308,9 +317,7 @@ export function LanSection({
                       onPress={handleStartWithManualIP}
                       disabled={!lanManualServerIP}
                     >
-                      <Text style={styles.primaryBtnText}>
-                        {t("settings.syncLANServerStart")}
-                      </Text>
+                      <Text style={styles.primaryBtnText}>{t("settings.syncLANServerStart")}</Text>
                     </TouchableOpacity>
                   </View>
                 </View>
@@ -344,9 +351,7 @@ export function LanSection({
                 </View>
               )}
 
-              {lanError && !showManualIPInput && (
-                <Text style={styles.errorText}>{lanError}</Text>
-              )}
+              {lanError && !showManualIPInput && <Text style={styles.errorText}>{lanError}</Text>}
 
               {!showManualIPInput && (
                 <View style={styles.btnRow}>
@@ -367,9 +372,7 @@ export function LanSection({
                       style={[styles.outlineBtn, styles.lanBtn]}
                       onPress={handleStopLanServer}
                     >
-                      <Text style={styles.outlineBtnText}>
-                        {t("settings.syncLANServerStop")}
-                      </Text>
+                      <Text style={styles.outlineBtnText}>{t("settings.syncLANServerStop")}</Text>
                     </TouchableOpacity>
                   )}
                 </View>
@@ -476,15 +479,13 @@ export function LanSection({
                         style={[
                           styles.progressFill,
                           {
-                            width: `${progress.totalFiles > 0 ? Math.round((progress.completedFiles / progress.totalFiles) * 100) : 0}%`,
+                            width: `${progressPercent() ?? 0}%`,
                           },
                         ]}
                       />
                     )}
                   </View>
-                  <Text style={styles.progressText}>
-                    {progress.message || progressLabel()}
-                  </Text>
+                  <Text style={styles.progressText}>{progressLabel() || progress.message}</Text>
                 </View>
               )}
             </View>
@@ -514,9 +515,7 @@ export function LanSection({
                 setShowScanner(false);
               }}
             >
-              <Text style={styles.scannerCloseText}>
-                {t("settings.syncClose") || "Close"}
-              </Text>
+              <Text style={styles.scannerCloseText}>{t("settings.syncClose") || "Close"}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/packages/app-expo/src/screens/settings/sync/sync-styles.ts
+++ b/packages/app-expo/src/screens/settings/sync/sync-styles.ts
@@ -1,3 +1,4 @@
+import { StyleSheet } from "react-native";
 import {
   type ThemeColors,
   fontSize,
@@ -6,7 +7,6 @@ import {
   spacing,
   withOpacity,
 } from "../../../styles/theme";
-import { StyleSheet } from "react-native";
 
 export const makeStyles = (colors: ThemeColors) =>
   StyleSheet.create({
@@ -135,8 +135,13 @@ export const makeStyles = (colors: ThemeColors) =>
     errorText: { fontSize: fontSize.sm, color: colors.destructive },
     syncRow: {
       flexDirection: "row",
-      alignItems: "center",
+      alignItems: "flex-start",
       justifyContent: "space-between",
+      gap: 12,
+    },
+    syncInfo: {
+      flex: 1,
+      minWidth: 0,
     },
     syncLabel: {
       fontSize: fontSize.sm,
@@ -157,6 +162,7 @@ export const makeStyles = (colors: ThemeColors) =>
     syncBtn: {
       flexDirection: "row",
       alignItems: "center",
+      alignSelf: "flex-start",
       gap: 6,
       borderRadius: radius.lg,
       backgroundColor: colors.primary,

--- a/packages/app/src/components/settings/SyncSettings.tsx
+++ b/packages/app/src/components/settings/SyncSettings.tsx
@@ -15,6 +15,19 @@ import { LANSyncDialog } from "./LANSyncDialog";
 
 type BackendType = "webdav" | "s3" | "lan";
 
+function formatSyncBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  const precision = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
 export function SyncSettings() {
   const { t } = useTranslation();
   const {
@@ -305,16 +318,39 @@ export function SyncSettings() {
     }
   };
 
+  const progressPercent = () => {
+    if (!progress || progress.phase === "database") return null;
+    if (progress.totalTransferBytes && progress.totalTransferBytes > 0) {
+      const ratio = (progress.totalCurrentBytes ?? 0) / progress.totalTransferBytes;
+      return Math.round(Math.max(0, Math.min(1, ratio)) * 100);
+    }
+    const totalFiles = Math.max(progress.totalFiles, 1);
+    if (progress.totalBytes && progress.totalBytes > 0) {
+      const currentBytes = progress.currentBytes ?? 0;
+      const fileRatio = Math.max(0, Math.min(1, currentBytes / progress.totalBytes));
+      return Math.round(((progress.completedFiles + fileRatio) / totalFiles) * 100);
+    }
+    return progress.totalFiles > 0
+      ? Math.round((progress.completedFiles / progress.totalFiles) * 100)
+      : 0;
+  };
+
   const progressLabel = () => {
     if (!progress) return null;
+    const byteProgress =
+      progress.phase === "files" && progress.totalTransferBytes && progress.totalTransferBytes > 0
+        ? ` - ${formatSyncBytes(progress.totalCurrentBytes ?? 0)} / ${formatSyncBytes(progress.totalTransferBytes)}`
+        : progress.phase === "files" && progress.totalBytes && progress.totalBytes > 0
+          ? ` - ${formatSyncBytes(progress.currentBytes ?? 0)} / ${formatSyncBytes(progress.totalBytes)}`
+          : "";
 
     if (isLanContext) {
       return progress.phase === "database"
         ? t("settings.syncLANImportProgressDatabase")
-        : t("settings.syncLANImportProgressFiles", {
+        : `${t("settings.syncLANImportProgressFiles", {
             completed: progress.completedFiles,
             total: progress.totalFiles,
-          });
+          })}${byteProgress}`;
     }
 
     return progress.phase === "database"
@@ -324,14 +360,14 @@ export function SyncSettings() {
               ? t("settings.syncUploading")
               : t("settings.syncDownloading"),
         })
-      : t("settings.syncProgressFiles", {
+      : `${t("settings.syncProgressFiles", {
           operation:
             progress.operation === "upload"
               ? t("settings.syncUploading")
               : t("settings.syncDownloading"),
           completed: progress.completedFiles,
           total: progress.totalFiles,
-        });
+        })}${byteProgress}`;
   };
 
   const renderBackendSelector = () => (
@@ -416,7 +452,9 @@ export function SyncSettings() {
           </div>
         </div>
         <div>
-          <label className="mb-1 block text-sm text-foreground">{t("settings.syncRemoteRoot")}</label>
+          <label className="mb-1 block text-sm text-foreground">
+            {t("settings.syncRemoteRoot")}
+          </label>
           <input
             type="text"
             value={webdavRemoteRoot}
@@ -429,7 +467,9 @@ export function SyncSettings() {
         <div className="flex items-center justify-between pt-1">
           <div>
             <span className="text-sm text-foreground">{t("settings.syncAllowInsecure")}</span>
-            <p className="mt-0.5 text-xs text-muted-foreground">{t("settings.syncAllowInsecureDesc")}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t("settings.syncAllowInsecureDesc")}
+            </p>
           </div>
           <Switch
             checked={webdavAllowInsecure}
@@ -628,7 +668,7 @@ export function SyncSettings() {
                     <div
                       className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
                       style={{
-                        width: `${progress.totalFiles > 0 ? Math.round((progress.completedFiles / progress.totalFiles) * 100) : 0}%`,
+                        width: `${progressPercent() ?? 0}%`,
                       }}
                     />
                   )}
@@ -698,17 +738,23 @@ export function SyncSettings() {
             <div className="flex items-center justify-between pt-1">
               <div>
                 <span className="text-sm text-foreground">{t("settings.syncAutoSync")}</span>
-                <p className="mt-0.5 text-xs text-muted-foreground">{t("settings.syncAutoSyncDesc")}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {t("settings.syncAutoSyncDesc")}
+                </p>
               </div>
               <Switch
-                checked={config?.type === "webdav" || config?.type === "s3" ? config.autoSync : false}
+                checked={
+                  config?.type === "webdav" || config?.type === "s3" ? config.autoSync : false
+                }
                 onCheckedChange={(checked) => setAutoSync(checked)}
               />
             </div>
             <div className="flex items-center justify-between gap-3 border-t border-border/40 pt-3">
               <div>
                 <span className="text-sm text-foreground">{t("settings.syncInterval")}</span>
-                <p className="mt-0.5 text-xs text-muted-foreground">{t("settings.syncIntervalDesc")}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {t("settings.syncIntervalDesc")}
+                </p>
               </div>
               <div className="flex items-center gap-2">
                 <input
@@ -726,7 +772,11 @@ export function SyncSettings() {
                   }}
                   className="w-20 rounded-md border border-input bg-background px-3 py-1.5 text-right text-sm text-foreground outline-none focus:border-primary"
                 />
-                <span className="text-xs text-muted-foreground">{t("settings.syncIntervalMinutes", { count: Number.parseInt(syncIntervalInput || "30", 10) || 30 })}</span>
+                <span className="text-xs text-muted-foreground">
+                  {t("settings.syncIntervalMinutes", {
+                    count: Number.parseInt(syncIntervalInput || "30", 10) || 30,
+                  })}
+                </span>
               </div>
             </div>
           </>
@@ -860,9 +910,7 @@ export function SyncSettings() {
               saveS3Config(d.config as never, (d.secretAccessKey as string) || "");
             }
           }}
-          validate={(d) =>
-            typeof d === "object" && d !== null && "backendType" in d
-          }
+          validate={(d) => typeof d === "object" && d !== null && "backendType" in d}
         />
       </section>
 

--- a/packages/app/src/lib/sync/sync-adapter-desktop.ts
+++ b/packages/app/src/lib/sync/sync-adapter-desktop.ts
@@ -15,6 +15,7 @@ import {
   readDir,
   readFile,
   remove,
+  stat,
   writeFile,
 } from "@tauri-apps/plugin-fs";
 
@@ -79,6 +80,16 @@ export class DesktopSyncAdapter implements ISyncAdapter {
   async readFileBytes(filePath: string): Promise<Uint8Array> {
     const resolved = await this.resolveToAbsolute(filePath);
     return readFile(resolved);
+  }
+
+  async getFileSize(filePath: string): Promise<number | null> {
+    try {
+      const resolved = await this.resolveToAbsolute(filePath);
+      const info = await stat(resolved);
+      return Number.isFinite(info.size) ? info.size : null;
+    } catch {
+      return null;
+    }
   }
 
   async writeFileBytes(filePath: string, data: Uint8Array): Promise<void> {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -3,6 +3,7 @@ export type {
   IDatabase,
   IWebSocket,
   FetchOptions,
+  FileTransferOptions,
   FilePickerOptions,
   WebSocketOptions,
   UpdateInfo,

--- a/packages/core/src/services/platform.ts
+++ b/packages/core/src/services/platform.ts
@@ -29,6 +29,12 @@ export interface FetchOptions extends RequestInit {
   onDownloadProgress?: (loaded: number, total: number) => void;
 }
 
+export interface FileTransferOptions {
+  headers?: Record<string, string>;
+  allowInsecure?: boolean;
+  onProgress?: (loaded: number, total: number) => void;
+}
+
 export interface UpdateInfo {
   version: string;
   notes?: string;
@@ -85,6 +91,8 @@ export interface IPlatformService {
 
   // ---- Network (for scenarios requiring custom headers) ----
   fetch(url: string, options?: FetchOptions): Promise<Response>;
+  downloadFile?(url: string, filePath: string, options?: FileTransferOptions): Promise<void>;
+  uploadFile?(url: string, filePath: string, options?: FileTransferOptions): Promise<void>;
   createWebSocket(url: string, options?: WebSocketOptions): Promise<IWebSocket>;
 
   // ---- App info ----

--- a/packages/core/src/stores/sync-store.ts
+++ b/packages/core/src/stores/sync-store.ts
@@ -16,13 +16,8 @@ import {
 } from "../sync/sync-backend";
 import type { ISyncBackend } from "../sync/sync-backend";
 import { createSyncBackend, getSecretKeyForBackend } from "../sync/sync-backend-factory";
+import type { SyncDirection, SyncProgress, SyncResult, SyncStatusType } from "../sync/sync-types";
 import { sanitizeWebDavRemoteRoot, sanitizeWebDavUrl } from "../sync/webdav-client";
-import type {
-  SyncDirection,
-  SyncProgress,
-  SyncResult,
-  SyncStatusType,
-} from "../sync/sync-types";
 import { eventBus } from "../utils/event-bus";
 
 let activeSyncPromise: Promise<SyncResult | null> | null = null;
@@ -177,8 +172,8 @@ function normalizeSyncConfig(config: SyncConfig): SyncConfig {
       url: sanitizeWebDavUrl(config.url),
       username: config.username.trim(),
       remoteRoot:
-        sanitizeWebDavRemoteRoot(config.remoteRoot ?? DEFAULT_WEBDAV_REMOTE_ROOT)
-        || DEFAULT_WEBDAV_REMOTE_ROOT,
+        sanitizeWebDavRemoteRoot(config.remoteRoot ?? DEFAULT_WEBDAV_REMOTE_ROOT) ||
+        DEFAULT_WEBDAV_REMOTE_ROOT,
     };
   }
   return config;
@@ -212,9 +207,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
             : normalizedConfig;
         const secretKey = config.type !== "lan" ? getSecretKeyForBackend(config.type) : null;
         const secret = secretKey ? await platform.kvGetItem(secretKey) : null;
-        console.log(
-          `[SyncStore] loadConfig: secret = ${secret ? "found" : "not found"}`,
-        );
+        console.log(`[SyncStore] loadConfig: secret = ${secret ? "found" : "not found"}`);
 
         const isConfigured =
           config.type === "lan"
@@ -267,7 +260,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
       notifyOnComplete:
         (existing as WebDavConfig)?.notifyOnComplete ?? DEFAULT_SYNC_CONFIG.notifyOnComplete,
     };
-    console.log(`[SyncStore] saveWebDavConfig: saving config...`);
+    console.log("[SyncStore] saveWebDavConfig: saving config...");
     await platform.kvSetItem(SYNC_CONFIG_KEY, JSON.stringify(config));
     await platform.kvSetItem(SYNC_SECRET_KEYS.webdav, password);
 
@@ -287,8 +280,8 @@ export const useSyncStore = create<SyncState>((set, get) => ({
         url: sanitizeWebDavUrl(url),
         username: username.trim(),
         remoteRoot:
-          sanitizeWebDavRemoteRoot(remoteRoot ?? DEFAULT_WEBDAV_REMOTE_ROOT)
-          || DEFAULT_WEBDAV_REMOTE_ROOT,
+          sanitizeWebDavRemoteRoot(remoteRoot ?? DEFAULT_WEBDAV_REMOTE_ROOT) ||
+          DEFAULT_WEBDAV_REMOTE_ROOT,
         allowInsecure: allowInsecure ?? false,
         autoSync: false,
         syncIntervalMins: DEFAULT_SYNC_CONFIG.syncIntervalMins,
@@ -492,15 +485,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
       const result = await runSimpleSync(
         backend,
         (progress) => {
-          set({
-            progress: {
-              phase: progress.phase,
-              operation: progress.operation,
-              completedFiles: 0,
-              totalFiles: 1,
-              message: progress.message,
-            },
-          });
+          set({ progress });
         },
         receiveOnly ? { receiveOnly: true } : undefined,
       );
@@ -697,13 +682,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
           (progress) => {
             set({
               status: "syncing-files",
-              progress: {
-                phase: progress.phase,
-                operation: progress.operation,
-                completedFiles: 0,
-                totalFiles: 1,
-                message: progress.message,
-              },
+              progress,
             });
           },
           {
@@ -805,7 +784,10 @@ export const useSyncStore = create<SyncState>((set, get) => ({
     const state = get();
     if (!state.config || state.config.type === "lan") return;
 
-    const clampedMinutes = Math.max(5, Math.min(720, Math.round(minutes || DEFAULT_SYNC_CONFIG.syncIntervalMins)));
+    const clampedMinutes = Math.max(
+      5,
+      Math.min(720, Math.round(minutes || DEFAULT_SYNC_CONFIG.syncIntervalMins)),
+    );
     const config = { ...state.config, syncIntervalMins: clampedMinutes };
     const platform = getPlatformService();
     await platform.kvSetItem(SYNC_CONFIG_KEY, JSON.stringify(config));

--- a/packages/core/src/sync/__tests__/sync-files.test.ts
+++ b/packages/core/src/sync/__tests__/sync-files.test.ts
@@ -1,13 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ISyncBackend, RemoteFile } from "../sync-backend";
-import { REMOTE_BOOKS_ROOT, REMOTE_COVERS, REMOTE_FILES } from "../sync-types";
+import {
+  REMOTE_BOOKS_ROOT,
+  REMOTE_COVERS,
+  REMOTE_FILES,
+  REMOTE_FILE_MANIFEST,
+} from "../sync-types";
 
 const mockAdapter = {
   getAppDataDir: vi.fn().mockResolvedValue("/appdata"),
+  getTempDir: vi.fn().mockResolvedValue("/tmp"),
   joinPath: vi.fn((...segs: string[]) => segs.join("/")),
   fileExists: vi.fn(),
   readFileBytes: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+  getFileSize: vi.fn().mockResolvedValue(null),
   writeFileBytes: vi.fn(),
+  copyFile: vi.fn(),
   deleteFile: vi.fn(),
   ensureDir: vi.fn(),
   listFiles: vi.fn().mockResolvedValue([]),
@@ -91,6 +99,35 @@ describe("sync-files", () => {
         `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
         expect.any(Uint8Array),
       );
+    });
+
+    it("uses direct file upload when the backend supports it", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test Book",
+        },
+      ]);
+
+      mockAdapter.fileExists.mockResolvedValue(true);
+
+      const backend = createMockBackend({
+        listDir: vi.fn().mockResolvedValue([]),
+        putFile: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await syncFiles(backend);
+      expect(result.filesUploaded).toBe(1);
+      expect(backend.putFile).toHaveBeenCalledWith(
+        `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+        "/appdata/books/book-1.epub",
+        expect.any(Function),
+      );
+      expect(mockAdapter.readFileBytes).not.toHaveBeenCalled();
+      expect(backend.put).not.toHaveBeenCalled();
     });
 
     it("migrates legacy files to the new layout via MOVE", async () => {
@@ -177,6 +214,204 @@ describe("sync-files", () => {
       expect(result.filesDownloaded).toBe(1);
     });
 
+    it("uses the remote file manifest for downloads without scanning remote directories", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test Book",
+        },
+      ]);
+
+      mockAdapter.fileExists.mockResolvedValue(false);
+
+      const backend = createMockBackend({
+        getJSON: vi.fn().mockResolvedValue({
+          version: 1,
+          generatedAt: 1000,
+          books: {
+            "book-1": {
+              folderName: "Test Book-book-1",
+              filePath: `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+            },
+          },
+        }),
+        listDir: vi.fn().mockResolvedValue([]),
+      });
+
+      const result = await syncFiles(backend, undefined, {
+        forceDownloadAll: true,
+      });
+
+      expect(result.filesDownloaded).toBe(1);
+      expect(backend.getJSON).toHaveBeenCalledWith(REMOTE_FILE_MANIFEST);
+      expect(backend.listDir).not.toHaveBeenCalled();
+      expect(backend.get).toHaveBeenCalledWith(
+        `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+      );
+    });
+
+    it("falls back to a remote scan when the manifest is missing needed download data", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test Book",
+        },
+      ]);
+
+      mockAdapter.fileExists.mockResolvedValue(false);
+
+      const remoteBookDirs: RemoteFile[] = [
+        {
+          name: "Test Book-book-1",
+          path: `${REMOTE_BOOKS_ROOT}/Test Book-book-1`,
+          size: 0,
+          lastModified: 0,
+          isDirectory: true,
+        },
+      ];
+      const folderContents: RemoteFile[] = [
+        {
+          name: "Test Book.epub",
+          path: `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+          size: 100,
+          lastModified: 1000,
+          isDirectory: false,
+        },
+      ];
+
+      const backend = createMockBackend({
+        getJSON: vi.fn().mockResolvedValue({
+          version: 1,
+          generatedAt: 1000,
+          books: {},
+        }),
+        listDir: vi.fn().mockImplementation(async (path: string) => {
+          if (path === REMOTE_BOOKS_ROOT) return remoteBookDirs;
+          if (path === `${REMOTE_BOOKS_ROOT}/Test Book-book-1`) return folderContents;
+          return [];
+        }),
+      });
+
+      const result = await syncFiles(backend, undefined, {
+        downloadRemoteBooks: true,
+      });
+
+      expect(result.filesDownloaded).toBe(1);
+      expect(backend.listDir).toHaveBeenCalledWith(REMOTE_BOOKS_ROOT);
+      expect(backend.get).toHaveBeenCalledWith(
+        `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+      );
+    });
+
+    it("uploads a local file and writes it into the manifest without scanning remote directories", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test Book",
+        },
+      ]);
+
+      mockAdapter.fileExists.mockResolvedValue(true);
+
+      const backend = createMockBackend({
+        getJSON: vi.fn().mockResolvedValue({
+          version: 1,
+          generatedAt: 1000,
+          books: {},
+        }),
+        listDir: vi.fn().mockResolvedValue([]),
+      });
+
+      const result = await syncFiles(backend);
+
+      expect(result.filesUploaded).toBe(1);
+      expect(backend.listDir).not.toHaveBeenCalled();
+      expect(backend.put).toHaveBeenCalledWith(
+        `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+        expect.any(Uint8Array),
+      );
+      expect(backend.putJSON).toHaveBeenCalledWith(
+        REMOTE_FILE_MANIFEST,
+        expect.objectContaining({
+          version: 1,
+          books: {
+            "book-1": expect.objectContaining({
+              folderName: "Test Book-book-1",
+              filePath: `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+            }),
+          },
+        }),
+      );
+    });
+
+    it("uses direct file download when the backend supports it", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test Book",
+        },
+      ]);
+
+      mockAdapter.fileExists.mockResolvedValue(false);
+
+      const remoteBookDirs: RemoteFile[] = [
+        {
+          name: "Test Book-book-1",
+          path: `${REMOTE_BOOKS_ROOT}/Test Book-book-1`,
+          size: 0,
+          lastModified: 0,
+          isDirectory: true,
+        },
+      ];
+      const folderContents: RemoteFile[] = [
+        {
+          name: "Test Book.epub",
+          path: `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+          size: 100,
+          lastModified: 1000,
+          isDirectory: false,
+        },
+      ];
+
+      const backend = createMockBackend({
+        getFileToPath: vi.fn().mockResolvedValue(undefined),
+        listDir: vi.fn().mockImplementation(async (path: string) => {
+          if (path === REMOTE_BOOKS_ROOT) return remoteBookDirs;
+          if (path === `${REMOTE_BOOKS_ROOT}/Test Book-book-1`) return folderContents;
+          return [];
+        }),
+      });
+
+      const result = await syncFiles(backend, undefined, {
+        forceDownloadAll: true,
+      });
+
+      expect(result.filesDownloaded).toBe(1);
+      expect(backend.getFileToPath).toHaveBeenCalledWith(
+        `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+        expect.stringMatching(/^\/tmp\/readany-transfer-.*\.epub$/),
+        expect.any(Function),
+      );
+      expect(mockAdapter.copyFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/tmp\/readany-transfer-.*\.epub$/),
+        "/appdata/books/book-1.epub",
+      );
+      expect(mockAdapter.writeFileBytes).not.toHaveBeenCalled();
+      expect(backend.get).not.toHaveBeenCalled();
+    });
+
     it("marks books as remote when local file missing and remote exists in new layout", async () => {
       mockSelect.mockResolvedValue([
         {
@@ -246,6 +481,83 @@ describe("sync-files", () => {
           operation: "upload",
         }),
       );
+    });
+
+    it("reports direct transfer byte progress", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test",
+        },
+      ]);
+      mockAdapter.fileExists.mockResolvedValue(true);
+
+      const backend = createMockBackend({
+        listDir: vi.fn().mockResolvedValue([]),
+        putFile: vi.fn(async (_remotePath, _localPath, onProgress) => {
+          onProgress?.(50, 100);
+        }),
+      });
+      const onProgress = vi.fn();
+
+      await syncFiles(backend, onProgress);
+
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "files",
+          operation: "upload",
+          completedFiles: 0,
+          totalFiles: 1,
+          currentBytes: 50,
+          totalBytes: 100,
+        }),
+      );
+      expect(onProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "files",
+          operation: "upload",
+          completedFiles: 1,
+          totalFiles: 1,
+        }),
+      );
+    });
+
+    it("does not rewrite the remote file manifest when it is unchanged", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Test Book",
+        },
+      ]);
+      mockAdapter.fileExists.mockResolvedValue(true);
+
+      const manifest = {
+        version: 1 as const,
+        generatedAt: 1000,
+        books: {
+          "book-1": {
+            folderName: "Test Book-book-1",
+            filePath: `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+            updatedAt: 1000,
+          },
+        },
+      };
+      const backend = createMockBackend({
+        getJSON: vi.fn().mockResolvedValue(manifest),
+        listDir: vi.fn().mockResolvedValue([]),
+      });
+
+      const result = await syncFiles(backend);
+
+      expect(result.filesUploaded).toBe(0);
+      expect(backend.listDir).not.toHaveBeenCalled();
+      expect(backend.putJSON).not.toHaveBeenCalledWith(REMOTE_FILE_MANIFEST, expect.anything());
     });
 
     it("renames the book folder when the title has changed", async () => {
@@ -356,17 +668,37 @@ describe("sync-files", () => {
         get: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4, 5])),
       });
 
-      const result = await downloadBookFile(
-        backend,
-        "book-1",
-        "books/book-1.epub",
-      );
+      const result = await downloadBookFile(backend, "book-1", "books/book-1.epub");
 
       expect(result).toBe("ok");
       expect(backend.get).toHaveBeenCalledWith(
         `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
       );
       expect(mockAdapter.writeFileBytes).toHaveBeenCalled();
+      expect(mockSetBookSyncStatus).toHaveBeenCalledWith("book-1", "local");
+    });
+
+    it("downloads on-demand via direct file transfer when available", async () => {
+      mockSelect.mockResolvedValue([{ id: "book-1", title: "Test Book" }]);
+
+      const backend = createMockBackend({
+        getFileToPath: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await downloadBookFile(backend, "book-1", "books/book-1.epub");
+
+      expect(result).toBe("ok");
+      expect(backend.getFileToPath).toHaveBeenCalledWith(
+        `${REMOTE_BOOKS_ROOT}/Test Book-book-1/Test Book.epub`,
+        expect.stringMatching(/^\/tmp\/readany-transfer-.*\.epub$/),
+        expect.any(Function),
+      );
+      expect(mockAdapter.copyFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/tmp\/readany-transfer-.*\.epub$/),
+        "/appdata/books/book-1.epub",
+      );
+      expect(mockAdapter.writeFileBytes).not.toHaveBeenCalled();
+      expect(backend.get).not.toHaveBeenCalled();
       expect(mockSetBookSyncStatus).toHaveBeenCalledWith("book-1", "local");
     });
 
@@ -382,15 +714,11 @@ describe("sync-files", () => {
           if (path === `${REMOTE_FILES}/book-1.epub`) {
             return new Uint8Array([9, 9, 9]);
           }
-          throw new Error("unexpected path " + path);
+          throw new Error(`unexpected path ${path}`);
         });
       const backend = createMockBackend({ get: getMock });
 
-      const result = await downloadBookFile(
-        backend,
-        "book-1",
-        "books/book-1.epub",
-      );
+      const result = await downloadBookFile(backend, "book-1", "books/book-1.epub");
 
       expect(result).toBe("ok");
       expect(getMock).toHaveBeenCalledWith(`${REMOTE_FILES}/book-1.epub`);
@@ -404,11 +732,7 @@ describe("sync-files", () => {
         get: vi.fn().mockRejectedValue(new Error("404 Not Found")),
       });
 
-      const result = await downloadBookFile(
-        backend,
-        "book-1",
-        "books/book-1.epub",
-      );
+      const result = await downloadBookFile(backend, "book-1", "books/book-1.epub");
 
       expect(result).toBe("not-found");
       expect(mockSetBookSyncStatus).toHaveBeenCalledWith("book-1", "remote");
@@ -433,11 +757,7 @@ describe("sync-files", () => {
         get: vi.fn().mockRejectedValue(new Error("network error")),
       });
 
-      const result = await downloadBookFile(
-        backend,
-        "book-1",
-        "books/book-1.epub",
-      );
+      const result = await downloadBookFile(backend, "book-1", "books/book-1.epub");
 
       expect(result).toBe("error");
       expect(mockSetBookSyncStatus).toHaveBeenCalledWith("book-1", "remote");

--- a/packages/core/src/sync/simple-sync.ts
+++ b/packages/core/src/sync/simple-sync.ts
@@ -19,6 +19,7 @@ import { runSerializedDbTask } from "../db/write-retry";
 import { getPlatformService } from "../services/platform";
 import type { ISyncBackend } from "./sync-backend";
 import type { SyncFilesOptions } from "./sync-files";
+import type { SyncProgress } from "./sync-types";
 
 interface SyncTableConfig {
   name: string;
@@ -507,11 +508,7 @@ async function listRemoteDeviceFiles(
 
 export async function runSimpleSync(
   backend: ISyncBackend,
-  onProgress?: (progress: {
-    phase: "database" | "files";
-    operation: "upload" | "download";
-    message: string;
-  }) => void,
+  onProgress?: (progress: SyncProgress) => void,
   options: SimpleSyncOptions = {},
 ): Promise<{
   success: boolean;
@@ -527,6 +524,8 @@ export async function runSimpleSync(
     onProgress?.({
       phase: "database",
       operation: receiveOnly ? "download" : "upload",
+      completedFiles: 0,
+      totalFiles: 0,
       message: "准备同步...",
     });
 
@@ -538,6 +537,8 @@ export async function runSimpleSync(
     onProgress?.({
       phase: "database",
       operation: receiveOnly ? "download" : "upload",
+      completedFiles: 0,
+      totalFiles: 0,
       message: "检查远程目录...",
     });
     try {
@@ -548,7 +549,13 @@ export async function runSimpleSync(
     }
 
     // 2. Pull and apply all other devices' changesets
-    onProgress?.({ phase: "database", operation: "download", message: "获取其他设备的变更..." });
+    onProgress?.({
+      phase: "database",
+      operation: "download",
+      completedFiles: 0,
+      totalFiles: 0,
+      message: "获取其他设备的变更...",
+    });
     const remoteFiles = await listRemoteDeviceFiles(backend);
     console.log(`[SimpleSync] Found ${remoteFiles.length} remote device snapshot(s)`);
 
@@ -569,6 +576,8 @@ export async function runSimpleSync(
         onProgress?.({
           phase: "database",
           operation: "download",
+          completedFiles: 0,
+          totalFiles: 0,
           message: `应用设备 ${deviceId.slice(0, 8)} 的变更...`,
         });
         const result = await applyChanges(payload, { forceApply });
@@ -588,6 +597,8 @@ export async function runSimpleSync(
       onProgress?.({
         phase: "database",
         operation: "download",
+        completedFiles: 0,
+        totalFiles: 0,
         message: "同步中止：远端数据读取失败",
       });
       return {
@@ -604,9 +615,19 @@ export async function runSimpleSync(
     // 3. Collect and push local changes
     let changeCount = 0;
     if (!receiveOnly) {
-      onProgress?.({ phase: "database", operation: "upload", message: "收集本地变更..." });
+      onProgress?.({
+        phase: "database",
+        operation: "upload",
+        completedFiles: 0,
+        totalFiles: 0,
+        message: "收集本地变更...",
+      });
       const localDelta = await collectChanges(lastSync);
-      const snapshotPayload = await collectChanges(0);
+      let snapshotPayload: DeviceSyncPayload | null = null;
+      const getSnapshotPayload = async () => {
+        snapshotPayload ??= await collectChanges(0);
+        return snapshotPayload;
+      };
 
       changeCount = Object.values(localDelta.tables).reduce(
         (sum, t) => sum + t.records.length + t.deletedIds.length,
@@ -618,9 +639,11 @@ export async function runSimpleSync(
           onProgress?.({
             phase: "database",
             operation: "upload",
+            completedFiles: 0,
+            totalFiles: 0,
             message: `上传 ${changeCount + totalApplied} 条变更...`,
           });
-          await backend.putJSON(deviceSyncPath(localDeviceId), snapshotPayload);
+          await backend.putJSON(deviceSyncPath(localDeviceId), await getSnapshotPayload());
         } else {
           // Keep a full snapshot on the server so devices that sync later can still
           // bootstrap from this device even when there are no new local changes.
@@ -628,7 +651,7 @@ export async function runSimpleSync(
             .getJSON<DeviceSyncPayload>(deviceSyncPath(localDeviceId))
             .catch(() => null);
           if (!existing || now - existing.timestamp > 5 * 60 * 1000) {
-            await backend.putJSON(deviceSyncPath(localDeviceId), snapshotPayload);
+            await backend.putJSON(deviceSyncPath(localDeviceId), await getSnapshotPayload());
           }
         }
       } catch (e) {
@@ -637,7 +660,13 @@ export async function runSimpleSync(
       }
     } else if (totalApplied > 0) {
       // receiveOnly mode: still upload merged snapshot so other devices see the result
-      onProgress?.({ phase: "database", operation: "upload", message: "上传合并后的快照..." });
+      onProgress?.({
+        phase: "database",
+        operation: "upload",
+        completedFiles: 0,
+        totalFiles: 0,
+        message: "上传合并后的快照...",
+      });
       try {
         const snapshotPayload = await collectChanges(0);
         await backend.putJSON(deviceSyncPath(localDeviceId), snapshotPayload);
@@ -655,6 +684,8 @@ export async function runSimpleSync(
     onProgress?.({
       phase: "files",
       operation: receiveOnly ? "download" : "upload",
+      completedFiles: 0,
+      totalFiles: 0,
       message: "同步书籍和封面文件...",
     });
     try {
@@ -669,11 +700,7 @@ export async function runSimpleSync(
       const fileResult = await syncFiles(
         backend,
         (progress) => {
-          onProgress?.({
-            phase: "files",
-            operation: progress.operation,
-            message: progress.message || "同步文件...",
-          });
+          onProgress?.(progress);
         },
         { ...defaultFileOptions, ...options.fileSyncOptions },
       );
@@ -698,6 +725,8 @@ export async function runSimpleSync(
     onProgress?.({
       phase: "database",
       operation: receiveOnly ? "download" : "upload",
+      completedFiles: 0,
+      totalFiles: 0,
       message: "同步完成",
     });
     return {

--- a/packages/core/src/sync/sync-adapter.ts
+++ b/packages/core/src/sync/sync-adapter.ts
@@ -30,6 +30,9 @@ export interface ISyncAdapter {
   /** Read a file as Uint8Array */
   readFileBytes(filePath: string): Promise<Uint8Array>;
 
+  /** Get file size in bytes, or null when unavailable. */
+  getFileSize(filePath: string): Promise<number | null>;
+
   /** Write Uint8Array to a file */
   writeFileBytes(filePath: string, data: Uint8Array): Promise<void>;
 

--- a/packages/core/src/sync/sync-backend.ts
+++ b/packages/core/src/sync/sync-backend.ts
@@ -33,7 +33,24 @@ export interface ISyncBackend {
   get(path: string): Promise<Uint8Array>;
 
   /** Download data with progress reporting (optional — falls back to get() if not implemented) */
-  getWithProgress?(path: string, onProgress?: (loaded: number, total: number) => void): Promise<Uint8Array>;
+  getWithProgress?(
+    path: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<Uint8Array>;
+
+  /** Upload a local file directly when the platform/backend supports native file transfer. */
+  putFile?(
+    path: string,
+    localFilePath: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<void>;
+
+  /** Download directly into a local file when the platform/backend supports native file transfer. */
+  getFileToPath?(
+    path: string,
+    localFilePath: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<void>;
 
   /** Get JSON data from a path, returns null if not found */
   getJSON<T>(path: string): Promise<T | null>;

--- a/packages/core/src/sync/sync-files.ts
+++ b/packages/core/src/sync/sync-files.ts
@@ -26,6 +26,7 @@ import {
   REMOTE_BOOKS_ROOT,
   REMOTE_COVERS,
   REMOTE_FILES,
+  REMOTE_FILE_MANIFEST,
   type SyncProgress,
 } from "./sync-types";
 
@@ -67,6 +68,86 @@ function getExt(name: string): string {
   return idx >= 0 ? name.slice(idx + 1) : "";
 }
 
+function isDirectFileTransferUnsupported(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /does not support direct file|Platform does not support direct file/i.test(message);
+}
+
+async function makeTempTransferPath(finalPath: string): Promise<string> {
+  const adapter = getSyncAdapter();
+  const tempDir = await adapter.getTempDir();
+  await adapter.ensureDir(tempDir);
+  const ext = getExt(finalPath) || "tmp";
+  return adapter.joinPath(
+    tempDir,
+    `readany-transfer-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`,
+  );
+}
+
+async function uploadFileToRemote(
+  backend: ISyncBackend,
+  remotePath: string,
+  localPath: string,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<number | null> {
+  if (backend.putFile) {
+    try {
+      await backend.putFile(remotePath, localPath, onProgress);
+      return null;
+    } catch (e) {
+      if (!isDirectFileTransferUnsupported(e)) throw e;
+      console.warn(
+        `[Sync] Direct upload unsupported for ${remotePath}; falling back to buffered upload`,
+      );
+    }
+  }
+
+  const adapter = getSyncAdapter();
+  const data = await adapter.readFileBytes(localPath);
+  onProgress?.(0, data.length);
+  await backend.put(remotePath, data);
+  onProgress?.(data.length, data.length);
+  return data.length;
+}
+
+async function downloadRemoteFileToPath(
+  backend: ISyncBackend,
+  remotePath: string,
+  localPath: string,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<number | null> {
+  const adapter = getSyncAdapter();
+
+  if (backend.getFileToPath) {
+    const tempPath = await makeTempTransferPath(localPath);
+    try {
+      await backend.getFileToPath(remotePath, tempPath, onProgress);
+      const dir = getDirName(localPath);
+      if (dir) await adapter.ensureDir(dir);
+      await adapter.copyFile(tempPath, localPath);
+      return null;
+    } catch (e) {
+      if (!isDirectFileTransferUnsupported(e)) throw e;
+      console.warn(
+        `[Sync] Direct download unsupported for ${remotePath}; falling back to buffered download`,
+      );
+    } finally {
+      try {
+        await adapter.deleteFile(tempPath);
+      } catch {}
+    }
+  }
+
+  const data = backend.getWithProgress
+    ? await backend.getWithProgress(remotePath, onProgress)
+    : await backend.get(remotePath);
+  const dir = getDirName(localPath);
+  if (dir) await adapter.ensureDir(dir);
+  await adapter.writeFileBytes(localPath, data);
+  onProgress?.(data.length, data.length);
+  return data.length;
+}
+
 type BookRow = {
   id: string;
   file_path: string;
@@ -83,18 +164,26 @@ type BookInfo = {
   localCoverPath: string;
   remoteDir: string;
   expectedFolderName: string;
-  remoteFilePath: string;        // {books root}/{folder}/{title}.{file ext}
-  remoteCoverPath: string;       // {books root}/{folder}/{title}.{cover ext}
-  legacyRemoteFileName: string;  // {id}.{file ext}, lives in REMOTE_FILES
+  remoteFilePath: string; // {books root}/{folder}/{title}.{file ext}
+  remoteCoverPath: string; // {books root}/{folder}/{title}.{cover ext}
+  legacyRemoteFileName: string; // {id}.{file ext}, lives in REMOTE_FILES
   legacyRemoteCoverName: string; // {id}.{cover ext}, lives in REMOTE_COVERS
   hasFile: boolean;
   hasCover: boolean;
 };
 
 type RemoteListings = {
-  bookDirByBookId: Map<string, string>;        // book.id -> existing folder name on remote
-  legacyFileNames: Set<string>;                // names inside REMOTE_FILES
-  legacyCoverNames: Set<string>;               // names inside REMOTE_COVERS
+  source: "manifest" | "scan";
+  manifest: RemoteFileManifest | null;
+  bookDirByBookId: Map<string, string>; // book.id -> existing folder name on remote
+  filePathByBookId: Map<string, string>;
+  coverPathByBookId: Map<string, string>;
+  fileSizeByBookId: Map<string, number>;
+  coverSizeByBookId: Map<string, number>;
+  legacyFileNames: Set<string>; // names inside REMOTE_FILES
+  legacyCoverNames: Set<string>; // names inside REMOTE_COVERS
+  legacyFileSizeByName: Map<string, number>;
+  legacyCoverSizeByName: Map<string, number>;
   /** Folders under REMOTE_BOOKS_ROOT shaped like {title}-{uuid} whose uuid is not in the DB. */
   orphanBookDirs: { folderName: string; bookId: string }[];
   /** Folders under REMOTE_BOOKS_ROOT with no valid uuid suffix and not matched to any book. */
@@ -104,7 +193,120 @@ type RemoteListings = {
 type MigrationResult = {
   fileAtNew: boolean;
   coverAtNew: boolean;
+  fileSize?: number;
+  coverSize?: number;
 };
+
+type RemoteFileManifestEntry = {
+  folderName: string;
+  filePath?: string;
+  coverPath?: string;
+  fileSize?: number;
+  coverSize?: number;
+  updatedAt?: number;
+};
+
+type RemoteFileManifest = {
+  version: 1;
+  generatedAt: number;
+  books: Record<string, RemoteFileManifestEntry>;
+};
+
+type FileTask = {
+  label: string;
+  sizeBytes?: number | null;
+  run: (onProgress?: (loaded: number, total: number) => void) => Promise<boolean>;
+};
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+async function runFileTasks(
+  tasks: FileTask[],
+  operation: "upload" | "download",
+  concurrency: number,
+  onProgress?: (progress: SyncProgress) => void,
+): Promise<boolean[]> {
+  let completed = 0;
+  const total = tasks.length;
+  const operationLabel = operation === "upload" ? "Uploading" : "Downloading";
+  const taskLoadedBytes = new Map<number, number>();
+  const taskTotalBytes = new Map<number, number>();
+  for (let i = 0; i < tasks.length; i++) {
+    const size = tasks[i].sizeBytes;
+    if (isPositiveFiniteNumber(size)) {
+      taskTotalBytes.set(i, size);
+      taskLoadedBytes.set(i, 0);
+    }
+  }
+
+  const getTotalTransferBytes = () => {
+    if (taskTotalBytes.size !== tasks.length) return undefined;
+    const totalBytes = Array.from(taskTotalBytes.values()).reduce((sum, bytes) => sum + bytes, 0);
+    return totalBytes > 0 ? totalBytes : undefined;
+  };
+
+  const getTotalCurrentBytes = () =>
+    Array.from(taskLoadedBytes.values()).reduce((sum, bytes) => sum + bytes, 0);
+
+  const tasksWithProgress = tasks.map((task, index) => async () => {
+    const fileNumber = index + 1;
+    const emitProgress = (currentBytes?: number, totalBytes?: number) => {
+      if (isPositiveFiniteNumber(totalBytes)) {
+        taskTotalBytes.set(index, totalBytes);
+      }
+      if (currentBytes !== undefined) {
+        const knownTotal = taskTotalBytes.get(index);
+        const boundedBytes = knownTotal
+          ? Math.max(0, Math.min(currentBytes, knownTotal))
+          : Math.max(0, currentBytes);
+        taskLoadedBytes.set(index, boundedBytes);
+      }
+      const totalTransferBytes = getTotalTransferBytes();
+      onProgress?.({
+        phase: "files",
+        operation,
+        currentFile: task.label,
+        completedFiles: completed,
+        totalFiles: total,
+        ...(currentBytes !== undefined ? { currentBytes } : {}),
+        ...(totalBytes !== undefined ? { totalBytes } : {}),
+        ...(taskLoadedBytes.size > 0 ? { totalCurrentBytes: getTotalCurrentBytes() } : {}),
+        ...(totalTransferBytes !== undefined ? { totalTransferBytes } : {}),
+        message: `${operationLabel} file ${fileNumber}/${total}...`,
+      });
+    };
+
+    emitProgress();
+    const result = await task.run((loaded, taskTotal) => {
+      if (taskTotal > 0) emitProgress(loaded, taskTotal);
+    });
+    completed++;
+    const finalTotal =
+      taskTotalBytes.get(index) ??
+      (isPositiveFiniteNumber(task.sizeBytes) ? task.sizeBytes : undefined);
+    if (result && finalTotal) {
+      taskTotalBytes.set(index, finalTotal);
+      taskLoadedBytes.set(index, finalTotal);
+    }
+    const totalTransferBytes = getTotalTransferBytes();
+    onProgress?.({
+      phase: "files",
+      operation,
+      currentFile: task.label,
+      completedFiles: completed,
+      totalFiles: total,
+      ...(finalTotal !== undefined ? { currentBytes: finalTotal, totalBytes: finalTotal } : {}),
+      ...(taskLoadedBytes.size > 0 ? { totalCurrentBytes: getTotalCurrentBytes() } : {}),
+      ...(totalTransferBytes !== undefined ? { totalTransferBytes } : {}),
+      message: `${operationLabel} file ${Math.min(completed + 1, total)}/${total}...`,
+    });
+    return result;
+  });
+
+  return parallelLimit(tasksWithProgress, concurrency);
+}
 
 /**
  * Sync book files and covers between local and remote.
@@ -147,17 +349,17 @@ export async function syncFiles(
 
   // --- Compute per-book info ---
   const bookInfos: BookInfo[] = books.map((book) => {
-    const fileExt = book.file_path ? (getExt(book.file_path) || "epub") : "";
-    const coverExt = book.cover_url ? (getExt(book.cover_url) || "jpg") : "";
+    const fileExt = book.file_path ? getExt(book.file_path) || "epub" : "";
+    const coverExt = book.cover_url ? getExt(book.cover_url) || "jpg" : "";
     const localFilePath = book.file_path
-      ? (isAbsoluteOrProtocolPath(book.file_path)
+      ? isAbsoluteOrProtocolPath(book.file_path)
         ? book.file_path
-        : adapter.joinPath(appDataDir, book.file_path))
+        : adapter.joinPath(appDataDir, book.file_path)
       : "";
     const localCoverPath = book.cover_url
-      ? (isAbsoluteOrProtocolPath(book.cover_url)
+      ? isAbsoluteOrProtocolPath(book.cover_url)
         ? book.cover_url
-        : adapter.joinPath(appDataDir, book.cover_url))
+        : adapter.joinPath(appDataDir, book.cover_url)
       : "";
     return {
       book,
@@ -184,28 +386,50 @@ export async function syncFiles(
   const localExistsResults = await Promise.all(allLocalPaths.map((p) => adapter.fileExists(p)));
   const localExistsMap = new Map<string, boolean>();
   allLocalPaths.forEach((p, i) => localExistsMap.set(p, localExistsResults[i]));
+  const localSizeResults = await Promise.all(
+    allLocalPaths.map((p) =>
+      localExistsMap.get(p) ? adapter.getFileSize(p) : Promise.resolve(null),
+    ),
+  );
+  const localSizeMap = new Map<string, number | null>();
+  allLocalPaths.forEach((p, i) => localSizeMap.set(p, localSizeResults[i]));
 
   // --- List remote directories (tolerant of failures) ---
-  const listings = await loadRemoteListings(backend, currentBookIds);
+  const listings = await loadRemoteListings(backend, bookInfos, localExistsMap, {
+    forceDownloadAll,
+    downloadRemoteBooks,
+  });
 
   // --- Phase 1: migrate per-book remote state (folder rename + legacy → new) ---
   console.log(
     `[Sync] Pre-migration: ${listings.bookDirByBookId.size} book dirs on remote, ` +
-    `${listings.legacyFileNames.size} legacy files, ${listings.legacyCoverNames.size} legacy covers`,
+      `${listings.legacyFileNames.size} legacy files, ${listings.legacyCoverNames.size} legacy covers`,
   );
 
   const migrationResults = new Map<string, MigrationResult>();
+  const remoteFileAtNew = new Map<string, boolean>();
+  const remoteCoverAtNew = new Map<string, boolean>();
+  const remoteFileSizeAtNew = new Map<string, number>();
+  const remoteCoverSizeAtNew = new Map<string, number>();
   const migrationTasks = bookInfos.map((info) => async () => {
     const result = await migrateBookRemoteState(backend, info, listings);
     migrationResults.set(info.book.id, result);
+    remoteFileAtNew.set(info.book.id, result.fileAtNew);
+    remoteCoverAtNew.set(info.book.id, result.coverAtNew);
+    if (isPositiveFiniteNumber(result.fileSize)) {
+      remoteFileSizeAtNew.set(info.book.id, result.fileSize);
+    }
+    if (isPositiveFiniteNumber(result.coverSize)) {
+      remoteCoverSizeAtNew.set(info.book.id, result.coverSize);
+    }
   });
   if (migrationTasks.length > 0) {
     await parallelLimit(migrationTasks, MIGRATION_CONCURRENCY);
   }
 
   // --- Phase 2: build upload/download task lists based on post-migration state ---
-  const uploadTasks: (() => Promise<boolean>)[] = [];
-  const downloadTasks: (() => Promise<boolean>)[] = [];
+  const uploadTasks: FileTask[] = [];
+  const downloadTasks: FileTask[] = [];
 
   for (const info of bookInfos) {
     const { book } = info;
@@ -217,11 +441,26 @@ export async function syncFiles(
       const remoteExists = migration.fileAtNew;
 
       if (!disableUploads && localExists && (forceUploadAll || !remoteExists)) {
-        uploadTasks.push(buildUploadFileTask(backend, info));
+        const task = buildUploadFileTask(backend, info);
+        const sizeBytes = localSizeMap.get(info.localFilePath) ?? null;
+        uploadTasks.push({
+          label: task.label,
+          sizeBytes,
+          run: async (onProgress) => {
+            const ok = await task.run(onProgress);
+            if (ok) remoteFileAtNew.set(book.id, true);
+            if (ok && isPositiveFiniteNumber(sizeBytes))
+              remoteFileSizeAtNew.set(book.id, sizeBytes);
+            return ok;
+          },
+        });
       }
 
       if (remoteExists && (forceDownloadAll || (downloadRemoteBooks && !localExists))) {
-        downloadTasks.push(buildDownloadFileTask(backend, info, setBookSyncStatus));
+        downloadTasks.push({
+          ...buildDownloadFileTask(backend, info, setBookSyncStatus),
+          sizeBytes: migration.fileSize,
+        });
       } else if (!localExists && remoteExists) {
         try {
           await setBookSyncStatus(book.id, "remote");
@@ -246,18 +485,34 @@ export async function syncFiles(
       const remoteExists = migration.coverAtNew;
 
       if (!disableUploads && localExists && (forceUploadAll || !remoteExists)) {
-        uploadTasks.push(buildUploadCoverTask(backend, info));
+        const task = buildUploadCoverTask(backend, info);
+        const sizeBytes = localSizeMap.get(info.localCoverPath) ?? null;
+        uploadTasks.push({
+          label: task.label,
+          sizeBytes,
+          run: async (onProgress) => {
+            const ok = await task.run(onProgress);
+            if (ok) remoteCoverAtNew.set(book.id, true);
+            if (ok && isPositiveFiniteNumber(sizeBytes)) {
+              remoteCoverSizeAtNew.set(book.id, sizeBytes);
+            }
+            return ok;
+          },
+        });
       }
 
       if (remoteExists && (forceDownloadAll || !localExists)) {
-        downloadTasks.push(buildDownloadCoverTask(backend, info));
+        downloadTasks.push({
+          ...buildDownloadCoverTask(backend, info),
+          sizeBytes: migration.coverSize,
+        });
       }
     }
   }
 
   console.log(
     `[Sync] Task summary: ${bookInfos.length} books, ` +
-    `upload: ${uploadTasks.length}, download: ${downloadTasks.length}`,
+      `upload: ${uploadTasks.length}, download: ${downloadTasks.length}`,
   );
 
   if (uploadTasks.length > 0) {
@@ -265,22 +520,7 @@ export async function syncFiles(
       `[Sync] 📤 Starting upload of ${uploadTasks.length} files (${UPLOAD_CONCURRENCY} concurrent)...`,
     );
     const uploadStart = Date.now();
-    let completed = 0;
-    const total = uploadTasks.length;
-    const tasksWithProgress = uploadTasks.map((task, index) => async () => {
-      onProgress?.({
-        phase: "files",
-        operation: "upload",
-        currentFile: `File ${index + 1}`,
-        completedFiles: completed,
-        totalFiles: total,
-        message: `Uploading file ${completed + 1}/${total}...`,
-      });
-      const result = await task();
-      completed++;
-      return result;
-    });
-    const uploadResults = await parallelLimit(tasksWithProgress, UPLOAD_CONCURRENCY);
+    const uploadResults = await runFileTasks(uploadTasks, "upload", UPLOAD_CONCURRENCY, onProgress);
     filesUploaded = uploadResults.filter((r) => r).length;
     filesUploadFailed = uploadResults.length - filesUploaded;
     console.log(
@@ -293,22 +533,12 @@ export async function syncFiles(
       `[Sync] 📥 Starting download of ${downloadTasks.length} files (${DOWNLOAD_CONCURRENCY} concurrent)...`,
     );
     const downloadStart = Date.now();
-    let completed = 0;
-    const total = downloadTasks.length;
-    const tasksWithProgress = downloadTasks.map((task, index) => async () => {
-      onProgress?.({
-        phase: "files",
-        operation: "download",
-        currentFile: `File ${index + 1}`,
-        completedFiles: completed,
-        totalFiles: total,
-        message: `Downloading file ${completed + 1}/${total}...`,
-      });
-      const result = await task();
-      completed++;
-      return result;
-    });
-    const downloadResults = await parallelLimit(tasksWithProgress, DOWNLOAD_CONCURRENCY);
+    const downloadResults = await runFileTasks(
+      downloadTasks,
+      "download",
+      DOWNLOAD_CONCURRENCY,
+      onProgress,
+    );
     filesDownloaded = downloadResults.filter((r) => r).length;
     filesDownloadFailed = downloadResults.length - filesDownloaded;
     console.log(
@@ -322,6 +552,16 @@ export async function syncFiles(
   }
   await cleanupLocalOrphans(adapter, appDataDir, currentBookIds);
 
+  await saveRemoteFileManifest(
+    backend,
+    bookInfos,
+    remoteFileAtNew,
+    remoteCoverAtNew,
+    remoteFileSizeAtNew,
+    remoteCoverSizeAtNew,
+    listings.manifest,
+  );
+
   console.log(`[Sync] ✅ File sync completed in ${Date.now() - syncFilesStart}ms`);
   return { filesUploaded, filesDownloaded, filesUploadFailed, filesDownloadFailed };
 }
@@ -330,8 +570,19 @@ export async function syncFiles(
 
 async function loadRemoteListings(
   backend: ISyncBackend,
-  currentBookIds: Set<string>,
+  bookInfos: BookInfo[],
+  localExistsMap: Map<string, boolean>,
+  options: Pick<SyncFilesOptions, "forceDownloadAll" | "downloadRemoteBooks">,
 ): Promise<RemoteListings> {
+  const currentBookIds = new Set(bookInfos.map((i) => i.book.id));
+  const manifest = await loadRemoteFileManifest(backend);
+  if (manifest && canUseRemoteFileManifest(manifest, bookInfos, localExistsMap, options)) {
+    console.log(
+      `[Sync] Using remote file manifest with ${Object.keys(manifest.books).length} entries`,
+    );
+    return buildListingsFromManifest(manifest, currentBookIds);
+  }
+
   const settled = await Promise.allSettled([
     backend.listDir(REMOTE_BOOKS_ROOT),
     backend.listDir(REMOTE_FILES),
@@ -366,6 +617,8 @@ async function loadRemoteListings(
       matched.add(match);
     }
   }
+  const fileSizeByBookId = new Map<string, number>();
+  const coverSizeByBookId = new Map<string, number>();
 
   const orphanBookDirs: { folderName: string; bookId: string }[] = [];
   const unknownBookDirs: { folderName: string }[] = [];
@@ -380,12 +633,179 @@ async function loadRemoteListings(
   }
 
   return {
+    source: "scan",
+    manifest,
     bookDirByBookId,
+    filePathByBookId: new Map(),
+    coverPathByBookId: new Map(),
+    fileSizeByBookId,
+    coverSizeByBookId,
     legacyFileNames: new Set(legacyFiles.filter((f) => !f.isDirectory).map((f) => f.name)),
     legacyCoverNames: new Set(legacyCovers.filter((f) => !f.isDirectory).map((f) => f.name)),
+    legacyFileSizeByName: new Map(
+      legacyFiles
+        .filter((f) => !f.isDirectory && isPositiveFiniteNumber(f.size))
+        .map((f) => [f.name, f.size]),
+    ),
+    legacyCoverSizeByName: new Map(
+      legacyCovers
+        .filter((f) => !f.isDirectory && isPositiveFiniteNumber(f.size))
+        .map((f) => [f.name, f.size]),
+    ),
     orphanBookDirs,
     unknownBookDirs,
   };
+}
+
+async function loadRemoteFileManifest(backend: ISyncBackend): Promise<RemoteFileManifest | null> {
+  try {
+    const manifest = await backend.getJSON<RemoteFileManifest>(REMOTE_FILE_MANIFEST);
+    if (
+      !manifest ||
+      manifest.version !== 1 ||
+      !manifest.books ||
+      typeof manifest.books !== "object"
+    ) {
+      return null;
+    }
+    return manifest;
+  } catch (e) {
+    console.warn("[Sync] Failed to load remote file manifest; falling back to directory scan:", e);
+    return null;
+  }
+}
+
+function canUseRemoteFileManifest(
+  manifest: RemoteFileManifest,
+  bookInfos: BookInfo[],
+  localExistsMap: Map<string, boolean>,
+  options: Pick<SyncFilesOptions, "forceDownloadAll" | "downloadRemoteBooks">,
+): boolean {
+  for (const info of bookInfos) {
+    const entry = manifest.books[info.book.id];
+    const localFileExists = localExistsMap.get(info.localFilePath) ?? false;
+    const localCoverExists = localExistsMap.get(info.localCoverPath) ?? false;
+    const needsRemoteBook =
+      info.hasFile &&
+      (options.forceDownloadAll || (options.downloadRemoteBooks && !localFileExists));
+    const needsRemoteCover = info.hasCover && (options.forceDownloadAll || !localCoverExists);
+
+    if (!entry && (needsRemoteBook || needsRemoteCover)) return false;
+    if (entry && needsRemoteBook && !entry.filePath) return false;
+    if (entry && needsRemoteCover && !entry.coverPath) return false;
+  }
+  return true;
+}
+
+function buildListingsFromManifest(
+  manifest: RemoteFileManifest,
+  currentBookIds: Set<string>,
+): RemoteListings {
+  const bookDirByBookId = new Map<string, string>();
+  const filePathByBookId = new Map<string, string>();
+  const coverPathByBookId = new Map<string, string>();
+  const fileSizeByBookId = new Map<string, number>();
+  const coverSizeByBookId = new Map<string, number>();
+
+  for (const [bookId, entry] of Object.entries(manifest.books)) {
+    if (!currentBookIds.has(bookId)) continue;
+    bookDirByBookId.set(bookId, entry.folderName);
+    if (entry.filePath) filePathByBookId.set(bookId, entry.filePath);
+    if (entry.coverPath) coverPathByBookId.set(bookId, entry.coverPath);
+    if (isPositiveFiniteNumber(entry.fileSize)) fileSizeByBookId.set(bookId, entry.fileSize);
+    if (isPositiveFiniteNumber(entry.coverSize)) coverSizeByBookId.set(bookId, entry.coverSize);
+  }
+
+  return {
+    source: "manifest",
+    manifest,
+    bookDirByBookId,
+    filePathByBookId,
+    coverPathByBookId,
+    fileSizeByBookId,
+    coverSizeByBookId,
+    legacyFileNames: new Set(),
+    legacyCoverNames: new Set(),
+    legacyFileSizeByName: new Map(),
+    legacyCoverSizeByName: new Map(),
+    orphanBookDirs: [],
+    unknownBookDirs: [],
+  };
+}
+
+async function saveRemoteFileManifest(
+  backend: ISyncBackend,
+  bookInfos: BookInfo[],
+  remoteFileAtNew: Map<string, boolean>,
+  remoteCoverAtNew: Map<string, boolean>,
+  remoteFileSizeAtNew: Map<string, number>,
+  remoteCoverSizeAtNew: Map<string, number>,
+  previousManifest: RemoteFileManifest | null,
+): Promise<void> {
+  const books: RemoteFileManifest["books"] = {};
+  for (const info of bookInfos) {
+    const hasRemoteFile = remoteFileAtNew.get(info.book.id) ?? false;
+    const hasRemoteCover = remoteCoverAtNew.get(info.book.id) ?? false;
+    if (!hasRemoteFile && !hasRemoteCover) continue;
+    books[info.book.id] = {
+      folderName: info.expectedFolderName,
+      ...(hasRemoteFile ? { filePath: info.remoteFilePath } : {}),
+      ...(hasRemoteCover ? { coverPath: info.remoteCoverPath } : {}),
+      ...(hasRemoteFile && remoteFileSizeAtNew.has(info.book.id)
+        ? { fileSize: remoteFileSizeAtNew.get(info.book.id) }
+        : {}),
+      ...(hasRemoteCover && remoteCoverSizeAtNew.has(info.book.id)
+        ? { coverSize: remoteCoverSizeAtNew.get(info.book.id) }
+        : {}),
+      updatedAt: Date.now(),
+    };
+  }
+
+  if (manifestBooksEqual(previousManifest?.books ?? {}, books)) {
+    return;
+  }
+
+  if (!previousManifest && Object.keys(books).length === 0) {
+    return;
+  }
+
+  try {
+    await backend.putJSON<RemoteFileManifest>(REMOTE_FILE_MANIFEST, {
+      version: 1,
+      generatedAt: Date.now(),
+      books,
+    });
+  } catch (e) {
+    console.warn("[Sync] Failed to save remote file manifest:", e);
+  }
+}
+
+function manifestBooksEqual(
+  previous: RemoteFileManifest["books"],
+  next: RemoteFileManifest["books"],
+): boolean {
+  const previousIds = Object.keys(previous).sort();
+  const nextIds = Object.keys(next).sort();
+  if (previousIds.length !== nextIds.length) return false;
+
+  for (let i = 0; i < previousIds.length; i++) {
+    const id = previousIds[i];
+    if (id !== nextIds[i]) return false;
+
+    const previousEntry = previous[id];
+    const nextEntry = next[id];
+    if (
+      previousEntry.folderName !== nextEntry.folderName ||
+      previousEntry.filePath !== nextEntry.filePath ||
+      previousEntry.coverPath !== nextEntry.coverPath ||
+      previousEntry.fileSize !== nextEntry.fileSize ||
+      previousEntry.coverSize !== nextEntry.coverSize
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**
@@ -405,6 +825,8 @@ async function migrateBookRemoteState(
   const existingFolderName = listings.bookDirByBookId.get(book.id);
   let fileAtNew = false;
   let coverAtNew = false;
+  let fileSize = listings.fileSizeByBookId.get(book.id);
+  let coverSize = listings.coverSizeByBookId.get(book.id);
 
   if (existingFolderName) {
     if (existingFolderName !== info.expectedFolderName) {
@@ -421,27 +843,45 @@ async function migrateBookRemoteState(
         const ext = getExt(f.name);
         if (!ext) continue;
         const cover = isCoverFileName(f.name);
-        const target = cover
-          ? buildBookRemoteCover(book, ext)
-          : buildBookRemoteFile(book, ext);
+        const target = cover ? buildBookRemoteCover(book, ext) : buildBookRemoteFile(book, ext);
         try {
           await backend.move(`${oldDir}/${f.name}`, target);
-          if (cover) coverAtNew = true;
-          else fileAtNew = true;
+          if (cover) {
+            coverAtNew = true;
+            if (isPositiveFiniteNumber(f.size)) coverSize = f.size;
+          } else {
+            fileAtNew = true;
+            if (isPositiveFiniteNumber(f.size)) fileSize = f.size;
+          }
         } catch (e) {
           console.warn(`[Sync] Folder-rename MOVE failed for ${book.id} (${f.name}):`, e);
           if (await backend.exists(target)) {
-            try { await backend.delete(`${oldDir}/${f.name}`); } catch {}
-            if (cover) coverAtNew = true;
-            else fileAtNew = true;
+            try {
+              await backend.delete(`${oldDir}/${f.name}`);
+            } catch {}
+            if (cover) {
+              coverAtNew = true;
+              if (isPositiveFiniteNumber(f.size)) coverSize = f.size;
+            } else {
+              fileAtNew = true;
+              if (isPositiveFiniteNumber(f.size)) fileSize = f.size;
+            }
           }
         }
       }
-      try { await backend.delete(oldDir); } catch {}
+      try {
+        await backend.delete(oldDir);
+      } catch {}
       // Update in-memory map so orphan cleanup downstream doesn't see this as unknown.
       listings.bookDirByBookId.delete(book.id);
       listings.bookDirByBookId.set(book.id, info.expectedFolderName);
     } else {
+      if (listings.source === "manifest") {
+        fileAtNew = listings.filePathByBookId.get(book.id) === info.remoteFilePath;
+        coverAtNew = listings.coverPathByBookId.get(book.id) === info.remoteCoverPath;
+        return { fileAtNew, coverAtNew, fileSize, coverSize };
+      }
+
       // Folder name matches. Peek inside to verify which files are present.
       const dir = `${REMOTE_BOOKS_ROOT}/${existingFolderName}`;
       let current: RemoteFile[] = [];
@@ -455,8 +895,14 @@ async function migrateBookRemoteState(
       const expectedCoverName = info.coverExt ? `${sanitized}.${info.coverExt}` : "";
       for (const f of current) {
         if (f.isDirectory) continue;
-        if (expectedFileName && f.name === expectedFileName) fileAtNew = true;
-        if (expectedCoverName && f.name === expectedCoverName) coverAtNew = true;
+        if (expectedFileName && f.name === expectedFileName) {
+          fileAtNew = true;
+          if (isPositiveFiniteNumber(f.size)) fileSize = f.size;
+        }
+        if (expectedCoverName && f.name === expectedCoverName) {
+          coverAtNew = true;
+          if (isPositiveFiniteNumber(f.size)) coverSize = f.size;
+        }
       }
     }
   }
@@ -467,6 +913,7 @@ async function migrateBookRemoteState(
     try {
       await backend.move(legacy, info.remoteFilePath);
       fileAtNew = true;
+      fileSize = listings.legacyFileSizeByName.get(info.legacyRemoteFileName) ?? fileSize;
       console.log(`[Sync] 🔁 Migrated legacy file → ${info.remoteFilePath}`);
     } catch (e) {
       console.warn(`[Sync] Legacy file MOVE failed for ${book.id}:`, e);
@@ -474,6 +921,7 @@ async function migrateBookRemoteState(
         try {
           await backend.delete(legacy);
           fileAtNew = true;
+          fileSize = listings.legacyFileSizeByName.get(info.legacyRemoteFileName) ?? fileSize;
           console.log(`[Sync] 🧹 Deleted redundant legacy file ${info.legacyRemoteFileName}`);
         } catch {}
       }
@@ -485,6 +933,7 @@ async function migrateBookRemoteState(
     try {
       await backend.move(legacy, info.remoteCoverPath);
       coverAtNew = true;
+      coverSize = listings.legacyCoverSizeByName.get(info.legacyRemoteCoverName) ?? coverSize;
       console.log(`[Sync] 🔁 Migrated legacy cover → ${info.remoteCoverPath}`);
     } catch (e) {
       console.warn(`[Sync] Legacy cover MOVE failed for ${book.id}:`, e);
@@ -492,31 +941,38 @@ async function migrateBookRemoteState(
         try {
           await backend.delete(legacy);
           coverAtNew = true;
+          coverSize = listings.legacyCoverSizeByName.get(info.legacyRemoteCoverName) ?? coverSize;
           console.log(`[Sync] 🧹 Deleted redundant legacy cover ${info.legacyRemoteCoverName}`);
         } catch {}
       }
     }
   }
 
-  return { fileAtNew, coverAtNew };
+  return { fileAtNew, coverAtNew, fileSize, coverSize };
 }
 
-function buildUploadFileTask(backend: ISyncBackend, info: BookInfo): () => Promise<boolean> {
-  return async () => {
-    const adapter = getSyncAdapter();
-    const taskStart = Date.now();
-    const bookTitle = info.book.title || "未知书籍";
-    try {
-      console.log(`[Sync] 📤 Uploading book: ${bookTitle} → ${info.remoteFilePath}`);
-      const data = await adapter.readFileBytes(info.localFilePath);
-      const sizeMB = (data.length / 1024 / 1024).toFixed(2);
-      await backend.put(info.remoteFilePath, data);
-      console.log(`[Sync] ✓ Uploaded "${bookTitle}" (${sizeMB} MB) in ${Date.now() - taskStart}ms`);
-      return true;
-    } catch (e) {
-      console.log(`[Sync] ✗ Failed to upload "${bookTitle}": ${e}`);
-      return false;
-    }
+function buildUploadFileTask(backend: ISyncBackend, info: BookInfo): FileTask {
+  const bookTitle = info.book.title || "未知书籍";
+  return {
+    label: bookTitle,
+    run: async (onProgress) => {
+      const taskStart = Date.now();
+      try {
+        console.log(`[Sync] 📤 Uploading book: ${bookTitle} → ${info.remoteFilePath}`);
+        const bytes = await uploadFileToRemote(
+          backend,
+          info.remoteFilePath,
+          info.localFilePath,
+          onProgress,
+        );
+        const size = bytes === null ? "" : ` (${(bytes / 1024 / 1024).toFixed(2)} MB)`;
+        console.log(`[Sync] ✓ Uploaded "${bookTitle}"${size} in ${Date.now() - taskStart}ms`);
+        return true;
+      } catch (e) {
+        console.log(`[Sync] ✗ Failed to upload "${bookTitle}": ${e}`);
+        return false;
+      }
+    },
   };
 }
 
@@ -524,65 +980,81 @@ function buildDownloadFileTask(
   backend: ISyncBackend,
   info: BookInfo,
   setBookSyncStatus: (id: string, status: "local" | "remote") => Promise<void>,
-): () => Promise<boolean> {
-  return async () => {
-    const adapter = getSyncAdapter();
-    const taskStart = Date.now();
-    const bookTitle = info.book.title || "未知书籍";
-    try {
-      console.log(`[Sync] 📥 Downloading book: ${bookTitle} ← ${info.remoteFilePath}`);
-      const data = await backend.get(info.remoteFilePath);
-      const sizeMB = (data.length / 1024 / 1024).toFixed(2);
-      const dir = getDirName(info.localFilePath);
-      if (dir) await adapter.ensureDir(dir);
-      await adapter.writeFileBytes(info.localFilePath, data);
-      await setBookSyncStatus(info.book.id, "local");
-      console.log(`[Sync] ✓ Downloaded "${bookTitle}" (${sizeMB} MB) in ${Date.now() - taskStart}ms`);
-      return true;
-    } catch (e) {
-      console.log(`[Sync] ✗ Failed to download "${bookTitle}": ${e}`);
-      return false;
-    }
+): FileTask {
+  const bookTitle = info.book.title || "未知书籍";
+  return {
+    label: bookTitle,
+    run: async (onProgress) => {
+      const taskStart = Date.now();
+      try {
+        console.log(`[Sync] 📥 Downloading book: ${bookTitle} ← ${info.remoteFilePath}`);
+        const bytes = await downloadRemoteFileToPath(
+          backend,
+          info.remoteFilePath,
+          info.localFilePath,
+          onProgress,
+        );
+        await setBookSyncStatus(info.book.id, "local");
+        const size = bytes === null ? "" : ` (${(bytes / 1024 / 1024).toFixed(2)} MB)`;
+        console.log(`[Sync] ✓ Downloaded "${bookTitle}"${size} in ${Date.now() - taskStart}ms`);
+        return true;
+      } catch (e) {
+        console.log(`[Sync] ✗ Failed to download "${bookTitle}": ${e}`);
+        return false;
+      }
+    },
   };
 }
 
-function buildUploadCoverTask(backend: ISyncBackend, info: BookInfo): () => Promise<boolean> {
-  return async () => {
-    const adapter = getSyncAdapter();
-    const taskStart = Date.now();
-    const bookTitle = info.book.title || "未知书籍";
-    try {
-      console.log(`[Sync] 📤 Uploading cover: ${bookTitle} → ${info.remoteCoverPath}`);
-      const data = await adapter.readFileBytes(info.localCoverPath);
-      const sizeKB = (data.length / 1024).toFixed(2);
-      await backend.put(info.remoteCoverPath, data);
-      console.log(`[Sync] ✓ Uploaded cover "${bookTitle}" (${sizeKB} KB) in ${Date.now() - taskStart}ms`);
-      return true;
-    } catch (e) {
-      console.log(`[Sync] ✗ Failed to upload cover "${bookTitle}": ${e}`);
-      return false;
-    }
+function buildUploadCoverTask(backend: ISyncBackend, info: BookInfo): FileTask {
+  const bookTitle = info.book.title || "未知书籍";
+  return {
+    label: `${bookTitle} cover`,
+    run: async (onProgress) => {
+      const taskStart = Date.now();
+      try {
+        console.log(`[Sync] 📤 Uploading cover: ${bookTitle} → ${info.remoteCoverPath}`);
+        const bytes = await uploadFileToRemote(
+          backend,
+          info.remoteCoverPath,
+          info.localCoverPath,
+          onProgress,
+        );
+        const size = bytes === null ? "" : ` (${(bytes / 1024).toFixed(2)} KB)`;
+        console.log(`[Sync] ✓ Uploaded cover "${bookTitle}"${size} in ${Date.now() - taskStart}ms`);
+        return true;
+      } catch (e) {
+        console.log(`[Sync] ✗ Failed to upload cover "${bookTitle}": ${e}`);
+        return false;
+      }
+    },
   };
 }
 
-function buildDownloadCoverTask(backend: ISyncBackend, info: BookInfo): () => Promise<boolean> {
-  return async () => {
-    const adapter = getSyncAdapter();
-    const taskStart = Date.now();
-    const bookTitle = info.book.title || "未知书籍";
-    try {
-      console.log(`[Sync] 📥 Downloading cover: ${bookTitle} ← ${info.remoteCoverPath}`);
-      const data = await backend.get(info.remoteCoverPath);
-      const sizeKB = (data.length / 1024).toFixed(2);
-      const dir = getDirName(info.localCoverPath);
-      if (dir) await adapter.ensureDir(dir);
-      await adapter.writeFileBytes(info.localCoverPath, data);
-      console.log(`[Sync] ✓ Downloaded cover "${bookTitle}" (${sizeKB} KB) in ${Date.now() - taskStart}ms`);
-      return true;
-    } catch (e) {
-      console.log(`[Sync] ✗ Failed to download cover "${bookTitle}": ${e}`);
-      return false;
-    }
+function buildDownloadCoverTask(backend: ISyncBackend, info: BookInfo): FileTask {
+  const bookTitle = info.book.title || "未知书籍";
+  return {
+    label: `${bookTitle} cover`,
+    run: async (onProgress) => {
+      const taskStart = Date.now();
+      try {
+        console.log(`[Sync] 📥 Downloading cover: ${bookTitle} ← ${info.remoteCoverPath}`);
+        const bytes = await downloadRemoteFileToPath(
+          backend,
+          info.remoteCoverPath,
+          info.localCoverPath,
+          onProgress,
+        );
+        const size = bytes === null ? "" : ` (${(bytes / 1024).toFixed(2)} KB)`;
+        console.log(
+          `[Sync] ✓ Downloaded cover "${bookTitle}"${size} in ${Date.now() - taskStart}ms`,
+        );
+        return true;
+      } catch (e) {
+        console.log(`[Sync] ✗ Failed to download cover "${bookTitle}": ${e}`);
+        return false;
+      }
+    },
   };
 }
 
@@ -600,12 +1072,18 @@ async function cleanupRemoteOrphans(
     tasks.push(async () => {
       try {
         let children: RemoteFile[] = [];
-        try { children = await backend.listDir(dir); } catch {}
+        try {
+          children = await backend.listDir(dir);
+        } catch {}
         for (const c of children) {
           if (c.isDirectory) continue;
-          try { await backend.delete(`${dir}/${c.name}`); } catch {}
+          try {
+            await backend.delete(`${dir}/${c.name}`);
+          } catch {}
         }
-        try { await backend.delete(dir); } catch {}
+        try {
+          await backend.delete(dir);
+        } catch {}
         console.log(`[Sync] 🗑️ Deleted remote orphan book folder: ${orphan.folderName}`);
         return true;
       } catch (e) {
@@ -760,16 +1238,6 @@ export async function downloadBookFile(
 
     onProgress?.({ downloaded: 0, total: 100 });
 
-    // Use progress-aware download if backend supports it
-    const getWithProgress = (p: string) => {
-      if (backend.getWithProgress) {
-        return backend.getWithProgress(p, (loaded, total) => {
-          if (total > 0) onProgress?.({ downloaded: loaded, total });
-        });
-      }
-      return backend.get(p);
-    };
-
     // Track whether *every* failure we saw was a 404. If so, the remote
     // genuinely doesn't have the file. If at least one attempt failed with
     // some other error, it's an "error" outcome — the caller can retry.
@@ -779,10 +1247,18 @@ export async function downloadBookFile(
       if (!/404|not found/i.test(msg)) sawNon404Error = true;
     };
 
-    let data: Uint8Array | null = null;
+    const appDataDir = await adapter.getAppDataDir();
+    const localPath = isAbsoluteOrProtocolPath(filePath)
+      ? filePath
+      : adapter.joinPath(appDataDir, filePath);
+    const reportDownloadProgress = (loaded: number, total: number) => {
+      if (total > 0) onProgress?.({ downloaded: loaded, total });
+    };
+    let downloaded = false;
     if (newPath) {
       try {
-        data = await getWithProgress(newPath);
+        await downloadRemoteFileToPath(backend, newPath, localPath, reportDownloadProgress);
+        downloaded = true;
         console.log(`[Sync] Downloaded ${newPath} (new layout)`);
       } catch (e) {
         noteFailure(e);
@@ -792,9 +1268,10 @@ export async function downloadBookFile(
         }
       }
     }
-    if (!data) {
+    if (!downloaded) {
       try {
-        data = await getWithProgress(legacyPath);
+        await downloadRemoteFileToPath(backend, legacyPath, localPath, reportDownloadProgress);
+        downloaded = true;
         console.log(`[Sync] Downloaded ${legacyPath} (legacy layout)`);
       } catch (e) {
         noteFailure(e);
@@ -806,7 +1283,7 @@ export async function downloadBookFile(
     }
     // Title-based fallback: same book imported separately on each device gets different UUIDs.
     // The DB sync brings both rows over, but the file is only on one id. Match by sanitized title.
-    if (!data && book?.title) {
+    if (!downloaded && book?.title) {
       try {
         const sanitizedTitle = sanitizeBookTitleForFs(book.title);
         const entries = await backend.listDir(REMOTE_BOOKS_ROOT);
@@ -820,7 +1297,8 @@ export async function downloadBookFile(
           const folderPath = `${REMOTE_BOOKS_ROOT}/${folder.name}`;
           const guess = `${folderPath}/${sanitizedTitle}.${ext}`;
           try {
-            data = await getWithProgress(guess);
+            await downloadRemoteFileToPath(backend, guess, localPath, reportDownloadProgress);
+            downloaded = true;
             console.log(`[Sync] Downloaded via title match: ${guess}`);
             break;
           } catch {
@@ -832,7 +1310,8 @@ export async function downloadBookFile(
               );
               if (hit) {
                 const hitPath = `${folderPath}/${hit.name}`;
-                data = await getWithProgress(hitPath);
+                await downloadRemoteFileToPath(backend, hitPath, localPath, reportDownloadProgress);
+                downloaded = true;
                 console.log(`[Sync] Downloaded via folder scan: ${hitPath}`);
                 break;
               }
@@ -841,27 +1320,16 @@ export async function downloadBookFile(
         }
       } catch (e) {
         noteFailure(e);
-        console.warn(`[Sync] Title-based fallback failed:`, e);
+        console.warn("[Sync] Title-based fallback failed:", e);
       }
     }
-    if (!data) {
+    if (!downloaded) {
       console.log(
         `[Sync] Book file not found on remote (new=${newPath}, legacy=${legacyPath}, title=${book?.title ?? "?"})`,
       );
       await setBookSyncStatus(bookId, "remote");
       return sawNon404Error ? "error" : "not-found";
     }
-
-    const sizeMB = (data.length / 1024 / 1024).toFixed(2);
-    console.log(`[Sync] Book ${bookId} fetched (${sizeMB} MB)`);
-
-    const appDataDir = await adapter.getAppDataDir();
-    const localPath = isAbsoluteOrProtocolPath(filePath)
-      ? filePath
-      : adapter.joinPath(appDataDir, filePath);
-    const dir = getDirName(localPath);
-    if (dir) await adapter.ensureDir(dir);
-    await adapter.writeFileBytes(localPath, data);
 
     onProgress?.({ downloaded: 100, total: 100 });
     await setBookSyncStatus(bookId, "local");

--- a/packages/core/src/sync/sync-types.ts
+++ b/packages/core/src/sync/sync-types.ts
@@ -45,6 +45,12 @@ export interface SyncProgress {
   currentFile?: string;
   completedFiles: number;
   totalFiles: number;
+  currentBytes?: number;
+  totalBytes?: number;
+  /** Bytes transferred across the whole current file batch. */
+  totalCurrentBytes?: number;
+  /** Total bytes for the whole current file batch, when every task size is known. */
+  totalTransferBytes?: number;
   message: string;
 }
 
@@ -59,12 +65,29 @@ export const REMOTE_FILES = "/readany/data/file";
 export const REMOTE_COVERS = "/readany/data/cover";
 /** New layout: each book lives in its own folder under this root. */
 export const REMOTE_BOOKS_ROOT = "/readany/data/books";
+/** Lightweight index for the canonical remote book/cover layout. */
+export const REMOTE_FILE_MANIFEST = "/readany/data/file-manifest.json";
 
 /** Known file extensions used to disambiguate cover vs book inside a book folder. */
 export const COVER_EXTENSIONS = new Set<string>([
-  "jpg", "jpeg", "png", "webp", "avif", "gif", "bmp",
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "avif",
+  "gif",
+  "bmp",
 ]);
 
 export const BOOK_EXTENSIONS = new Set<string>([
-  "epub", "pdf", "mobi", "azw", "azw3", "cbz", "cbr", "fb2", "txt", "umd",
+  "epub",
+  "pdf",
+  "mobi",
+  "azw",
+  "azw3",
+  "cbz",
+  "cbr",
+  "fb2",
+  "txt",
+  "umd",
 ]);

--- a/packages/core/src/sync/webdav-backend.ts
+++ b/packages/core/src/sync/webdav-backend.ts
@@ -10,7 +10,7 @@ import {
   type WebDavConfig,
 } from "./sync-backend";
 import { REMOTE_BOOKS_ROOT, REMOTE_COVERS, REMOTE_DATA, REMOTE_FILES } from "./sync-types";
-import { sanitizeWebDavRemoteRoot, WebDavClient } from "./webdav-client";
+import { WebDavClient, sanitizeWebDavRemoteRoot } from "./webdav-client";
 
 /**
  * WebDAV backend implementation.
@@ -20,6 +20,7 @@ export class WebDavBackend implements ISyncBackend {
   readonly type = "webdav" as const;
   private client: WebDavClient;
   private config: WebDavConfig;
+  private directoriesEnsured = false;
 
   constructor(config: WebDavConfig, password: string) {
     this.config = config;
@@ -27,8 +28,10 @@ export class WebDavBackend implements ISyncBackend {
   }
 
   private getRemoteRoot(): string {
-    return sanitizeWebDavRemoteRoot(this.config.remoteRoot ?? DEFAULT_WEBDAV_REMOTE_ROOT)
-      || DEFAULT_WEBDAV_REMOTE_ROOT;
+    return (
+      sanitizeWebDavRemoteRoot(this.config.remoteRoot ?? DEFAULT_WEBDAV_REMOTE_ROOT) ||
+      DEFAULT_WEBDAV_REMOTE_ROOT
+    );
   }
 
   private baseUrlAlreadyIncludesRemoteRoot(): boolean {
@@ -45,8 +48,8 @@ export class WebDavBackend implements ISyncBackend {
     const remoteRoot = this.getRemoteRoot();
     const resolved = path.replace(/^\/readany(?=\/|$)/, `/${remoteRoot}`);
     if (
-      this.baseUrlAlreadyIncludesRemoteRoot()
-      && (resolved === `/${remoteRoot}` || resolved.startsWith(`/${remoteRoot}/`))
+      this.baseUrlAlreadyIncludesRemoteRoot() &&
+      (resolved === `/${remoteRoot}` || resolved.startsWith(`/${remoteRoot}/`))
     ) {
       const deduped = resolved.slice(remoteRoot.length + 1);
       return deduped ? (deduped.startsWith("/") ? deduped : `/${deduped}`) : "/";
@@ -61,6 +64,8 @@ export class WebDavBackend implements ISyncBackend {
   }
 
   async ensureDirectories(): Promise<void> {
+    if (this.directoriesEnsured) return;
+
     // Create directories for the new simple sync (JSON-based)
     await this.client.ensureDirectory(this.resolvePath("/readany/sync"));
     await this.client.ensureDirectory(this.resolvePath(REMOTE_DATA));
@@ -69,6 +74,7 @@ export class WebDavBackend implements ISyncBackend {
     // Legacy directories kept ensured during the transition window (cheap & safe)
     await this.client.mkcol(this.resolvePath(REMOTE_FILES));
     await this.client.mkcol(this.resolvePath(REMOTE_COVERS));
+    this.directoriesEnsured = true;
   }
 
   async put(path: string, data: Uint8Array): Promise<void> {
@@ -89,12 +95,41 @@ export class WebDavBackend implements ISyncBackend {
     }
   }
 
+  async putFile(
+    path: string,
+    localFilePath: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<void> {
+    const resolved = this.resolvePath(path);
+    try {
+      await this.client.putFile(resolved, localFilePath, onProgress);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (!/\b(403|404|409)\b/.test(message)) throw e;
+      const parent = resolved.substring(0, resolved.lastIndexOf("/"));
+      if (!parent || parent === "/") throw e;
+      await this.client.ensureDirectory(parent);
+      await this.client.putFile(resolved, localFilePath, onProgress);
+    }
+  }
+
   async get(path: string): Promise<Uint8Array> {
     return this.client.get(this.resolvePath(path));
   }
 
-  async getWithProgress(path: string, onProgress?: (loaded: number, total: number) => void): Promise<Uint8Array> {
+  async getWithProgress(
+    path: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<Uint8Array> {
     return this.client.getWithProgress(this.resolvePath(path), onProgress);
+  }
+
+  async getFileToPath(
+    path: string,
+    localFilePath: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<void> {
+    return this.client.getFileToPath(this.resolvePath(path), localFilePath, onProgress);
   }
 
   async getJSON<T>(path: string): Promise<T | null> {

--- a/packages/core/src/sync/webdav-client.ts
+++ b/packages/core/src/sync/webdav-client.ts
@@ -150,12 +150,9 @@ function createRequestWebDavError(
 ): WebDavError {
   const err = error as { name?: string; message?: string; cause?: { code?: string } };
   const lowerMessage = err.message?.toLowerCase() ?? "";
-  const connectionMessage = i18n.t(
-    "settings.syncWebdavNetworkError",
-    {
-      defaultValue: "无法连接到 WebDAV 服务器，请检查网络、地址、端口或证书配置。",
-    },
-  );
+  const connectionMessage = i18n.t("settings.syncWebdavNetworkError", {
+    defaultValue: "无法连接到 WebDAV 服务器，请检查网络、地址、端口或证书配置。",
+  });
 
   if (
     err.name === "AbortError" ||
@@ -263,6 +260,10 @@ export class WebDavClient {
       .map((segment) => encodeURIComponent(segment))
       .join("/");
     return `${this.baseUrl}${encoded}`;
+  }
+
+  private getAuthHeaders(): Record<string, string> {
+    return { Authorization: this.authHeader };
   }
 
   /** True if the status code indicates a transient, retry-worthy failure. */
@@ -432,6 +433,32 @@ export class WebDavClient {
     }
   }
 
+  async putFile(
+    path: string,
+    localFilePath: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<void> {
+    const platform = getPlatformService();
+    if (!platform.uploadFile) {
+      throw new Error("Platform does not support direct file upload");
+    }
+
+    const url = this.buildUrl(path);
+    const logPath = path.startsWith("/") ? path : `/${path}`;
+    console.log(`[WebDAV] PUT ${logPath} (file upload)`);
+    const startTime = Date.now();
+    await platform.uploadFile(url, localFilePath, {
+      headers: {
+        ...this.getAuthHeaders(),
+        "Content-Type": "application/octet-stream",
+      },
+      allowInsecure: this.allowInsecure,
+      onProgress,
+    });
+    this.hadAuthSuccess = true;
+    console.log(`[WebDAV] PUT ${logPath} completed in ${Date.now() - startTime}ms`);
+  }
+
   /** Upload a JSON object */
   async putJSON(path: string, data: unknown): Promise<void> {
     await this.put(path, JSON.stringify(data), "application/json");
@@ -497,6 +524,29 @@ export class WebDavClient {
       }
       throw error;
     }
+  }
+
+  async getFileToPath(
+    path: string,
+    localFilePath: string,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<void> {
+    const platform = getPlatformService();
+    if (!platform.downloadFile) {
+      throw new Error("Platform does not support direct file download");
+    }
+
+    const url = this.buildUrl(path);
+    const logPath = path.startsWith("/") ? path : `/${path}`;
+    console.log(`[WebDAV] GET ${logPath} (file download)`);
+    const startTime = Date.now();
+    await platform.downloadFile(url, localFilePath, {
+      headers: this.getAuthHeaders(),
+      allowInsecure: this.allowInsecure,
+      onProgress,
+    });
+    this.hadAuthSuccess = true;
+    console.log(`[WebDAV] GET ${logPath} completed in ${Date.now() - startTime}ms`);
   }
 
   /** Download text content from a path (GET) */
@@ -589,7 +639,9 @@ export class WebDavClient {
     });
     if (!resp.ok && resp.status !== 207) {
       if (resp.status === 404 || resp.status === 409) return [];
-      throw new Error(`WebDAV PROPFIND failed for ${path}: ${resp.status} ${resp.statusText || ""}`);
+      throw new Error(
+        `WebDAV PROPFIND failed for ${path}: ${resp.status} ${resp.statusText || ""}`,
+      );
     }
     const xml = await resp.text();
     return parsePropfindResponse(xml, path);


### PR DESCRIPTION
## Summary
- add direct WebDAV file upload/download paths and remote file manifest support to reduce repeated scans/buffered transfers
- report aggregated byte progress for concurrent file sync and show it on desktop/mobile/LAN sync UIs
- keep the mobile sync action button in the top-right of the status card while rendering progress below it

## Tests
- pnpm --filter @readany/core test -- src/sync/__tests__/sync-files.test.ts src/stores/sync-store.test.ts
- pnpm exec tsc -p packages/core/tsconfig.json --noEmit
- pnpm exec tsc -p packages/app/tsconfig.json --noEmit
- pnpm exec tsc -p packages/app-expo/tsconfig.json --noEmit
- git diff --check
- pnpm exec biome check packages/core/src/sync/sync-files.ts packages/core/src/sync/sync-types.ts packages/core/src/sync/__tests__/sync-files.test.ts packages/app-expo/src/lib/sync/sync-adapter-mobile.ts packages/app-expo/src/screens/settings/SyncSettingsScreen.tsx packages/app-expo/src/screens/settings/sync/LanSection.tsx packages/app-expo/src/screens/settings/sync/sync-styles.ts