### PR TITLE
feat: add per-book reading data reset

### DIFF
--- a/packages/app-expo/src/components/library/BookCard.tsx
+++ b/packages/app-expo/src/components/library/BookCard.tsx
@@ -50,6 +50,7 @@ interface BookCardProps {
   book: Book;
   onOpen: (book: Book) => void;
   onDelete: (bookId: string, options?: { preserveData?: boolean }) => void;
+  onResetReadingData?: (bookId: string) => void;
   onManageTags?: (book: Book) => void;
   onVectorize?: (book: Book) => void;
   isVectorizing?: boolean;
@@ -67,6 +68,7 @@ export const BookCard = memo(function BookCard({
   book,
   onOpen,
   onDelete,
+  onResetReadingData,
   onManageTags,
   onVectorize,
   isVectorizing,
@@ -115,8 +117,6 @@ export const BookCard = memo(function BookCard({
   }, [book.meta.coverUrl]);
 
   const progressPct = Math.round(book.progress * 100);
-  const hasCover = resolvedCoverUrl && !imageError;
-
   const vecPct = vectorProgress
     ? vectorProgress.totalChunks > 0
       ? Math.round((vectorProgress.processedChunks / vectorProgress.totalChunks) * 100)
@@ -405,6 +405,7 @@ export const BookCard = memo(function BookCard({
         onManageTags={onManageTags}
         onVectorize={onVectorize}
         onDelete={onDelete}
+        onResetReadingData={onResetReadingData}
       />
     </>
   );

--- a/packages/app-expo/src/components/library/BookCardActionSheet.tsx
+++ b/packages/app-expo/src/components/library/BookCardActionSheet.tsx
@@ -1,11 +1,12 @@
+import { GroupPickerSheet } from "@/components/library/GroupPickerSheet";
 import {
   CheckIcon,
   DatabaseIcon,
   FolderInputIcon,
   HashIcon,
+  RotateCcwIcon,
   Trash2Icon,
 } from "@/components/ui/Icon";
-import { GroupPickerSheet } from "@/components/library/GroupPickerSheet";
 import { useLibraryStore } from "@/stores/library-store";
 import { type ThemeColors, fontSize, fontWeight, radius, spacing, useColors } from "@/styles/theme";
 import type { Book } from "@readany/core/types";
@@ -31,6 +32,7 @@ interface BookCardActionSheetProps {
   onManageTags?: (book: Book) => void;
   onVectorize?: (book: Book) => void;
   onDelete: (bookId: string, options?: { preserveData?: boolean }) => void;
+  onResetReadingData?: (bookId: string) => void;
 }
 
 export function BookCardActionSheet({
@@ -41,12 +43,14 @@ export function BookCardActionSheet({
   onManageTags,
   onVectorize,
   onDelete,
+  onResetReadingData,
 }: BookCardActionSheetProps) {
   const colors = useColors();
   const styles = useMemo(() => makeStyles(colors), [colors]);
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const { t } = useTranslation();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [preserveDataOnDelete, setPreserveDataOnDelete] = useState(true);
   const [showGroupPicker, setShowGroupPicker] = useState(false);
   const groups = useLibraryStore((state) => state.groups);
@@ -91,7 +95,10 @@ export function BookCardActionSheet({
             if (book.isVectorized) {
               Alert.alert(
                 t("home.vec_reindex", "重新索引"),
-                t("home.vec_reindexConfirm", "该书已完成索引，重新索引将重置现有数据，确定继续吗？"),
+                t(
+                  "home.vec_reindexConfirm",
+                  "该书已完成索引，重新索引将重置现有数据，确定继续吗？",
+                ),
                 [
                   { text: t("common.cancel"), style: "cancel" },
                   { text: t("common.confirm"), onPress: () => onVectorize(book) },
@@ -100,6 +107,18 @@ export function BookCardActionSheet({
             } else {
               onVectorize(book);
             }
+          },
+        }
+      : null,
+    onResetReadingData
+      ? {
+          key: "reset-reading-data",
+          icon: <RotateCcwIcon size={18} color={colors.destructive} />,
+          label: t("library.resetReadingData", "重置阅读数据"),
+          destructive: true,
+          onPress: () => {
+            onClose();
+            setShowResetConfirm(true);
           },
         }
       : null,
@@ -224,6 +243,45 @@ export function BookCardActionSheet({
                 }}
               >
                 <Text style={styles.confirmDangerText}>{t("common.remove", "删除")}</Text>
+              </TouchableOpacity>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      <Modal
+        visible={showResetConfirm}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowResetConfirm(false)}
+      >
+        <Pressable style={styles.confirmOverlay} onPress={() => setShowResetConfirm(false)}>
+          <Pressable style={styles.confirmCard} onPress={() => {}}>
+            <Text style={styles.confirmTitle}>
+              {t("library.resetReadingDataTitle", "重置阅读数据？")}
+            </Text>
+            <Text style={styles.confirmDescription}>
+              {t(
+                "library.resetReadingDataDescription",
+                "这会清空本书的阅读进度、当前位置和阅读字数统计，但不会删除书籍、笔记、高亮或书签。",
+              )}
+            </Text>
+
+            <View style={styles.confirmActions}>
+              <TouchableOpacity
+                style={styles.confirmSecondary}
+                onPress={() => setShowResetConfirm(false)}
+              >
+                <Text style={styles.confirmSecondaryText}>{t("common.cancel", "取消")}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.confirmDanger}
+                onPress={() => {
+                  setShowResetConfirm(false);
+                  onResetReadingData?.(book.id);
+                }}
+              >
+                <Text style={styles.confirmDangerText}>{t("common.reset", "重置")}</Text>
               </TouchableOpacity>
             </View>
           </Pressable>

--- a/packages/app-expo/src/screens/LibraryScreen.tsx
+++ b/packages/app-expo/src/screens/LibraryScreen.tsx
@@ -197,6 +197,7 @@ export function LibraryScreen() {
     loadBooks,
     importBooks,
     removeBook,
+    resetBookReadingData,
     setFilter,
     setGroupView,
     setActiveGroupId,
@@ -685,6 +686,7 @@ export function LibraryScreen() {
             cardWidth={gridItemWidth}
             onOpen={handleOpen}
             onDelete={removeBook}
+            onResetReadingData={resetBookReadingData}
             onManageTags={handleManageTags}
             onVectorize={handleVectorize}
             isVectorizing={vectorizingBookId === item.book.id}
@@ -707,6 +709,7 @@ export function LibraryScreen() {
       handleOpen,
       handleVectorize,
       removeBook,
+      resetBookReadingData,
       s.gridItem,
       selectedBookIds,
       selectionMode,

--- a/packages/app-expo/src/stores/library-store.ts
+++ b/packages/app-expo/src/stores/library-store.ts
@@ -69,6 +69,7 @@ export interface LibraryState {
   setActiveGroupId: (groupId: string) => void;
   addBook: (book: Book) => Promise<void>;
   removeBook: (bookId: string, options?: RemoveBookOptions) => Promise<void>;
+  resetBookReadingData: (bookId: string) => Promise<void>;
   updateBook: (bookId: string, updates: Partial<Book>) => void;
   setFilter: (filter: Partial<LibraryFilter>) => void;
   setViewMode: (mode: LibraryViewMode) => void;
@@ -802,6 +803,23 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
       } catch {
         /* file may not exist */
       }
+    }
+    debouncedSave("library-books", get().books);
+  },
+
+  resetBookReadingData: async (bookId) => {
+    set((state) => ({
+      books: state.books.map((book) =>
+        book.id === bookId ? { ...book, progress: 0, currentCfi: undefined } : book,
+      ),
+    }));
+    try {
+      await db.initDatabase();
+      await db.resetBookReadingData(bookId);
+    } catch (err) {
+      console.error("Failed to reset book reading data:", err);
+      await get().loadBooks();
+      return;
     }
     debouncedSave("library-books", get().books);
   },

--- a/packages/app/src/components/home/BookCard.tsx
+++ b/packages/app/src/components/home/BookCard.tsx
@@ -1,3 +1,4 @@
+import { GroupPickerPopover } from "@/components/home/GroupPickerPopover";
 import { ConfigGuideDialog, type ConfigGuideType } from "@/components/shared/ConfigGuideDialog";
 import {
   Dialog,
@@ -7,7 +8,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { GroupPickerPopover } from "@/components/home/GroupPickerPopover";
 import { useResolvedSrc, useSyncVersion } from "@/hooks/use-resolved-src";
 import { openDesktopBook } from "@/lib/library/open-book";
 /**
@@ -30,6 +30,7 @@ import {
   Loader2,
   MoreVertical,
   Plus,
+  RotateCcw,
   Trash2,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
@@ -50,6 +51,7 @@ export const BookCard = memo(function BookCard({
 }: BookCardProps) {
   const { t } = useTranslation();
   const removeBook = useLibraryStore((s) => s.removeBook);
+  const resetBookReadingData = useLibraryStore((s) => s.resetBookReadingData);
   const closeAppTab = useAppStore((s) => s.removeTab);
   const closeReaderTab = useReaderStore((s) => s.removeTab);
   const allTags = useLibraryStore((s) => s.allTags);
@@ -71,6 +73,7 @@ export const BookCard = memo(function BookCard({
   const [vectorProgress, setVectorProgress] = useState<VectorizeProgress | null>(null);
   const [configGuide, setConfigGuide] = useState<ConfigGuideType>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showResetReadingDataDialog, setShowResetReadingDataDialog] = useState(false);
   const [showReindexConfirm, setShowReindexConfirm] = useState(false);
   const [preserveDataOnDelete, setPreserveDataOnDelete] = useState(true);
   const coverRef = useRef<HTMLDivElement>(null);
@@ -100,7 +103,13 @@ export const BookCard = memo(function BookCard({
       onSelect?.(book.id);
       return;
     }
-    if (showMenu || showDeleteDialog || showReindexConfirm || Date.now() < suppressOpenUntilRef.current) {
+    if (
+      showMenu ||
+      showDeleteDialog ||
+      showResetReadingDataDialog ||
+      showReindexConfirm ||
+      Date.now() < suppressOpenUntilRef.current
+    ) {
       return;
     }
     await openDesktopBook({ book, t });
@@ -113,6 +122,14 @@ export const BookCard = memo(function BookCard({
     setMenuPos(null);
     setPreserveDataOnDelete(true);
     setShowDeleteDialog(true);
+  }, []);
+
+  const handleResetReadingData = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    suppressOpenUntilRef.current = Date.now() + 600;
+    setShowMenu(false);
+    setMenuPos(null);
+    setShowResetReadingDataDialog(true);
   }, []);
 
   const doVectorize = useCallback(async () => {
@@ -153,16 +170,13 @@ export const BookCard = memo(function BookCard({
     [book.isVectorized, hasVectorCapability, vectorizing, doVectorize],
   );
 
-  const handleMoveGroup = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      suppressOpenUntilRef.current = Date.now() + 300;
-      setShowMenu(false);
-      setMenuPos(null);
-      setShowGroupPicker(true);
-    },
-    [],
-  );
+  const handleMoveGroup = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    suppressOpenUntilRef.current = Date.now() + 300;
+    setShowMenu(false);
+    setMenuPos(null);
+    setShowGroupPicker(true);
+  }, []);
 
   const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
     setImageLoaded(event.currentTarget.naturalWidth > 0);
@@ -486,7 +500,15 @@ export const BookCard = memo(function BookCard({
                 </div>
               )}
             </div>
-            {/* Delete button */}
+            {/* Destructive actions */}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10"
+              onClick={handleResetReadingData}
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+              {t("library.resetReadingData", "重置阅读数据")}
+            </button>
             <button
               type="button"
               className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10"
@@ -618,20 +640,68 @@ export const BookCard = memo(function BookCard({
         </DialogContent>
       </Dialog>
 
+      <Dialog open={showResetReadingDataDialog} onOpenChange={setShowResetReadingDataDialog}>
+        <DialogContent className="max-w-md" onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>{t("library.resetReadingDataTitle", "重置阅读数据？")}</DialogTitle>
+            <DialogDescription>
+              {t(
+                "library.resetReadingDataDescription",
+                "这会清空本书的阅读进度、当前位置和阅读字数统计，但不会删除书籍、笔记、高亮或书签。",
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <button
+              type="button"
+              className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowResetReadingDataDialog(false);
+              }}
+            >
+              {t("common.cancel", "取消")}
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-9 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition-colors hover:bg-destructive/90"
+              onClick={async (e) => {
+                e.stopPropagation();
+                suppressOpenUntilRef.current = Date.now() + 600;
+                setShowResetReadingDataDialog(false);
+                const matchingTabIds = useAppStore
+                  .getState()
+                  .tabs.filter((tab) => tab.bookId === book.id)
+                  .map((tab) => tab.id);
+                for (const tabId of matchingTabIds) {
+                  closeAppTab(tabId);
+                  closeReaderTab(tabId);
+                }
+                await resetBookReadingData(book.id);
+              }}
+            >
+              {t("common.reset", "重置")}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Re-index confirmation dialog */}
       <Dialog open={showReindexConfirm} onOpenChange={setShowReindexConfirm}>
         <DialogContent className="max-w-sm" onClick={(e) => e.stopPropagation()}>
           <DialogHeader>
             <DialogTitle>{t("home.vec_reindex")}</DialogTitle>
-            <DialogDescription>
-              {t("home.vec_reindexConfirm")}
-            </DialogDescription>
+            <DialogDescription>{t("home.vec_reindexConfirm")}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <button
               type="button"
               className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-medium transition-colors hover:bg-muted"
-              onClick={(e) => { e.stopPropagation(); setShowReindexConfirm(false); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowReindexConfirm(false);
+              }}
             >
               {t("common.cancel")}
             </button>

--- a/packages/app/src/lib/db/database.ts
+++ b/packages/app/src/lib/db/database.ts
@@ -11,6 +11,7 @@ export {
   getDeletedBookByTitle,
   insertBook,
   updateBook,
+  resetBookReadingData,
   deleteBook,
   getGroups,
   insertGroup,

--- a/packages/app/src/stores/library-store.ts
+++ b/packages/app/src/stores/library-store.ts
@@ -348,6 +348,7 @@ export interface LibraryState {
   setActiveGroupId: (groupId: string) => void;
   addBook: (book: Book) => void;
   removeBook: (bookId: string, options?: RemoveBookOptions) => Promise<void>;
+  resetBookReadingData: (bookId: string) => Promise<void>;
   updateBook: (bookId: string, updates: Partial<Book>) => void;
   setFilter: (filter: Partial<LibraryFilter>) => void;
   setViewMode: (mode: LibraryViewMode) => void;
@@ -821,6 +822,22 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
         console.error("[removeBook] File cleanup error:", err);
       }
     }
+  },
+
+  resetBookReadingData: async (bookId) => {
+    set((state) => ({
+      books: state.books.map((book) =>
+        book.id === bookId ? { ...book, progress: 0, currentCfi: undefined } : book,
+      ),
+    }));
+    try {
+      await db.resetBookReadingData(bookId);
+    } catch (err) {
+      console.error("Failed to reset book reading data:", err);
+      await get().loadBooks();
+      return;
+    }
+    debouncedSave("library-books", get().books);
   },
 
   updateBook: (bookId, updates) => {

--- a/packages/core/src/db/__tests__/book-queries.test.ts
+++ b/packages/core/src/db/__tests__/book-queries.test.ts
@@ -1,5 +1,5 @@
-import type { Book } from "../../types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Book } from "../../types";
 
 // --- Mock db-core ---
 const mockExecute = vi.fn();
@@ -16,7 +16,11 @@ const coreMocks = vi.hoisted(() => ({
   insertTombstone: vi.fn(),
   parseJSON: vi.fn((str: string | null | undefined, fallback: unknown) => {
     if (!str) return fallback;
-    try { return JSON.parse(str); } catch { return fallback; }
+    try {
+      return JSON.parse(str);
+    } catch {
+      return fallback;
+    }
   }),
 }));
 
@@ -26,7 +30,9 @@ const dependencyMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../db-core", () => coreMocks);
-vi.mock("../thread-queries", () => ({ deleteThreadsByBookId: dependencyMocks.deleteThreadsByBookId }));
+vi.mock("../thread-queries", () => ({
+  deleteThreadsByBookId: dependencyMocks.deleteThreadsByBookId,
+}));
 vi.mock("../chunk-queries", () => ({ deleteChunks: dependencyMocks.deleteChunks }));
 
 const {
@@ -35,6 +41,7 @@ const {
   getDeletedBookByFileHash,
   insertBook,
   updateBook,
+  resetBookReadingData,
   deleteBook,
 } = await import("../book-queries");
 
@@ -166,7 +173,7 @@ describe("book-queries", () => {
 
       const book = await getBook("book-1");
       expect(book).not.toBeNull();
-      expect(book!.id).toBe("book-1");
+      expect(book?.id).toBe("book-1");
       expect(mockSelect).toHaveBeenCalledWith(
         "SELECT * FROM books WHERE id = ? AND deleted_at IS NULL",
         ["book-1"],
@@ -256,24 +263,67 @@ describe("book-queries", () => {
     });
   });
 
+  describe("resetBookReadingData", () => {
+    it("resets book progress and deletes reading sessions", async () => {
+      mockExecute.mockResolvedValue(undefined);
+      mockSelect.mockResolvedValueOnce([{ id: "session-1" }]);
+
+      await resetBookReadingData("book-1");
+
+      expect(mockExecute).toHaveBeenCalledWith(expect.stringContaining("UPDATE books SET"), [
+        0,
+        "",
+        3000,
+        1,
+        "device-1",
+        "book-1",
+      ]);
+      expect(mockSelect).toHaveBeenCalledWith("SELECT id FROM reading_sessions WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(coreMocks.insertTombstone).toHaveBeenCalledWith(
+        mockDb,
+        "session-1",
+        "reading_sessions",
+      );
+      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM reading_sessions WHERE book_id = ?", [
+        "book-1",
+      ]);
+    });
+  });
+
   describe("deleteBook", () => {
     it("soft-deletes book and preserves notes + reading stats when requested", async () => {
       mockExecute.mockResolvedValue(undefined);
 
       await deleteBook("book-1", { preserveData: true });
 
-      expect(mockSelect).not.toHaveBeenCalledWith("SELECT id FROM highlights WHERE book_id = ?", ["book-1"]);
-      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM highlights WHERE book_id = ?", ["book-1"]);
-      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM notes WHERE book_id = ?", ["book-1"]);
-      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM bookmarks WHERE book_id = ?", ["book-1"]);
-      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM reading_sessions WHERE book_id = ?", ["book-1"]);
+      expect(mockSelect).not.toHaveBeenCalledWith("SELECT id FROM highlights WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM highlights WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM notes WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM bookmarks WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(mockExecute).not.toHaveBeenCalledWith(
+        "DELETE FROM reading_sessions WHERE book_id = ?",
+        ["book-1"],
+      );
       expect(mockExecute).not.toHaveBeenCalledWith("DELETE FROM books WHERE id = ?", ["book-1"]);
       expect(dependencyMocks.deleteThreadsByBookId).toHaveBeenCalledWith("book-1");
       expect(dependencyMocks.deleteChunks).toHaveBeenCalledWith("book-1");
-      expect(mockExecute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE books"),
-        [expect.any(Number), 3000, 1, "device-1", "book-1"],
-      );
+      expect(mockExecute).toHaveBeenCalledWith(expect.stringContaining("UPDATE books"), [
+        expect.any(Number),
+        3000,
+        1,
+        "device-1",
+        "book-1",
+      ]);
     });
 
     it("hard-deletes everything when preserveData is not requested", async () => {
@@ -281,18 +331,30 @@ describe("book-queries", () => {
       mockSelect
         .mockResolvedValueOnce([{ id: "hl-1" }])
         .mockResolvedValueOnce([{ id: "note-1" }])
-        .mockResolvedValueOnce([{ id: "bm-1" }]);
+        .mockResolvedValueOnce([{ id: "bm-1" }])
+        .mockResolvedValueOnce([{ id: "session-1" }]);
 
       await deleteBook("book-1");
 
-      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM highlights WHERE book_id = ?", ["book-1"]);
+      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM highlights WHERE book_id = ?", [
+        "book-1",
+      ]);
       expect(mockExecute).toHaveBeenCalledWith("DELETE FROM notes WHERE book_id = ?", ["book-1"]);
-      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM bookmarks WHERE book_id = ?", ["book-1"]);
-      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM reading_sessions WHERE book_id = ?", ["book-1"]);
+      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM bookmarks WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM reading_sessions WHERE book_id = ?", [
+        "book-1",
+      ]);
       expect(mockExecute).toHaveBeenCalledWith("DELETE FROM books WHERE id = ?", ["book-1"]);
       expect(coreMocks.insertTombstone).toHaveBeenCalledWith(mockDb, "hl-1", "highlights");
       expect(coreMocks.insertTombstone).toHaveBeenCalledWith(mockDb, "note-1", "notes");
       expect(coreMocks.insertTombstone).toHaveBeenCalledWith(mockDb, "bm-1", "bookmarks");
+      expect(coreMocks.insertTombstone).toHaveBeenCalledWith(
+        mockDb,
+        "session-1",
+        "reading_sessions",
+      );
       expect(coreMocks.insertTombstone).toHaveBeenCalledWith(mockDb, "book-1", "books");
     });
   });

--- a/packages/core/src/db/__tests__/session-queries.test.ts
+++ b/packages/core/src/db/__tests__/session-queries.test.ts
@@ -1,5 +1,5 @@
-import type { ReadingSession } from "../../types/reading";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReadingSession } from "../../types/reading";
 
 const mockExecute = vi.fn();
 const mockSelect = vi.fn();
@@ -8,6 +8,7 @@ const mockDb = { execute: mockExecute, select: mockSelect, close: vi.fn() };
 const coreMocks = vi.hoisted(() => ({
   getDB: vi.fn(),
   getDeviceId: vi.fn(),
+  insertTombstone: vi.fn(),
   nextSyncVersion: vi.fn(),
   nextUpdatedAt: vi.fn(),
 }));
@@ -20,6 +21,7 @@ const {
   getReadingSessionsByDateRange,
   insertReadingSession,
   updateReadingSession,
+  deleteReadingSessionsForBook,
 } = await import("../session-queries");
 
 const sampleSession: ReadingSession = {
@@ -38,6 +40,7 @@ describe("session-queries", () => {
     vi.clearAllMocks();
     coreMocks.getDB.mockResolvedValue(mockDb);
     coreMocks.getDeviceId.mockResolvedValue("device-1");
+    coreMocks.insertTombstone.mockResolvedValue(undefined);
     coreMocks.nextSyncVersion.mockResolvedValue(1);
     coreMocks.nextUpdatedAt.mockResolvedValue(3000);
   });
@@ -162,8 +165,8 @@ describe("session-queries", () => {
       expect(params[1]).toBe("book-1");
       expect(params[2]).toBe(1000); // startedAt
       expect(params[3]).toBe(2000); // endedAt
-      expect(params[4]).toBe(900);  // totalActiveTime
-      expect(params[5]).toBe(10);   // pagesRead
+      expect(params[4]).toBe(900); // totalActiveTime
+      expect(params[5]).toBe(10); // pagesRead
       expect(params[6]).toBe(15000); // charactersRead
       expect(params[7]).toBe("STOPPED"); // state
     });
@@ -212,6 +215,32 @@ describe("session-queries", () => {
       expect(sql).toContain("updated_at = ?");
       expect(sql).toContain("sync_version = ?");
       expect(sql).toContain("last_modified_by = ?");
+    });
+  });
+
+  describe("deleteReadingSessionsForBook", () => {
+    it("creates tombstones and deletes sessions for a book", async () => {
+      mockSelect.mockResolvedValue([{ id: "session-1" }, { id: "session-2" }]);
+      mockExecute.mockResolvedValue(undefined);
+
+      await deleteReadingSessionsForBook("book-1");
+
+      expect(mockSelect).toHaveBeenCalledWith("SELECT id FROM reading_sessions WHERE book_id = ?", [
+        "book-1",
+      ]);
+      expect(coreMocks.insertTombstone).toHaveBeenCalledWith(
+        mockDb,
+        "session-1",
+        "reading_sessions",
+      );
+      expect(coreMocks.insertTombstone).toHaveBeenCalledWith(
+        mockDb,
+        "session-2",
+        "reading_sessions",
+      );
+      expect(mockExecute).toHaveBeenCalledWith("DELETE FROM reading_sessions WHERE book_id = ?", [
+        "book-1",
+      ]);
     });
   });
 });

--- a/packages/core/src/db/book-queries.ts
+++ b/packages/core/src/db/book-queries.ts
@@ -8,6 +8,7 @@ import {
   nextUpdatedAt,
   parseJSON,
 } from "./db-core";
+import { deleteReadingSessionsForBook } from "./session-queries";
 import { deleteThreadsByBookId } from "./thread-queries";
 
 interface BookRow {
@@ -304,6 +305,11 @@ export async function setBookSyncStatus(id: string, syncStatus: Book["syncStatus
   await database.execute("UPDATE books SET sync_status = ? WHERE id = ?", [syncStatus, id]);
 }
 
+export async function resetBookReadingData(id: string): Promise<void> {
+  await updateBook(id, { progress: 0, currentCfi: "" });
+  await deleteReadingSessionsForBook(id);
+}
+
 export async function deleteBook(id: string, options: DeleteBookOptions = {}): Promise<void> {
   const database = await getDB();
   const preserveData = options.preserveData ?? false;
@@ -348,7 +354,7 @@ export async function deleteBook(id: string, options: DeleteBookOptions = {}): P
   await database.execute("DELETE FROM highlights WHERE book_id = ?", [id]);
   await database.execute("DELETE FROM notes WHERE book_id = ?", [id]);
   await database.execute("DELETE FROM bookmarks WHERE book_id = ?", [id]);
-  await database.execute("DELETE FROM reading_sessions WHERE book_id = ?", [id]);
+  await deleteReadingSessionsForBook(id);
   await deleteThreadsByBookId(id);
   await deleteChunks(id);
   await insertTombstone(database, id, "books");

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -41,6 +41,7 @@ export {
   insertBook,
   updateBook,
   setBookSyncStatus,
+  resetBookReadingData,
   deleteBook,
 } from "./book-queries";
 
@@ -96,6 +97,7 @@ export {
   getReadingSessionsByDateRange,
   insertReadingSession,
   updateReadingSession,
+  deleteReadingSessionsForBook,
 } from "./session-queries";
 
 export {

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -27,6 +27,7 @@ export {
   insertBook,
   updateBook,
   setBookSyncStatus,
+  resetBookReadingData,
   deleteBook,
   // Group queries
   getGroups,
@@ -67,6 +68,7 @@ export {
   getReadingSessionsByDateRange,
   insertReadingSession,
   updateReadingSession,
+  deleteReadingSessionsForBook,
   // Chunk queries
   getChunks,
   insertChunks,

--- a/packages/core/src/db/session-queries.ts
+++ b/packages/core/src/db/session-queries.ts
@@ -1,5 +1,5 @@
 import type { ReadingSession } from "../types/reading";
-import { getDB, getDeviceId, nextSyncVersion, nextUpdatedAt } from "./db-core";
+import { getDB, getDeviceId, insertTombstone, nextSyncVersion, nextUpdatedAt } from "./db-core";
 
 type ReadingSessionRow = {
   id: string;
@@ -120,4 +120,18 @@ export async function updateReadingSession(
 
   values.push(id);
   await database.execute(`UPDATE reading_sessions SET ${sets.join(", ")} WHERE id = ?`, values);
+}
+
+export async function deleteReadingSessionsForBook(bookId: string): Promise<void> {
+  const database = await getDB();
+  const sessionRows = await database.select<{ id: string }>(
+    "SELECT id FROM reading_sessions WHERE book_id = ?",
+    [bookId],
+  );
+
+  for (const row of sessionRows) {
+    await insertTombstone(database, row.id, "reading_sessions");
+  }
+
+  await database.execute("DELETE FROM reading_sessions WHERE book_id = ?", [bookId]);
 }


### PR DESCRIPTION
## Summary
- add a core reset API that clears a book's reading sessions and resets its saved progress/current CFI
- create reading-session tombstones when clearing stats so sync can propagate the reset
- expose resetBookReadingData in desktop/mobile library stores
- add a mobile book action sheet entry to reset reading data without deleting the book, notes, highlights, or bookmarks

## Notes
- Issue #336 also mentions drag-seek word count accuracy. Current reader progress sliders already suppress reading-stat accumulation during seek/programmatic navigation; this PR focuses on the missing per-book reset action requested in the issue.

## Verification
- pnpm --filter @readany/core test -- session-queries book-queries
- pnpm --filter app exec tsc --noEmit
- pnpm --filter @readany/app-expo exec tsc --noEmit
- pnpm exec biome check packages/core/src/db/session-queries.ts packages/core/src/db/book-queries.ts packages/core/src/db/database.ts packages/core/src/db/index.ts packages/core/src/db/__tests__/session-queries.test.ts packages/core/src/db/__tests__/book-queries.test.ts packages/app-expo/src/components/library/BookCardActionSheet.tsx
- git diff --check

Fixes #336