### PR TITLE
fix(tts): DashScope 进度同步与暂停/继续修复

### DIFF
--- a/packages/core/src/stores/tts-store.ts
+++ b/packages/core/src/stores/tts-store.ts
@@ -218,6 +218,28 @@ export const useTTSStore = create<TTSState>()(
       const config = normalizeTTSConfig(get().config);
       const { playState } = get();
       if (playState !== "paused") return;
+
+      // Engines with true suspend/resume: if that player is actually suspended,
+      // continue exactly where paused — no re-synthesis, no API re-call, no jump.
+      // Do NOT bump generation or rebind callbacks; the original speak()'s callbacks
+      // keep driving progress. Otherwise fall through to the re-speak block below
+      // (system engine, or engine changed while paused so the player isn't suspended).
+      if (config.engine === "dashscope" && config.dashscopeApiKey) {
+        const player = getDashScopeTTS();
+        if (player.paused) {
+          player.resume();
+          set({ playState: "playing" });
+          return;
+        }
+      } else if (config.engine === "edge") {
+        const player = getEdgeTTS();
+        if (player.paused) {
+          player.resume();
+          set({ playState: "playing" });
+          return;
+        }
+      }
+
       if (_sessionSegments.length > 0) {
         const nextIndex = Math.max(0, Math.min(_sessionCurrentIndex, _sessionSegments.length - 1));
         const remainingSegments = _sessionSegments.slice(nextIndex);

--- a/packages/core/src/stores/tts-store.ts
+++ b/packages/core/src/stores/tts-store.ts
@@ -64,6 +64,9 @@ let _sessionCurrentIndex = 0;
 /** Generation counter — incremented on every play/jumpToChunk to invalidate stale callbacks */
 let _sessionGeneration = 0;
 let _sleepTimerHandle: ReturnType<typeof setTimeout> | null = null;
+/** Voice the active DashScope run is synthesizing with; lets resume() decide whether
+ *  it can true-resume (voice unchanged) or must re-speak (voice changed). */
+let _dashscopeActiveVoice: string | undefined;
 
 function getSystemTTS(): ITTSPlayer {
   if (!_systemTTS) _systemTTS = _factories.createSystemTTS();
@@ -148,6 +151,7 @@ export const useTTSStore = create<TTSState>()(
 
     play: (text: string | string[]) => {
       const config = normalizeTTSConfig(get().config);
+      _dashscopeActiveVoice = config.dashscopeVoice;
       const segments = Array.isArray(text) ? text.map((item) => item.trim()).filter(Boolean) : [text.trim()].filter(Boolean);
       const sessionSegments = segments.length > 0 ? segments : [Array.isArray(text) ? text.join(" ").trim() : text.trim()].filter(Boolean);
       _sessionSegments = sessionSegments;
@@ -228,7 +232,7 @@ export const useTTSStore = create<TTSState>()(
       // resume would skip highlights — it stays on the re-speak path below (its main behavior).
       if (config.engine === "dashscope" && config.dashscopeApiKey) {
         const player = getDashScopeTTS();
-        if (player.paused) {
+        if (player.paused && config.dashscopeVoice === _dashscopeActiveVoice) {
           player.resume();
           set({ playState: "playing" });
           return;
@@ -259,6 +263,7 @@ export const useTTSStore = create<TTSState>()(
 
           if (config.engine === "dashscope" && config.dashscopeApiKey) {
             const player = getDashScopeTTS();
+            _dashscopeActiveVoice = config.dashscopeVoice;
             player.onStateChange = onState;
             player.onChunkChange = onChunk;
             player.onEnd = handleEnd;
@@ -299,6 +304,7 @@ export const useTTSStore = create<TTSState>()(
       dashscope.stop();
       _sessionSegments = [];
       _sessionCurrentIndex = 0;
+      _dashscopeActiveVoice = undefined;
       set({
         playState: "stopped",
         currentText: "",
@@ -346,6 +352,7 @@ export const useTTSStore = create<TTSState>()(
     jumpToChunk: (index: number) => {
       if (index < 0 || index >= _sessionSegments.length) return;
       const config = normalizeTTSConfig(get().config);
+      _dashscopeActiveVoice = config.dashscopeVoice;
       getSystemTTS().stop();
       getEdgeTTS().stop();
       getDashScopeTTS().stop();

--- a/packages/core/src/stores/tts-store.ts
+++ b/packages/core/src/stores/tts-store.ts
@@ -219,20 +219,15 @@ export const useTTSStore = create<TTSState>()(
       const { playState } = get();
       if (playState !== "paused") return;
 
-      // Engines with true suspend/resume: if that player is actually suspended,
-      // continue exactly where paused — no re-synthesis, no API re-call, no jump.
-      // Do NOT bump generation or rebind callbacks; the original speak()'s callbacks
-      // keep driving progress. Otherwise fall through to the re-speak block below
-      // (system engine, or engine changed while paused so the player isn't suspended).
+      // DashScope supports true suspend/resume and derives progress from the audio
+      // clock (#358), so if it is actually suspended, continue exactly where paused —
+      // no re-synthesis, no API re-call, no jump. Do NOT bump generation or rebind
+      // callbacks; the original speak()'s callbacks keep driving progress.
+      // Edge is intentionally NOT true-resumed here: its highlight notifications are
+      // wall-clock timers cleared on pause and not rescheduled on resume, so a true
+      // resume would skip highlights — it stays on the re-speak path below (its main behavior).
       if (config.engine === "dashscope" && config.dashscopeApiKey) {
         const player = getDashScopeTTS();
-        if (player.paused) {
-          player.resume();
-          set({ playState: "playing" });
-          return;
-        }
-      } else if (config.engine === "edge") {
-        const player = getEdgeTTS();
         if (player.paused) {
           player.resume();
           set({ playState: "playing" });

--- a/packages/core/src/tts/playback-cursor.test.ts
+++ b/packages/core/src/tts/playback-cursor.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveCurrentChunk } from "./playback-cursor";
+
+describe("resolveCurrentChunk", () => {
+  it("returns -1 for empty boundaries", () => {
+    expect(resolveCurrentChunk([], 5)).toBe(-1);
+  });
+
+  it("returns -1 before the first boundary starts", () => {
+    expect(resolveCurrentChunk([{ index: 0, startAt: 1 }], 0.5)).toBe(-1);
+  });
+
+  it("returns the chunk when currentTime equals its startAt", () => {
+    const b = [
+      { index: 0, startAt: 0 },
+      { index: 1, startAt: 10 },
+    ];
+    expect(resolveCurrentChunk(b, 10)).toBe(1);
+  });
+
+  it("returns the chunk whose interval contains currentTime", () => {
+    const b = [
+      { index: 0, startAt: 0 },
+      { index: 1, startAt: 10 },
+      { index: 2, startAt: 21 },
+    ];
+    expect(resolveCurrentChunk(b, 5)).toBe(0);
+    expect(resolveCurrentChunk(b, 15)).toBe(1);
+  });
+
+  it("never runs ahead of the audio clock", () => {
+    // The core anti-"runaway" guarantee: while still inside chunk 0's window,
+    // it must report 0 — never the later chunks that are merely queued ahead.
+    const b = [
+      { index: 0, startAt: 0 },
+      { index: 1, startAt: 10 },
+      { index: 2, startAt: 21 },
+    ];
+    expect(resolveCurrentChunk(b, 9.9)).toBe(0);
+    expect(resolveCurrentChunk(b, 20.9)).toBe(1);
+  });
+
+  it("returns the last chunk past the final boundary", () => {
+    const b = [
+      { index: 0, startAt: 0 },
+      { index: 1, startAt: 10 },
+    ];
+    expect(resolveCurrentChunk(b, 999)).toBe(1);
+  });
+
+  it("handles skipped indices (chunks that produced no audio)", () => {
+    const b = [
+      { index: 0, startAt: 0 },
+      { index: 2, startAt: 10 },
+    ];
+    expect(resolveCurrentChunk(b, 5)).toBe(0);
+    expect(resolveCurrentChunk(b, 10)).toBe(2);
+  });
+});

--- a/packages/core/src/tts/playback-cursor.ts
+++ b/packages/core/src/tts/playback-cursor.ts
@@ -1,0 +1,24 @@
+/**
+ * Playback cursor for streamed TTS: maps the audio-clock time to the chunk
+ * currently being heard, so progress tracks real playback instead of network speed.
+ */
+export interface ChunkBoundary {
+  /** Chunk index within the current speak() call (0-based). */
+  index: number;
+  /** AudioContext-timeline start time of this chunk's first audio buffer (seconds). */
+  startAt: number;
+}
+
+/**
+ * Given chunk start-time boundaries (appended in ascending startAt order) and the
+ * current audio-clock time, return the index of the chunk currently playing, or -1
+ * if no chunk has started yet.
+ */
+export function resolveCurrentChunk(boundaries: ChunkBoundary[], currentTime: number): number {
+  let current = -1;
+  for (const b of boundaries) {
+    if (b.startAt <= currentTime) current = b.index;
+    else break;
+  }
+  return current;
+}

--- a/packages/core/src/tts/tts-players.ts
+++ b/packages/core/src/tts/tts-players.ts
@@ -138,6 +138,7 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
   private currentStreamIndex = 0;
   private boundaryRecorded = false;
   private lastNotifiedChunkIndex = -1;
+  private runId = 0;
 
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
   onChunkChange?: (index: number, total: number) => void;
@@ -165,6 +166,7 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
     this.pendingBytes = [];
 
     const chunks = Array.isArray(text) ? text.filter(Boolean) : splitIntoChunks(text);
+    const myRun = ++this.runId;
     this._playing = true;
     this._paused = false;
     this.allChunksDone = false;
@@ -205,21 +207,27 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
     }, 200);
 
     for (let i = 0; i < chunks.length; i++) {
-      if (!this._playing) return;
+      if (!this._playing || myRun !== this.runId) return;
       this.currentStreamIndex = i;
       this.boundaryRecorded = false;
       try {
-        await this.streamChunk(chunks[i], config, i === 0);
+        await this.streamChunk(chunks[i], config, i === 0, myRun);
       } catch (err) {
         console.error("[DashScope TTS] chunk error:", err);
       }
     }
 
+    if (myRun !== this.runId) return;
     this.flushPendingBytes();
     this.allChunksDone = true;
   }
 
-  private async streamChunk(text: string, config: TTSConfig, isFirst: boolean): Promise<void> {
+  private async streamChunk(
+    text: string,
+    config: TTSConfig,
+    isFirst: boolean,
+    myRun: number,
+  ): Promise<void> {
     const platform = getPlatformService();
     this.abortController = new AbortController();
     this.pendingBytes = [];
@@ -256,7 +264,7 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
     let firstAudioReceived = false;
 
     while (true) {
-      if (!this._playing) {
+      if (!this._playing || myRun !== this.runId) {
         reader.cancel();
         return;
       }

--- a/packages/core/src/tts/tts-players.ts
+++ b/packages/core/src/tts/tts-players.ts
@@ -8,6 +8,7 @@
 
 import { getPlatformService } from "../services/platform";
 import { fetchEdgeTTSAudio } from "./edge-tts";
+import { type ChunkBoundary, resolveCurrentChunk } from "./playback-cursor";
 import { splitIntoChunks } from "./text-utils";
 import type { ITTSPlayer, TTSConfig } from "./types";
 
@@ -132,6 +133,11 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
   private checkEndTimer: ReturnType<typeof setInterval> | null = null;
   private pendingBytes: Uint8Array[] = [];
   private decodeTimeout: ReturnType<typeof setTimeout> | null = null;
+  private chunkBoundaries: ChunkBoundary[] = [];
+  private totalChunks = 0;
+  private currentStreamIndex = 0;
+  private boundaryRecorded = false;
+  private lastNotifiedChunkIndex = -1;
 
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
   onChunkChange?: (index: number, total: number) => void;
@@ -163,6 +169,9 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
     this._paused = false;
     this.allChunksDone = false;
     this.hasAudioData = false;
+    this.totalChunks = chunks.length;
+    this.chunkBoundaries = [];
+    this.lastNotifiedChunkIndex = -1;
 
     this.audioCtx = new AudioContext();
     this.gainNode = this.audioCtx.createGain();
@@ -171,6 +180,13 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
 
     this.checkEndTimer = setInterval(() => {
       if (!this._playing) return;
+      if (this.audioCtx) {
+        const current = resolveCurrentChunk(this.chunkBoundaries, this.audioCtx.currentTime);
+        if (current >= 0 && current !== this.lastNotifiedChunkIndex) {
+          this.lastNotifiedChunkIndex = current;
+          this.onChunkChange?.(current, this.totalChunks);
+        }
+      }
       if (
         this.allChunksDone &&
         this.audioCtx &&
@@ -190,7 +206,8 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
 
     for (let i = 0; i < chunks.length; i++) {
       if (!this._playing) return;
-      this.onChunkChange?.(i, chunks.length);
+      this.currentStreamIndex = i;
+      this.boundaryRecorded = false;
       try {
         await this.streamChunk(chunks[i], config, i === 0);
       } catch (err) {
@@ -332,6 +349,11 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
     source.start(startAt);
     this.scheduledEnd = startAt + audioBuffer.duration;
     this.hasAudioData = true;
+
+    if (!this.boundaryRecorded) {
+      this.chunkBoundaries.push({ index: this.currentStreamIndex, startAt });
+      this.boundaryRecorded = true;
+    }
   }
 
   private finishPlayback() {
@@ -376,6 +398,9 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
     this.pendingBytes = [];
     this.allChunksDone = false;
     this.hasAudioData = false;
+    this.chunkBoundaries = [];
+    this.lastNotifiedChunkIndex = -1;
+    this.boundaryRecorded = false;
     this._playing = false;
     this._paused = false;
     this.onStateChange?.("stopped");

--- a/packages/core/src/tts/tts-players.ts
+++ b/packages/core/src/tts/tts-players.ts
@@ -270,6 +270,10 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
       }
       const { done, value } = await reader.read();
       if (done) break;
+      if (!this._playing || myRun !== this.runId) {
+        reader.cancel();
+        return;
+      }
 
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split("\n");
@@ -306,6 +310,7 @@ export class DashScopeTTSPlayer implements ITTSPlayer {
       }
     }
 
+    if (myRun !== this.runId) return;
     this.flushPendingBytes();
   }
 

--- a/packages/core/src/tts/types.ts
+++ b/packages/core/src/tts/types.ts
@@ -88,6 +88,8 @@ export interface ITTSPlayer {
   pause(): void;
   resume(): void;
   stop(): void;
+  /** Whether playback is currently paused (true suspend). Optional — platforms without true pause may omit it. */
+  readonly paused?: boolean;
 
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
   onChunkChange?: (index: number, total: number) => void;


### PR DESCRIPTION
## 概述

修复 DashScope 引擎的两个朗读问题:进度与音频不同步(#358)、暂停后再开始导致跳段/重叠/重复请求(#364)。改动集中在 `packages/core`,共 5 个文件。

## 问题与设计

### #358 进度狂奔

原先在「开始请求每句」时就更新进度,远早于音频实际播放(网络合成远快于实时),导致进度高亮一路冲到结尾。

设计:进度改由**音频时钟**推算——记录每句首块音频在 `AudioContext` 时间轴上的起点(边界表),抽出纯函数 `resolveCurrentChunk(boundaries, currentTime)`,复用项目原有的 200ms 定时器按 `AudioContext.currentTime` 反查当前句,仅在句变化时通知。

副作用(正向):正文歌词式滚动/高亮由进度驱动,暂停时 `suspend()` 冻结 `currentTime` → 进度冻结 → 滚动/高亮也随之停住(此前暂停时仍会继续滚)。

### #364 暂停/继续跳段、重叠、重复请求

两层原因:(a) `resume()` 对所有引擎都「重新 speak」;(b) `speak()` 不可重入,新一轮启动时旧循环未真正终止 → 两路并发改写同一批状态。

设计:

- 给 `DashScopeTTSPlayer.speak()` 加单调 **run 令牌**,旧循环 `await` 后发现被取代即退出(覆盖 jumpToChunk / 快速重开等入口);
- **DashScope** 暂停/继续改用播放器**真正的 `suspend()`/`resume()`**(原地续播、不重调 API、不跳),由 `player.paused` **且音色未变**守卫;若暂停中改了音色,则回落「重说」用新音色重新合成(DashScope 合成只取决于 `voice`);
- **Edge、系统引擎维持原有「重说」**:Edge 的当前句高亮是 setTimeout 计时器,暂停清除后不重排,直接真正恢复会高亮跳格,故暂不启用;
- `ITTSPlayer` 新增**可选** `readonly paused?: boolean`(实现类已有,向后兼容)。

## 已知限制

进度按音频时钟推算,采样节拍**沿用项目原有的 200ms 结束检测定时器(`checkEndTimer`,非本 PR 引入)**:若某句合成音频时长 < ~200ms(极短的行,如单字/标题),其高亮/计数有概率被一次 tick 跳过(音频本身始终完整播放)。正常语句(数秒)不受影响。

## 影响范围 / 兼容性

仅改 `packages/core`(`tts/playback-cursor.ts` + 测试、`tts/tts-players.ts` 的 DashScope 类、`stores/tts-store.ts`、`tts/types.ts`);Edge / 系统引擎内部、UI 均未改;接口为可选新增,无破坏性变更。

## 测试

纯函数 `resolveCurrentChunk` 含单测(`playback-cursor.test.ts`);player / store 依赖 `AudioContext`,node 环境无法有意义单测(与仓库约定一致),以手动验证为主:DashScope 暂停/继续不跳不重叠、暂停中切音色后续播用新音色、连点/跳句正常、Edge 与系统正常、进度跟随音频不狂奔。

上述场景已在 dev 环境手动验证;也建议合并前自行复测一遍。

## 相关(不在本 PR 范围)

排查期间整理的同问题域 TTS issue,供参考:#349(切引擎不停旧引擎)、#365(句间爆音)、#370(播放中切音色即时生效)。

后续可把 Edge 也收敛到同一机制(音频时钟光标 + run 令牌 + 真正恢复),以消除其「恢复后高亮跳格」的限制;本 PR 不涉及。

Fixes #358
Fixes #364
