### PR TITLE
fix(reader): strip ruby text from selections

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -2031,7 +2031,7 @@ a { color: ${primary} !important; }
     }
 
     function emitSelection(doc, sel, range) {
-      const text = sel.toString().trim();
+      const text = getRangeTextWithoutRuby(range, sel.toString());
       if (!text) return;
 
       const rect = range.getBoundingClientRect();
@@ -2129,6 +2129,18 @@ a { color: ${primary} !important; }
       if (!selection || !selection.rangeCount) return null;
       const range = selection.getRangeAt(0);
       return range && !range.collapsed ? range : null;
+    }
+
+    function getRangeTextWithoutRuby(range, fallback) {
+      try {
+        const fragment = range.cloneContents();
+        fragment.querySelectorAll('rt, rp').forEach(function (node) {
+          node.remove();
+        });
+        const text = (fragment.textContent || '').trim();
+        if (text) return text;
+      } catch {}
+      return (fallback || '').trim();
     }
 
     function getSelectionEndRect(range) {

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -2031,7 +2031,7 @@ a { color: ${primary} !important; }
     }
 
     function emitSelection(doc, sel, range) {
-      const text = sel.toString().trim();
+      const text = getRangeTextWithoutRuby(range, sel.toString());
       if (!text) return;
 
       const rect = range.getBoundingClientRect();
@@ -2129,6 +2129,18 @@ a { color: ${primary} !important; }
       if (!selection || !selection.rangeCount) return null;
       const range = selection.getRangeAt(0);
       return range && !range.collapsed ? range : null;
+    }
+
+    function getRangeTextWithoutRuby(range, fallback) {
+      try {
+        const fragment = range.cloneContents();
+        fragment.querySelectorAll('rt, rp').forEach(function (node) {
+          node.remove();
+        });
+        const text = (fragment.textContent || '').trim();
+        if (text) return text;
+      } catch {}
+      return (fallback || '').trim();
     }
 
     function getSelectionEndRect(range) {

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -112,6 +112,20 @@ function getSelectionRange(selection?: Selection | null): Range | null {
   return range.collapsed ? null : range;
 }
 
+function getRangeTextWithoutRuby(range: Range, fallback = ""): string {
+  try {
+    const fragment = range.cloneContents();
+    for (const node of fragment.querySelectorAll("rt, rp")) {
+      node.remove();
+    }
+    const text = fragment.textContent?.trim();
+    if (text) return text;
+  } catch {
+    // Fall back to the browser selection text if cloning fails.
+  }
+  return fallback.trim();
+}
+
 function getSelectionEndRect(range: Range | null): DOMRect | null {
   if (!range) return null;
 
@@ -1969,7 +1983,7 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
       const sel = doc.getSelection();
       const range = getSelectionRange(sel);
       if (!range) return null;
-      const text = (sel?.toString() || "").trim();
+      const text = getRangeTextWithoutRuby(range, sel?.toString() || "");
       if (!text) return null;
 
       // Get CFI for the selection


### PR DESCRIPTION
## Summary
- Strip ruby annotation nodes from selected text before saving highlights or notes on desktop
- Apply the same selection text cleanup in the mobile WebView reader template
- Rebuild the generated mobile reader.html asset

## Verification
- pnpm --filter app exec tsc --noEmit
- pnpm --filter @readany/app-expo exec tsc --noEmit
- git diff --check