### PR TITLE
feat: add highlight erase action

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -626,6 +626,70 @@
       }
     }
 
+    // User annotation registry: per-doc WeakMap of cfi -> { range }
+    const docAnnotationRegistries = new WeakMap();
+
+    function isUserTapAnnotation(annotation) {
+      const value = annotation?.value;
+      if (!annotation || !value) return false;
+      return !annotation.flash &&
+        annotation.type !== 'tts-highlight' &&
+        !value.startsWith('flash-') &&
+        !value.startsWith('foliate-search:') &&
+        !value.startsWith(TTS_ANNOTATION_PREFIX);
+    }
+
+    function registerAnnotationRange(doc, cfi, range) {
+      let registry = docAnnotationRegistries.get(doc);
+      if (!registry) {
+        registry = new Map();
+        docAnnotationRegistries.set(doc, registry);
+      }
+      registry.set(cfi, { range });
+    }
+
+    function unregisterAnnotationRange(doc, cfi) {
+      const registry = docAnnotationRegistries.get(doc);
+      if (registry) registry.delete(cfi);
+    }
+
+    function isPointInAnnotationRange(doc, x, y) {
+      const registry = docAnnotationRegistries.get(doc);
+      if (!registry || registry.size === 0) return null;
+      const pad = 8;
+      for (const [cfi, entry] of registry) {
+        try {
+          for (const rect of entry.range.getClientRects()) {
+            if (x >= rect.left - pad && x <= rect.right + pad &&
+                y >= rect.top - pad && y <= rect.bottom + pad + 4) {
+              return { cfi, range: entry.range };
+            }
+          }
+        } catch {
+          registry.delete(cfi);
+        }
+      }
+      return null;
+    }
+
+    function postShowAnnotation(value, range) {
+      const doc = range?.startContainer?.ownerDocument;
+      if (!value || !range || !doc) return;
+      armNoteTapGuard(doc, 900);
+      const rect = range.getBoundingClientRect();
+      const iframe = doc.defaultView?.frameElement;
+      const iframeRect = iframe ? iframe.getBoundingClientRect() : { left: 0, top: 0 };
+      postToRN('show-annotation', {
+        value,
+        position: {
+          x: iframeRect.left + rect.left + rect.width / 2,
+          y: iframeRect.top + rect.top - 8,
+          selectionTop: iframeRect.top + rect.top,
+          selectionBottom: iframeRect.top + rect.bottom,
+        },
+      });
+    }
+
     // Note tooltip registry: per-doc WeakMap of cfi -> { range, note }
     const docNoteRegistries = new WeakMap();
 
@@ -1085,11 +1149,17 @@
             draw(Overlayer.squiggly, { color: '#000000', width: 1.5 });
             // Register for long-press tooltip
             if (doc && range && annotation.value) {
+              registerAnnotationRange(doc, annotation.value, range);
               registerNoteRange(doc, annotation.value, range, annotation.note);
               console.log('[draw-annotation] registered note range for:', annotation.value);
             }
           } else {
             draw(Overlayer.highlight, { color: colorMap[color] || colorMap.yellow });
+            if (doc && range && isUserTapAnnotation(annotation)) {
+              registerAnnotationRange(doc, annotation.value, range);
+            } else if (doc && annotation.value) {
+              unregisterAnnotationRange(doc, annotation.value);
+            }
             // Remove stale tooltip registration if note was removed
             if (doc && annotation.value) {
               unregisterNoteRange(doc, annotation.value);
@@ -1097,24 +1167,17 @@
           }
         });
 
-        el.addEventListener('delete-annotation', () => { /* no-op */ });
+        el.addEventListener('delete-annotation', (e) => {
+          const { value, doc } = e.detail || {};
+          if (!value || !doc) return;
+          unregisterAnnotationRange(doc, value);
+          unregisterNoteRange(doc, value);
+        });
 
         el.addEventListener('show-annotation', (e) => {
           const { value, index, range } = e.detail;
           if (!value || !range) return;
-          armNoteTapGuard(range.startContainer.ownerDocument, 900);
-          const rect = range.getBoundingClientRect();
-          const iframe = range.startContainer.ownerDocument?.defaultView?.frameElement;
-          const iframeRect = iframe ? iframe.getBoundingClientRect() : { left: 0, top: 0 };
-          postToRN('show-annotation', {
-            value,
-            position: {
-              x: iframeRect.left + rect.left + rect.width / 2,
-              y: iframeRect.top + rect.top - 8,
-              selectionTop: iframeRect.top + rect.top,
-              selectionBottom: iframeRect.top + rect.bottom,
-            },
-          });
+          postShowAnnotation(value, range);
         });
 
         container.appendChild(el);
