### PR TITLE
fix(ollama): use native fetch instead of Tauri HTTP plugin for Windows compatibility

### DIFF
--- a/packages/core/src/ai/llm-provider.ts
+++ b/packages/core/src/ai/llm-provider.ts
@@ -66,10 +66,22 @@ function sanitizeCustomHeaders(headers?: Headers): Headers | undefined {
   return sanitized;
 }
 
+function isTauriDesktop(): boolean {
+    return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function selectFetchImplementation(endpoint: AIEndpoint): typeof globalThis.fetch {
+      if (endpoint.provider === "ollama" && isTauriDesktop()) {  // 桌面端 Ollama：替换底层 fetch 为原生 fetch，绕过 Tauri HTTP 插件
+        return globalThis.fetch.bind(globalThis);
+    }
+    // 默认使用 _streamingFetch（Tauri 插件）或原生 fetch
+    return (_streamingFetch ?? globalThis.fetch).bind(globalThis);
+}
+
 export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof globalThis.fetch {
   const exactUrl = endpoint.useExactRequestUrl ? endpoint.baseUrl?.trim() : "";
-  const baseFetch = (_streamingFetch ?? globalThis.fetch).bind(globalThis);
-
+  const baseFetch = selectFetchImplementation(endpoint);
+  
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const finalInput = isRequestLike(input)
       ? exactUrl


### PR DESCRIPTION
## Problem / 问题
On Windows, Ollama connection fails with 404 error. The root cause is that Tauri's HTTP plugin is incompatible with Ollama's local API.
（Windows 下 Ollama 连接返回 404，原因是 Tauri 的 HTTP 插件不兼容）

## Solution / 解决方案
Force using native `fetch` instead of Tauri's HTTP plugin.
（强制使用原生 fetch 绕过 Tauri）

## Tested / 测试环境
- Windows 11 + Ollama 0.24.0
- ✅ Model list loads successfully
- ✅ Chat requests work