### PR TITLE
fix(sync): improve WebDAV desktop compatibility

### DIFF
--- a/packages/app/src-tauri/Cargo.toml
+++ b/packages/app/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
-tauri-plugin-http = "2"
+tauri-plugin-http = { version = "2", features = ["dangerous-settings"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 sqlite-vec = "0.1"
 zerocopy = "0.8"

--- a/packages/core/src/sync/__tests__/simple-sync.integration.test.ts
+++ b/packages/core/src/sync/__tests__/simple-sync.integration.test.ts
@@ -281,6 +281,7 @@ class FakeSyncDb {
 class MemoryBackend implements ISyncBackend {
   readonly type = "webdav";
   readonly jsonFiles = new Map<string, unknown>();
+  readonly unreadableJsonPaths = new Set<string>();
 
   async testConnection(): Promise<boolean> {
     return true;
@@ -295,6 +296,9 @@ class MemoryBackend implements ISyncBackend {
   }
 
   async getJSON<T>(path: string): Promise<T | null> {
+    if (this.unreadableJsonPaths.has(path)) {
+      throw new Error(`WebDAV GET failed for ${path}: 403 Forbidden`);
+    }
     return this.jsonFiles.has(path) ? clone(this.jsonFiles.get(path) as T) : null;
   }
 
@@ -328,7 +332,9 @@ class MemoryBackend implements ISyncBackend {
   async move(fromPath: string, toPath: string): Promise<void> {
     const data = this.jsonFiles.get(fromPath);
     if (data === undefined) throw new Error(`MemoryBackend MOVE: source not found ${fromPath}`);
-    if (this.jsonFiles.has(toPath)) throw new Error(`MemoryBackend MOVE: destination exists ${toPath}`);
+    if (this.jsonFiles.has(toPath)) {
+      throw new Error(`MemoryBackend MOVE: destination exists ${toPath}`);
+    }
     this.jsonFiles.set(toPath, data);
     this.jsonFiles.delete(fromPath);
   }
@@ -562,5 +568,73 @@ describe("simple sync convergence", () => {
         }
       ).tables,
     ).toHaveProperty("books");
+  });
+
+  it("downloads remote snapshots using the listed path", async () => {
+    class AliasPathBackend extends MemoryBackend {
+      async listDir(path: string): Promise<RemoteFile[]> {
+        const files = await super.listDir(path);
+        return files.map((file) =>
+          file.name === "device-a.json" ? { ...file, path: "/logical/device-a.json" } : file,
+        );
+      }
+
+      async getJSON<T>(path: string): Promise<T | null> {
+        if (path === "/logical/device-a.json") {
+          return super.getJSON<T>("/readany/sync/device-a.json");
+        }
+        if (path === "/readany/sync/device-a.json") {
+          throw new Error("should use listed path");
+        }
+        return super.getJSON<T>(path);
+      }
+    }
+
+    const backend = new AliasPathBackend();
+    const deviceB = new FakeSyncDb();
+
+    backend.jsonFiles.set("/readany/sync/device-a.json", {
+      deviceId: "device-a",
+      timestamp: 1000,
+      since: 0,
+      tables: {
+        books: {
+          records: [bookRow({ updated_at: 1000 })],
+          deletedIds: [],
+        },
+      },
+    });
+
+    now = 3000;
+    const result = await syncDevice("device-b", deviceB, backend);
+
+    expect(result.success).toBe(true);
+    expect(deviceB.get("books", "book-1")).toBeTruthy();
+  });
+
+  it("skips unreadable remote device snapshots and continues syncing", async () => {
+    const backend = new MemoryBackend();
+    const local = new FakeSyncDb();
+    local.insert("books", bookRow({ title: "Local", updated_at: 3000 }));
+
+    backend.jsonFiles.set("/readany/sync/device-locked.json", {
+      deviceId: "locked",
+      timestamp: 1000,
+      since: 0,
+      tables: {
+        books: {
+          records: [bookRow({ id: "remote-book", title: "Locked remote", updated_at: 1000 })],
+          deletedIds: [],
+        },
+      },
+    });
+    backend.unreadableJsonPaths.add("/readany/sync/device-locked.json");
+
+    now = 4000;
+    const result = await syncDevice("device-local", local, backend);
+
+    expect(result.success).toBe(true);
+    expect(local.get("books", "remote-book")).toBeUndefined();
+    expect(backend.jsonFiles.has("/readany/sync/device-device-local.json")).toBe(true);
   });
 });

--- a/packages/core/src/sync/simple-sync.ts
+++ b/packages/core/src/sync/simple-sync.ts
@@ -495,7 +495,7 @@ async function listRemoteDeviceFiles(
       .filter((f) => !f.isDirectory && f.name.startsWith("device-") && f.name.endsWith(".json"))
       .map((f) => ({
         deviceId: f.name.replace(/^device-/, "").replace(/\.json$/, ""),
-        path: `${SYNC_DIR}/${f.name}`,
+        path: f.path || `${SYNC_DIR}/${f.name}`,
       }));
   } catch {
     return [];
@@ -560,15 +560,25 @@ export async function runSimpleSync(
     console.log(`[SimpleSync] Found ${remoteFiles.length} remote device snapshot(s)`);
 
     let totalApplied = 0;
-    let remoteSyncError: string | null = null;
+    let skippedRemoteSnapshots = 0;
     for (const { deviceId, path } of remoteFiles) {
       // Skip our own file
       if (deviceId === localDeviceId) continue;
 
+      let payload: DeviceSyncPayload | null;
       try {
         console.log(`[SimpleSync] Downloading changes from device ${deviceId}...`);
-        const payload = await backend.getJSON<DeviceSyncPayload>(path);
-        if (!payload) continue;
+        payload = await backend.getJSON<DeviceSyncPayload>(path);
+      } catch (e) {
+        skippedRemoteSnapshots++;
+        console.warn(
+          `[SimpleSync] Skipping unreadable remote snapshot from device ${deviceId}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        continue;
+      }
+
+      if (!payload) continue;
+      try {
         console.log(
           `[SimpleSync] Downloaded device ${deviceId}: ${Object.keys(payload.tables).length} table(s)`,
         );
@@ -587,29 +597,15 @@ export async function runSimpleSync(
         totalApplied += result.applied;
       } catch (e) {
         const error = e instanceof Error ? e.message : String(e);
-        remoteSyncError = `Failed to apply changes from device ${deviceId}: ${error}`;
-        console.warn(`[SimpleSync] ${remoteSyncError}`);
-        break;
+        console.warn(`[SimpleSync] Failed to apply changes from device ${deviceId}: ${error}`);
+        throw e;
       }
     }
 
-    if (remoteSyncError) {
-      onProgress?.({
-        phase: "database",
-        operation: "download",
-        completedFiles: 0,
-        totalFiles: 0,
-        message: "同步中止：远端数据读取失败",
-      });
-      return {
-        success: false,
-        changes: totalApplied,
-        filesUploaded: 0,
-        filesDownloaded: 0,
-        filesUploadFailed: 0,
-        filesDownloadFailed: 0,
-        error: remoteSyncError,
-      };
+    if (skippedRemoteSnapshots > 0) {
+      console.warn(
+        `[SimpleSync] Skipped ${skippedRemoteSnapshots} unreadable remote device snapshot(s)`,
+      );
     }
 
     // 3. Collect and push local changes

--- a/packages/core/src/sync/webdav-backend.ts
+++ b/packages/core/src/sync/webdav-backend.ts
@@ -57,6 +57,12 @@ export class WebDavBackend implements ISyncBackend {
     return resolved;
   }
 
+  private joinLogicalPath(parentPath: string, name: string): string {
+    const parent = parentPath.replace(/\/+$/, "") || "/";
+    const encodedName = name.replace(/^\/+|\/+$/g, "");
+    return parent === "/" ? `/${encodedName}` : `${parent}/${encodedName}`;
+  }
+
   async testConnection(): Promise<boolean> {
     await this.client.testConnection();
     await this.ensureDirectories();
@@ -144,7 +150,7 @@ export class WebDavBackend implements ISyncBackend {
     const resources = await this.client.safeReadDir(this.resolvePath(path));
     return resources.map((r) => ({
       name: r.name,
-      path: r.href,
+      path: this.joinLogicalPath(path, r.name),
       size: r.contentLength ?? 0,
       lastModified: r.lastModified ? new Date(r.lastModified).getTime() : 0,
       isDirectory: r.isCollection,

--- a/packages/core/src/sync/webdav-client.test.ts
+++ b/packages/core/src/sync/webdav-client.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { type FetchOptions, type IPlatformService, setPlatformService } from "../services/platform";
+import { WebDavClient } from "./webdav-client";
+
+function installFetchStub(
+  handler: (url: string, options?: FetchOptions) => Response | Promise<Response>,
+): void {
+  setPlatformService({
+    platformType: "web",
+    isMobile: false,
+    isDesktop: false,
+    fetch: handler,
+  } as unknown as IPlatformService);
+}
+
+describe("WebDavClient PROPFIND parsing", () => {
+  afterEach(() => {
+    setPlatformService(null as unknown as IPlatformService);
+  });
+
+  it("keeps only direct children under the requested WebDAV path", async () => {
+    const xml = `<?xml version="1.0" encoding="utf-8"?>
+      <d:multistatus xmlns:d="DAV:">
+        <d:response>
+          <d:href>/dav/readany/sync/</d:href>
+          <d:propstat><d:prop><d:resourcetype><d:collection /></d:resourcetype></d:prop></d:propstat>
+        </d:response>
+        <d:response>
+          <d:href>/dav/readany/sync/device-a.json</d:href>
+          <d:propstat><d:prop><d:resourcetype/><d:getcontentlength>12</d:getcontentlength></d:prop></d:propstat>
+        </d:response>
+        <d:response>
+          <d:href>/dav/readany/sync/archive/</d:href>
+          <d:propstat><d:prop><d:resourcetype><d:collection /></d:resourcetype></d:prop></d:propstat>
+        </d:response>
+        <d:response>
+          <d:href>/dav/readany/sync/archive/device-old.json</d:href>
+          <d:propstat><d:prop><d:resourcetype/><d:getcontentlength>99</d:getcontentlength></d:prop></d:propstat>
+        </d:response>
+        <d:response>
+          <d:href>/dav/other/sync/device-foreign.json</d:href>
+          <d:propstat><d:prop><d:resourcetype/><d:getcontentlength>99</d:getcontentlength></d:prop></d:propstat>
+        </d:response>
+      </d:multistatus>`;
+
+    installFetchStub(() => new Response(xml, { status: 207 }));
+
+    const client = new WebDavClient("https://dav.example.com/dav/readany", "alice", "secret");
+    const resources = await client.propfind("/sync");
+
+    expect(resources).toEqual([
+      {
+        href: "/dav/readany/sync/device-a.json",
+        name: "device-a.json",
+        isCollection: false,
+        contentLength: 12,
+        lastModified: undefined,
+        etag: undefined,
+      },
+      {
+        href: "/dav/readany/sync/archive",
+        name: "archive",
+        isCollection: true,
+        contentLength: undefined,
+        lastModified: undefined,
+        etag: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/sync/webdav-client.ts
+++ b/packages/core/src/sync/webdav-client.ts
@@ -644,7 +644,7 @@ export class WebDavClient {
       );
     }
     const xml = await resp.text();
-    return parsePropfindResponse(xml, path);
+    return parsePropfindResponse(xml, path, this.buildUrl(path));
   }
 
   /** Safely list directory, create if not exists */
@@ -666,28 +666,48 @@ export class WebDavClient {
  * Parse a PROPFIND multistatus XML response.
  * Uses regex-based parsing — no DOM parser needed since the XML structure is predictable.
  */
-function parsePropfindResponse(xml: string, basePath: string): DavResource[] {
+function parsePropfindResponse(xml: string, basePath: string, requestUrl: string): DavResource[] {
+  const blocks: string[] = [];
+
+  // Split by WebDAV response boundaries regardless of namespace prefix.
+  const responseRegex = /<(?:[\w-]+:)?response\b[^>]*>([\s\S]*?)<\/(?:[\w-]+:)?response>/gi;
+  let match = responseRegex.exec(xml);
+  while (match !== null) {
+    blocks.push(match[1]);
+    match = responseRegex.exec(xml);
+  }
+
+  const strictBasePath = normalizeWebDavPath(new URL(requestUrl).pathname);
+  const fallbackBasePath = normalizeWebDavPath(basePath);
+  let resources = parsePropfindBlocks(blocks, strictBasePath, requestUrl);
+
+  if (resources.length === 0 && fallbackBasePath !== strictBasePath) {
+    resources = parsePropfindBlocks(blocks, fallbackBasePath, requestUrl);
+  }
+
+  return resources;
+}
+
+function parsePropfindBlocks(
+  blocks: string[],
+  basePath: string,
+  requestUrl: string,
+): DavResource[] {
   const resources: DavResource[] = [];
 
-  // Split by <D:response> or <d:response> boundaries (case-insensitive)
-  const responseRegex = /<(?:D|d):response[^>]*>([\s\S]*?)<\/(?:D|d):response>/gi;
-  let match: RegExpExecArray | null;
-  while ((match = responseRegex.exec(xml)) !== null) {
-    const block = match[1];
-
+  for (const block of blocks) {
     const href = extractTagContent(block, "href") || "";
-    const isCollection =
-      block.includes("<D:collection") ||
-      block.includes("<d:collection") ||
-      block.includes("<D:collection/") ||
-      block.includes("<d:collection/");
+    const hrefPath = normalizeWebDavPath(getPathnameFromHref(href, requestUrl));
+    if (!isDirectChildPath(basePath, hrefPath)) continue;
+
+    const isCollection = /<(?:(?:\w+):)?collection\b[^>]*\/?>/i.test(block);
     const contentLengthStr = extractTagContent(block, "getcontentlength");
     const lastModified = extractTagContent(block, "getlastmodified");
     const etag = extractTagContent(block, "getetag")?.replace(/"/g, "");
 
     resources.push({
-      href: decodeURIComponent(href),
-      name: filenameFromHref(href),
+      href: hrefPath,
+      name: filenameFromPath(hrefPath),
       isCollection,
       contentLength: contentLengthStr ? Number.parseInt(contentLengthStr, 10) : undefined,
       lastModified: lastModified || undefined,
@@ -695,23 +715,50 @@ function parsePropfindResponse(xml: string, basePath: string): DavResource[] {
     });
   }
 
-  // Filter out the parent directory itself (first result is usually the queried path)
-  const baseNormalized = basePath.replace(/\/+$/, "").replace(/^\/+/, "");
-  return resources.filter((r) => {
-    const hrefNormalized = r.href.replace(/\/+$/, "").replace(/^\/+/, "");
-    return hrefNormalized !== baseNormalized;
-  });
+  return resources;
 }
 
-/** Extract text content of an XML tag (case-insensitive, supports D: and d: namespace prefix) */
+function safeDecodeWebDavPath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function getPathnameFromHref(href: string, requestUrl: string): string {
+  try {
+    return new URL(href, requestUrl).pathname;
+  } catch {
+    return href;
+  }
+}
+
+function normalizeWebDavPath(path: string): string {
+  const decoded = safeDecodeWebDavPath(path).replace(/\/{2,}/g, "/");
+  const trimmed = decoded.replace(/\/+$/, "");
+  return trimmed.startsWith("/") ? trimmed || "/" : `/${trimmed}`;
+}
+
+function isDirectChildPath(basePath: string, hrefPath: string): boolean {
+  if (hrefPath === basePath) return false;
+  const prefix = basePath === "/" ? "/" : `${basePath}/`;
+  if (!hrefPath.startsWith(prefix)) return false;
+  const relative = hrefPath.slice(prefix.length).replace(/\/+$/, "");
+  return relative.length > 0 && !relative.includes("/");
+}
+
+/** Extract text content of an XML tag (case-insensitive, supports arbitrary namespace prefix) */
 function extractTagContent(xml: string, localName: string): string | null {
-  const regex = new RegExp(`<(?:D|d):${localName}[^>]*>([^<]*)<\\/(?:D|d):${localName}>`, "i");
+  const regex = new RegExp(
+    `<(?:[\\w-]+:)?${localName}\\b[^>]*>([^<]*)<\\/(?:[\\w-]+:)?${localName}>`,
+    "i",
+  );
   const match = regex.exec(xml);
   return match ? match[1].trim() : null;
 }
 
-/** Extract filename from a WebDAV href */
-function filenameFromHref(href: string): string {
-  const decoded = decodeURIComponent(href);
-  return decoded.replace(/\/+$/, "").split("/").pop() || "";
+/** Extract filename from a normalized WebDAV path */
+function filenameFromPath(path: string): string {
+  return path.replace(/\/+$/, "").split("/").pop() || "";
 }


### PR DESCRIPTION
## Summary
- enable Tauri HTTP dangerous settings for desktop WebDAV connections that allow insecure certificates
- fix WebDAV PROPFIND namespace/path parsing and directory detection
- make sync use returned remote paths and skip unreadable stale snapshot files without aborting the whole sync
- add WebDAV client and sync integration coverage

## Verification
- pnpm --filter @readany/core exec vitest run src/sync/webdav-client.test.ts src/sync/__tests__/simple-sync.integration.test.ts
- cargo check --manifest-path packages/app/src-tauri/Cargo.toml
- git diff --check