@@ -1498,6 +1561,7 @@ a { color: ${primary} !important; }
         }
         const touch = e.touches[0];
         const hitNote = isPointInNoteRange(doc, touch.clientX, touch.clientY);
+        const hitAnnotation = hitNote || isPointInAnnotationRange(doc, touch.clientX, touch.clientY);
         tapState = {
           startedAt: Date.now(),
           startX: touch.clientX,
@@ -1505,8 +1569,9 @@ a { color: ${primary} !important; }
           moved: false,
           target: e.target,
           noteRangeHit: !!hitNote,
+          annotationRangeHit: hitAnnotation,
         };
-        if (hitNote) armNoteTapGuard(doc);
+        if (hitAnnotation) armNoteTapGuard(doc);
       }, { passive: true });
 
       doc.addEventListener('touchmove', (e) => {
@@ -1546,13 +1611,21 @@ a { color: ${primary} !important; }
         tapState = null;
         if (!state || state.moved || e.changedTouches.length !== 1) return;
         if (Date.now() - state.startedAt > MAX_TAP_MS) return;
+        const touch = e.changedTouches[0];
+        const hitAnnotation = state.annotationRangeHit || isPointInAnnotationRange(doc, touch.clientX, touch.clientY);
+        if (hitAnnotation) {
+          e.preventDefault();
+          e.stopPropagation();
+          postShowAnnotation(hitAnnotation.cfi, hitAnnotation.range);
+          return;
+        }
+
         if (state.noteRangeHit || isNoteTapGuardActive(doc)) {
           e.preventDefault();
           e.stopPropagation();
           return;
         }
 
-        const touch = e.changedTouches[0];
         const target = e.target || state.target;
         if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) return;
 

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -626,6 +626,70 @@
       }
     }
 
+    // User annotation registry: per-doc WeakMap of cfi -> { range }
+    const docAnnotationRegistries = new WeakMap();
+
+    function isUserTapAnnotation(annotation) {
+      const value = annotation?.value;
+      if (!annotation || !value) return false;
+      return !annotation.flash &&
+        annotation.type !== 'tts-highlight' &&
+        !value.startsWith('flash-') &&
+        !value.startsWith('foliate-search:') &&
+        !value.startsWith(TTS_ANNOTATION_PREFIX);
+    }
+
+    function registerAnnotationRange(doc, cfi, range) {
+      let registry = docAnnotationRegistries.get(doc);
+      if (!registry) {
+        registry = new Map();
+        docAnnotationRegistries.set(doc, registry);
+      }
+      registry.set(cfi, { range });
+    }
+
+    function unregisterAnnotationRange(doc, cfi) {
+      const registry = docAnnotationRegistries.get(doc);
+      if (registry) registry.delete(cfi);
+    }
+
+    function isPointInAnnotationRange(doc, x, y) {
+      const registry = docAnnotationRegistries.get(doc);
+      if (!registry || registry.size === 0) return null;
+      const pad = 8;
+      for (const [cfi, entry] of registry) {
+        try {
+          for (const rect of entry.range.getClientRects()) {
+            if (x >= rect.left - pad && x <= rect.right + pad &&
+                y >= rect.top - pad && y <= rect.bottom + pad + 4) {
+              return { cfi, range: entry.range };
+            }
+          }
+        } catch {
+          registry.delete(cfi);
+        }
+      }
+      return null;
+    }
+
+    function postShowAnnotation(value, range) {
+      const doc = range?.startContainer?.ownerDocument;
+      if (!value || !range || !doc) return;
+      armNoteTapGuard(doc, 900);
+      const rect = range.getBoundingClientRect();
+      const iframe = doc.defaultView?.frameElement;
+      const iframeRect = iframe ? iframe.getBoundingClientRect() : { left: 0, top: 0 };
+      postToRN('show-annotation', {
+        value,
+        position: {
+          x: iframeRect.left + rect.left + rect.width / 2,
+          y: iframeRect.top + rect.top - 8,
+          selectionTop: iframeRect.top + rect.top,
+          selectionBottom: iframeRect.top + rect.bottom,
+        },
+      });
+    }
+
     // Note tooltip registry: per-doc WeakMap of cfi -> { range, note }
     const docNoteRegistries = new WeakMap();
 
@@ -1085,11 +1149,17 @@
             draw(Overlayer.squiggly, { color: '#000000', width: 1.5 });
             // Register for long-press tooltip
             if (doc && range && annotation.value) {
+              registerAnnotationRange(doc, annotation.value, range);
               registerNoteRange(doc, annotation.value, range, annotation.note);
               console.log('[draw-annotation] registered note range for:', annotation.value);
             }
           } else {
             draw(Overlayer.highlight, { color: colorMap[color] || colorMap.yellow });
+            if (doc && range && isUserTapAnnotation(annotation)) {
+              registerAnnotationRange(doc, annotation.value, range);
+            } else if (doc && annotation.value) {
+              unregisterAnnotationRange(doc, annotation.value);
+            }
             // Remove stale tooltip registration if note was removed
             if (doc && annotation.value) {
               unregisterNoteRange(doc, annotation.value);
@@ -1097,24 +1167,17 @@
           }
         });
 
-        el.addEventListener('delete-annotation', () => { /* no-op */ });
+        el.addEventListener('delete-annotation', (e) => {
+          const { value, doc } = e.detail || {};
+          if (!value || !doc) return;
+          unregisterAnnotationRange(doc, value);
+          unregisterNoteRange(doc, value);
+        });
 
         el.addEventListener('show-annotation', (e) => {
           const { value, index, range } = e.detail;
           if (!value || !range) return;
-          armNoteTapGuard(range.startContainer.ownerDocument, 900);
-          const rect = range.getBoundingClientRect();
-          const iframe = range.startContainer.ownerDocument?.defaultView?.frameElement;
-          const iframeRect = iframe ? iframe.getBoundingClientRect() : { left: 0, top: 0 };
-          postToRN('show-annotation', {
-            value,
-            position: {
-              x: iframeRect.left + rect.left + rect.width / 2,
-              y: iframeRect.top + rect.top - 8,
-              selectionTop: iframeRect.top + rect.top,
-              selectionBottom: iframeRect.top + rect.bottom,
-            },
-          });
+          postShowAnnotation(value, range);
         });
 
         container.appendChild(el);
@@ -1498,6 +1561,7 @@ a { color: ${primary} !important; }
         }
         const touch = e.touches[0];
         const hitNote = isPointInNoteRange(doc, touch.clientX, touch.clientY);
+        const hitAnnotation = hitNote || isPointInAnnotationRange(doc, touch.clientX, touch.clientY);
         tapState = {
           startedAt: Date.now(),
           startX: touch.clientX,
@@ -1505,8 +1569,9 @@ a { color: ${primary} !important; }
           moved: false,
           target: e.target,
           noteRangeHit: !!hitNote,
+          annotationRangeHit: hitAnnotation,
         };
-        if (hitNote) armNoteTapGuard(doc);
+        if (hitAnnotation) armNoteTapGuard(doc);
       }, { passive: true });
 
       doc.addEventListener('touchmove', (e) => {
@@ -1546,13 +1611,21 @@ a { color: ${primary} !important; }
         tapState = null;
         if (!state || state.moved || e.changedTouches.length !== 1) return;
         if (Date.now() - state.startedAt > MAX_TAP_MS) return;
+        const touch = e.changedTouches[0];
+        const hitAnnotation = state.annotationRangeHit || isPointInAnnotationRange(doc, touch.clientX, touch.clientY);
+        if (hitAnnotation) {
+          e.preventDefault();
+          e.stopPropagation();
+          postShowAnnotation(hitAnnotation.cfi, hitAnnotation.range);
+          return;
+        }
+
         if (state.noteRangeHit || isNoteTapGuardActive(doc)) {
           e.preventDefault();
           e.stopPropagation();
           return;
         }
 
-        const touch = e.changedTouches[0];
         const target = e.target || state.target;
         if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) return;
 

--- a/packages/app-expo/src/components/reader/SelectionPopover.tsx
+++ b/packages/app-expo/src/components/reader/SelectionPopover.tsx
@@ -99,8 +99,7 @@ export function SelectionPopover({
     }
   }, [selection.cfi, hasExistingHighlight]);
 
-  const buttonCount =
-    4 + (onNote ? 1 : 0) + (onTranslate ? 1 : 0) + (onSpeak ? 1 : 0) + (canRemoveHighlight ? 1 : 0);
+  const buttonCount = 4 + (onNote ? 1 : 0) + (onTranslate ? 1 : 0) + (onSpeak ? 1 : 0);
   const colorRowItemCount = HIGHLIGHT_COLORS.length + (canRemoveHighlight ? 2 : 0);
   const colorRowWidth = showColors
     ? HIGHLIGHT_COLORS.length * COLOR_DOT_SIZE +
@@ -260,12 +259,6 @@ export function SelectionPopover({
           {onSpeak && (
             <TouchableOpacity style={s.iconBtn} onPress={handleSpeak}>
               <Volume2Icon size={18} color={colors.foreground} />
-            </TouchableOpacity>
-          )}
-
-          {canRemoveHighlight && (
-            <TouchableOpacity style={s.iconBtn} onPress={handleRemove}>
-              <Trash2Icon size={18} color={colors.destructive} />
             </TouchableOpacity>
           )}
         </View>

--- a/packages/app-expo/src/components/reader/SelectionPopover.tsx
+++ b/packages/app-expo/src/components/reader/SelectionPopover.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/Icon";
 import { RichTextEditor } from "@/components/ui/RichTextEditor";
 import type { SelectionEvent } from "@/hooks/use-reader-bridge";
-import { radius, spacing, useColors } from "@/styles/theme";
+import { radius, spacing, useColors, withOpacity } from "@/styles/theme";
 import type { ThemeColors } from "@/styles/theme";
 import { HIGHLIGHT_COLORS, HIGHLIGHT_COLOR_HEX } from "@readany/core/types";
 import type { HighlightColor } from "@readany/core/types";
@@ -38,6 +38,11 @@ const SCREEN_HEIGHT = Dimensions.get("window").height;
 const POPOVER_MARGIN = 8;
 const POPOVER_PADDING = 4;
 const BUTTON_SIZE = 36;
+const COLOR_DOT_SIZE = 28;
+const COLOR_REMOVE_BUTTON_SIZE = 28;
+const COLOR_ROW_GAP = 6;
+const COLOR_ROW_PADDING_X = 8;
+const COLOR_ROW_DIVIDER_WIDTH = 1;
 const GAP = 2;
 const SAFE_TOP = 14;
 const SAFE_BOTTOM = 20;
@@ -79,6 +84,7 @@ export function SelectionPopover({
   const [noteContent, setNoteContent] = useState(existingHighlight?.note || "");
   const existingHighlightNote = existingHighlight?.note || "";
   const hasExistingHighlight = !!existingHighlight;
+  const canRemoveHighlight = hasExistingHighlight && !!onRemoveHighlight;
   const activeHighlightColor = existingHighlight?.color ?? defaultColor;
   const previousSelectionCfiRef = useRef(selection.cfi);
 
@@ -94,15 +100,19 @@ export function SelectionPopover({
   }, [selection.cfi, hasExistingHighlight]);
 
   const buttonCount =
-    4 +
-    (onNote ? 1 : 0) +
-    (onTranslate ? 1 : 0) +
-    (onSpeak ? 1 : 0) +
-    (hasExistingHighlight && onRemoveHighlight ? 1 : 0);
+    4 + (onNote ? 1 : 0) + (onTranslate ? 1 : 0) + (onSpeak ? 1 : 0) + (canRemoveHighlight ? 1 : 0);
+  const colorRowItemCount = HIGHLIGHT_COLORS.length + (canRemoveHighlight ? 2 : 0);
+  const colorRowWidth = showColors
+    ? HIGHLIGHT_COLORS.length * COLOR_DOT_SIZE +
+      (canRemoveHighlight ? COLOR_ROW_DIVIDER_WIDTH + COLOR_REMOVE_BUTTON_SIZE : 0) +
+      Math.max(0, colorRowItemCount - 1) * COLOR_ROW_GAP +
+      COLOR_ROW_PADDING_X * 2
+    : 0;
+  const actionRowWidth = buttonCount * (BUTTON_SIZE + GAP) + POPOVER_PADDING * 2;
   const colorRowHeight = showColors ? 40 : 0;
   const popoverHeight = 44 + colorRowHeight + POPOVER_PADDING * 2 + GAP;
   const popoverWidth = Math.min(
-    buttonCount * (BUTTON_SIZE + GAP) + POPOVER_PADDING * 2,
+    Math.max(actionRowWidth, colorRowWidth + POPOVER_PADDING * 2),
     SCREEN_WIDTH - POPOVER_MARGIN * 2,
   );
 
@@ -203,6 +213,19 @@ export function SelectionPopover({
                 onPress={() => onHighlight(color)}
               />
             ))}
+            {canRemoveHighlight && (
+              <>
+                <View style={s.colorRowDivider} />
+                <TouchableOpacity
+                  style={s.colorRemoveBtn}
+                  onPress={handleRemove}
+                  accessibilityRole="button"
+                  accessibilityLabel={t("notebook.deleteHighlight", "删除高亮")}
+                >
+                  <Trash2Icon size={16} color={colors.destructive} />
+                </TouchableOpacity>
+              </>
+            )}
           </View>
         )}
 
@@ -240,7 +263,7 @@ export function SelectionPopover({
             </TouchableOpacity>
           )}
 
-          {existingHighlight && onRemoveHighlight && (
+          {canRemoveHighlight && (
             <TouchableOpacity style={s.iconBtn} onPress={handleRemove}>
               <Trash2Icon size={18} color={colors.destructive} />
             </TouchableOpacity>
@@ -319,19 +342,33 @@ const makeStyles = (colors: ThemeColors) =>
     colorRow: {
       flexDirection: "row",
       justifyContent: "center",
+      alignItems: "center",
       gap: 6,
       paddingVertical: 6,
       paddingHorizontal: 8,
       marginBottom: GAP,
     },
     colorDot: {
-      width: 28,
-      height: 28,
-      borderRadius: 14,
+      width: COLOR_DOT_SIZE,
+      height: COLOR_DOT_SIZE,
+      borderRadius: COLOR_DOT_SIZE / 2,
     },
     colorDotActive: {
       borderWidth: 2,
       borderColor: colors.primary,
+    },
+    colorRowDivider: {
+      width: COLOR_ROW_DIVIDER_WIDTH,
+      height: 20,
+      backgroundColor: colors.border,
+    },
+    colorRemoveBtn: {
+      width: COLOR_REMOVE_BUTTON_SIZE,
+      height: COLOR_REMOVE_BUTTON_SIZE,
+      borderRadius: radius.lg,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: withOpacity(colors.destructive, 0.08),
     },
     actionRow: {
       flexDirection: "row",

--- a/packages/app/src/components/reader/SelectionPopover.tsx
+++ b/packages/app/src/components/reader/SelectionPopover.tsx
@@ -125,6 +125,20 @@ export function SelectionPopover({
               )}
             </button>
           ))}
+          {annotated && (
+            <>
+              <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+              <button
+                type="button"
+                className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                title={t("notebook.deleteHighlight")}
+                aria-label={t("notebook.deleteHighlight")}
+                onClick={onRemoveHighlight}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </>
+          )}
         </div>
       )}
 

--- a/packages/app/src/components/reader/SelectionPopover.tsx
+++ b/packages/app/src/components/reader/SelectionPopover.tsx
@@ -48,7 +48,7 @@ export function SelectionPopover({
   onTranslate,
   onAskAI,
   onSpeak,
-  onClose: _onClose,
+  onClose,
 }: SelectionPopoverProps) {
   const { t } = useTranslation();
   const [showColors, setShowColors] = useState(!isPdf);
@@ -90,79 +90,76 @@ export function SelectionPopover({
     { icon: Headphones, label: t("tts.speakSelection"), onClick: onSpeak },
   ];
 
-  // For existing annotations, add delete button
-  if (annotated) {
-    buttons.push({
-      icon: Trash2,
-      label: t("common.delete"),
-      onClick: onRemoveHighlight,
-      isHighlight: false,
-      disabled: false,
-    });
-  }
-
   return (
-    <div
-      className="absolute z-50 flex flex-col items-center gap-1"
-      style={{ left: position.x, top: position.y }}
-    >
-      {/* Color picker row */}
-      {showColors && !isPdf && (
-        <div className="flex items-center gap-1 rounded-lg border border-border bg-background p-1.5 shadow-lg">
-          {HIGHLIGHT_COLORS.map((color) => (
-            <button
-              type="button"
-              key={color}
-              className={cn(
-                "flex h-6 w-6 items-center justify-center rounded-full transition-transform hover:scale-110",
-              )}
-              style={{ backgroundColor: HIGHLIGHT_COLOR_HEX[color] }}
-              title={t(`reader.color.${color}`)}
-              onClick={() => handleColorSelect(color)}
-            >
-              {selectedColor === color && (
-                <Check className="h-3.5 w-3.5 text-white drop-shadow-md" />
-              )}
-            </button>
-          ))}
-          {annotated && (
-            <>
-              <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+    <div className="absolute inset-0 z-50">
+      <button
+        type="button"
+        aria-label={t("common.close")}
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+      />
+      <div
+        className="absolute flex flex-col items-center gap-1"
+        style={{ left: position.x, top: position.y }}
+      >
+        {/* Color picker row */}
+        {showColors && !isPdf && (
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-background p-1.5 shadow-lg">
+            {HIGHLIGHT_COLORS.map((color) => (
               <button
                 type="button"
-                className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                title={t("notebook.deleteHighlight")}
-                aria-label={t("notebook.deleteHighlight")}
-                onClick={onRemoveHighlight}
+                key={color}
+                className={cn(
+                  "flex h-6 w-6 items-center justify-center rounded-full transition-transform hover:scale-110",
+                )}
+                style={{ backgroundColor: HIGHLIGHT_COLOR_HEX[color] }}
+                title={t(`reader.color.${color}`)}
+                onClick={() => handleColorSelect(color)}
               >
-                <Trash2 className="h-3.5 w-3.5" />
+                {selectedColor === color && (
+                  <Check className="h-3.5 w-3.5 text-white drop-shadow-md" />
+                )}
               </button>
-            </>
-          )}
-        </div>
-      )}
-
-      {/* Main action buttons */}
-      <div className="flex items-center gap-0.5 rounded-lg border border-border bg-background p-1 shadow-lg">
-        {buttons.map((btn) => (
-          <button
-            type="button"
-            key={btn.label}
-            className={cn(
-              "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
-              btn.disabled ? "cursor-not-allowed opacity-40" : "hover:bg-muted",
-              btn.isHighlight && showColors && !isPdf && "bg-muted",
-              btn.icon === Trash2 &&
-                !btn.disabled &&
-                "hover:bg-destructive/10 hover:text-destructive",
+            ))}
+            {annotated && (
+              <>
+                <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+                <button
+                  type="button"
+                  className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                  title={t("notebook.deleteHighlight")}
+                  aria-label={t("notebook.deleteHighlight")}
+                  onClick={onRemoveHighlight}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </>
             )}
-            title={btn.label}
-            onClick={btn.disabled ? undefined : btn.onClick}
-            disabled={btn.disabled}
-          >
-            <btn.icon className="h-4 w-4" />
-          </button>
-        ))}
+          </div>
+        )}
+
+        {/* Main action buttons */}
+        <div className="flex items-center gap-0.5 rounded-lg border border-border bg-background p-1 shadow-lg">
+          {buttons.map((btn) => (
+            <button
+              type="button"
+              key={btn.label}
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
+                btn.disabled ? "cursor-not-allowed opacity-40" : "hover:bg-muted",
+                btn.isHighlight && showColors && !isPdf && "bg-muted",
+                btn.icon === Trash2 &&
+                  !btn.disabled &&
+                  "hover:bg-destructive/10 hover:text-destructive",
+              )}
+              title={btn.label}
+              onClick={btn.disabled ? undefined : btn.onClick}
+              disabled={btn.disabled}
+            >
+              <btn.icon className="h-4 w-4" />
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a delete highlight button at the end of the desktop highlight color row for existing highlights
- add the same erase action to the mobile color row and keep popover positioning aware of the wider row
- keep the existing action-row trash button behavior unchanged

## Issues
- Fixes #324
- Related to #318

## Verification
- pnpm --filter app exec tsc --noEmit
- pnpm --filter @readany/app-expo exec tsc --noEmit
- pnpm exec biome check packages/app/src/components/reader/SelectionPopover.tsx packages/app-expo/src/components/reader/SelectionPopover.tsx
- git diff --check