### PR TITLE
fix: merge duplicate book stats by file hash

### DIFF
--- a/packages/core/src/stats/book-identity.ts
+++ b/packages/core/src/stats/book-identity.ts
@@ -1,0 +1,66 @@
+import type { Book } from "../types";
+
+export interface StatsBookIdentity {
+  bookById: Map<string, Book>;
+  canonicalBookById: Map<string, Book>;
+  canonicalBookIdById: Map<string, string>;
+}
+
+function toBookArray(books: Book[] | Map<string, Book>): Book[] {
+  return books instanceof Map ? Array.from(books.values()) : books;
+}
+
+function isActiveBook(book: Book): boolean {
+  return book.deletedAt === undefined;
+}
+
+function rankBookForStats(book: Book): number {
+  const activeBonus = isActiveBook(book) ? 1_000_000_000_000_000 : 0;
+  return activeBonus + Math.max(book.lastOpenedAt ?? 0, book.updatedAt ?? 0, book.addedAt ?? 0);
+}
+
+function pickCanonicalBook(a: Book, b: Book): Book {
+  const rankA = rankBookForStats(a);
+  const rankB = rankBookForStats(b);
+  if (rankA !== rankB) return rankA > rankB ? a : b;
+  return a.id.localeCompare(b.id) <= 0 ? a : b;
+}
+
+export function createStatsBookIdentity(books: Book[] | Map<string, Book>): StatsBookIdentity {
+  const bookList = toBookArray(books);
+  const bookById = new Map(bookList.map((book) => [book.id, book]));
+  const canonicalByHash = new Map<string, Book>();
+
+  for (const book of bookList) {
+    const fileHash = book.fileHash?.trim();
+    if (!fileHash) continue;
+    const existing = canonicalByHash.get(fileHash);
+    canonicalByHash.set(fileHash, existing ? pickCanonicalBook(existing, book) : book);
+  }
+
+  const canonicalBookIdById = new Map<string, string>();
+  const canonicalBookById = new Map<string, Book>();
+  for (const book of bookList) {
+    const fileHash = book.fileHash?.trim();
+    const canonicalBook = fileHash ? canonicalByHash.get(fileHash) ?? book : book;
+    canonicalBookIdById.set(book.id, canonicalBook.id);
+    canonicalBookById.set(book.id, canonicalBook);
+  }
+
+  return {
+    bookById,
+    canonicalBookById,
+    canonicalBookIdById,
+  };
+}
+
+export function getCanonicalStatsBook(
+  identity: StatsBookIdentity,
+  bookId: string,
+): Book | undefined {
+  return identity.canonicalBookById.get(bookId) ?? identity.bookById.get(bookId);
+}
+
+export function getCanonicalStatsBookId(identity: StatsBookIdentity, bookId: string): string {
+  return identity.canonicalBookIdById.get(bookId) ?? bookId;
+}

--- a/packages/core/src/stats/fact-builder.test.ts
+++ b/packages/core/src/stats/fact-builder.test.ts
@@ -157,4 +157,56 @@ describe("buildDailyReadingFacts", () => {
       totalTime: 15,
     });
   });
+
+  it("merges sessions from deleted duplicate records into the active book by file hash", () => {
+    const renamedBook: Book = {
+      ...books[0],
+      id: "book-active",
+      fileHash: "same-file",
+      meta: {
+        ...books[0].meta,
+        title: "如何成为不完美主义者",
+      },
+      updatedAt: 10,
+    };
+    const deletedOldTitle: Book = {
+      ...books[0],
+      id: "book-deleted",
+      fileHash: "same-file",
+      deletedAt: 20,
+      meta: {
+        ...books[0].meta,
+        title: "如何成为不完美主义者（改变无数人...",
+      },
+      updatedAt: 5,
+    };
+
+    const sessions: ReadingSession[] = [
+      createSession({
+        id: "old-title-session",
+        bookId: "book-deleted",
+        totalActiveTime: 11 * 60 * 1000,
+        pagesRead: 4,
+      }),
+      createSession({
+        id: "renamed-session",
+        bookId: "book-active",
+        totalActiveTime: 89 * 60 * 1000,
+        pagesRead: 8,
+      }),
+    ];
+
+    const [fact] = buildDailyReadingFacts(sessions, [deletedOldTitle, renamedBook]);
+
+    expect(fact.booksTouched).toBe(1);
+    expect(fact.bookBreakdown).toEqual([
+      expect.objectContaining({
+        bookId: "book-active",
+        title: "如何成为不完美主义者",
+        totalTime: 100,
+        pagesRead: 12,
+        sessionsCount: 2,
+      }),
+    ]);
+  });
 });

--- a/packages/core/src/stats/fact-builder.ts
+++ b/packages/core/src/stats/fact-builder.ts
@@ -1,6 +1,11 @@
 import type { Book, ReadingSession } from "../types";
 import type { DailyBookBreakdown, DailyReadingFact } from "./schema";
 import {
+  createStatsBookIdentity,
+  getCanonicalStatsBook,
+  getCanonicalStatsBookId,
+} from "./book-identity";
+import {
   getMonthKey,
   getWeekKey,
   getYearKey,
@@ -80,7 +85,7 @@ export function buildDailyReadingFacts(
   sessions: ReadingSession[],
   books: Book[] | Map<string, Book> = [],
 ): DailyReadingFact[] {
-  const bookIndex = books instanceof Map ? books : createBookIndex(books);
+  const bookIdentity = createStatsBookIdentity(books);
   const days = new Map<string, DayAccumulator>();
 
   for (const session of sessions) {
@@ -101,12 +106,13 @@ export function buildDailyReadingFacts(
       day.lastSessionAt === undefined ? sessionEndAt : Math.max(day.lastSessionAt, sessionEndAt);
     day.hourBuckets.set(sessionHour, (day.hourBuckets.get(sessionHour) ?? 0) + totalTime);
 
-    const book = bookIndex.get(session.bookId);
+    const statsBookId = getCanonicalStatsBookId(bookIdentity, session.bookId);
+    const book = getCanonicalStatsBook(bookIdentity, session.bookId);
     const existingBook =
-      day.books.get(session.bookId) ??
+      day.books.get(statsBookId) ??
       (book
         ? {
-            bookId: session.bookId,
+            bookId: statsBookId,
             title: book.meta.title,
             author: book.meta.author,
             coverUrl: book.meta.coverUrl,
@@ -126,7 +132,7 @@ export function buildDailyReadingFacts(
     existingBook.charactersRead = (existingBook.charactersRead ?? 0) + (session.charactersRead ?? 0);
     existingBook.sessionsCount += 1;
 
-    day.books.set(session.bookId, existingBook);
+    day.books.set(statsBookId, existingBook);
     days.set(date, day);
   }
 

--- a/packages/core/src/stats/live-facts.ts
+++ b/packages/core/src/stats/live-facts.ts
@@ -1,5 +1,10 @@
 import type { Book, ReadingSession } from "../types";
 import type { DailyBookBreakdown, DailyReadingFact } from "./schema";
+import {
+  createStatsBookIdentity,
+  getCanonicalStatsBook,
+  getCanonicalStatsBookId,
+} from "./book-identity";
 import { getMonthKey, getWeekKey, getYearKey, toLocalDateKey } from "./period-utils";
 
 function toMinutes(milliseconds: number): number {
@@ -67,11 +72,12 @@ export function mergeCurrentSessionIntoDailyFacts(
     return dailyFacts;
   }
 
-  const bookIndex = books instanceof Map ? books : new Map(books.map((book) => [book.id, book]));
+  const bookIdentity = createStatsBookIdentity(books);
+  const statsBookId = getCanonicalStatsBookId(bookIdentity, currentSession.bookId);
   const sessionDate = toLocalDateKey(currentSession.startedAt);
   const sessionMinutes = toMinutes(currentSession.totalActiveTime);
   const sessionHour = new Date(currentSession.startedAt).getHours();
-  const book = bookIndex.get(currentSession.bookId);
+  const book = getCanonicalStatsBook(bookIdentity, currentSession.bookId);
 
   const nextFacts = dailyFacts.map((fact) => ({
     ...fact,
@@ -100,9 +106,9 @@ export function mergeCurrentSessionIntoDailyFacts(
   target.hourlyDistribution[sessionHour] = (target.hourlyDistribution[sessionHour] ?? 0) + sessionMinutes;
   target.peakHour = getPeakHour(target.hourlyDistribution);
 
-  let targetBook = target.bookBreakdown.find((item) => item.bookId === currentSession.bookId);
+  let targetBook = target.bookBreakdown.find((item) => item.bookId === statsBookId);
   if (!targetBook) {
-    targetBook = createBookBreakdown(currentSession, book);
+    targetBook = createBookBreakdown({ ...currentSession, bookId: statsBookId }, book);
     target.bookBreakdown.push(targetBook);
   }
 

--- a/packages/core/src/stats/reading-stats.test.ts
+++ b/packages/core/src/stats/reading-stats.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Book, ReadingSession } from "../types";
+
+const dbMocks = vi.hoisted(() => ({
+  getBooks: vi.fn(),
+  getReadingSessions: vi.fn(),
+  getReadingSessionsByDateRange: vi.fn(),
+}));
+
+vi.mock("../db/database", () => dbMocks);
+
+const { ReadingStatsService } = await import("./reading-stats");
+
+function createBook(overrides: Partial<Book>): Book {
+  return {
+    id: overrides.id ?? "book-1",
+    filePath: overrides.filePath ?? "/tmp/book.epub",
+    format: overrides.format ?? "epub",
+    meta: {
+      title: "Deep Reading",
+      author: "Alice",
+      ...overrides.meta,
+    },
+    addedAt: overrides.addedAt ?? 1,
+    updatedAt: overrides.updatedAt ?? 1,
+    deletedAt: overrides.deletedAt,
+    progress: overrides.progress ?? 0,
+    currentCfi: overrides.currentCfi,
+    isVectorized: overrides.isVectorized ?? false,
+    vectorizeProgress: overrides.vectorizeProgress ?? 0,
+    tags: overrides.tags ?? [],
+    fileHash: overrides.fileHash,
+    syncStatus: overrides.syncStatus ?? "local",
+    lastOpenedAt: overrides.lastOpenedAt,
+  };
+}
+
+function createSession(overrides: Partial<ReadingSession>): ReadingSession {
+  return {
+    id: overrides.id ?? "session-1",
+    bookId: overrides.bookId ?? "book-1",
+    state: overrides.state ?? "STOPPED",
+    startedAt: overrides.startedAt ?? new Date(2026, 3, 17, 9, 0, 0).getTime(),
+    endedAt: overrides.endedAt,
+    totalActiveTime: overrides.totalActiveTime ?? 30 * 60 * 1000,
+    pagesRead: overrides.pagesRead ?? 10,
+    charactersRead: overrides.charactersRead ?? 12_000,
+  };
+}
+
+describe("ReadingStatsService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts duplicate deleted book records as the active book in overall stats", async () => {
+    const active = createBook({
+      id: "book-active",
+      fileHash: "same-file",
+      meta: { title: "如何成为不完美主义者", author: "斯蒂芬·盖斯" },
+      progress: 0.4,
+      updatedAt: 20,
+    });
+    const deleted = createBook({
+      id: "book-deleted",
+      fileHash: "same-file",
+      deletedAt: 10,
+      meta: { title: "如何成为不完美主义者（改变无数人...", author: "斯蒂芬·盖斯" },
+      updatedAt: 5,
+    });
+    dbMocks.getBooks.mockResolvedValue([deleted, active]);
+    dbMocks.getReadingSessions.mockImplementation((bookId: string) =>
+      Promise.resolve(
+        bookId === "book-deleted"
+          ? [createSession({ bookId, totalActiveTime: 20 * 60 * 1000 })]
+          : [createSession({ bookId, totalActiveTime: 40 * 60 * 1000 })],
+      ),
+    );
+
+    const stats = await new ReadingStatsService().getOverallStats();
+
+    expect(stats.totalBooks).toBe(1);
+    expect(stats.totalReadingTime).toBe(60);
+    expect(stats.totalSessions).toBe(2);
+  });
+
+  it("merges period book stats for duplicate deleted records into the active title", async () => {
+    const active = createBook({
+      id: "book-active",
+      fileHash: "same-file",
+      meta: { title: "如何成为不完美主义者", author: "斯蒂芬·盖斯", coverUrl: "cover-new" },
+      progress: 0.4,
+    });
+    const deleted = createBook({
+      id: "book-deleted",
+      fileHash: "same-file",
+      deletedAt: 10,
+      meta: { title: "如何成为不完美主义者（改变无数人...", author: "斯蒂芬·盖斯" },
+    });
+    dbMocks.getBooks.mockResolvedValue([deleted, active]);
+    dbMocks.getReadingSessionsByDateRange.mockResolvedValue([
+      createSession({ id: "old", bookId: "book-deleted", totalActiveTime: 11 * 60 * 1000 }),
+      createSession({ id: "new", bookId: "book-active", totalActiveTime: 89 * 60 * 1000 }),
+    ]);
+
+    const stats = await new ReadingStatsService().getBookStatsForPeriod(
+      new Date(2026, 3, 1),
+      new Date(2026, 3, 30),
+    );
+
+    expect(stats).toEqual([
+      expect.objectContaining({
+        bookId: "book-active",
+        title: "如何成为不完美主义者",
+        coverUrl: "cover-new",
+        totalTime: 100,
+      }),
+    ]);
+  });
+});

--- a/packages/core/src/stats/reading-stats.ts
+++ b/packages/core/src/stats/reading-stats.ts
@@ -2,6 +2,11 @@
  * Reading Stats service — computes reading statistics from session data
  */
 import { getBooks, getReadingSessions, getReadingSessionsByDateRange } from "../db/database";
+import {
+  createStatsBookIdentity,
+  getCanonicalStatsBook,
+  getCanonicalStatsBookId,
+} from "./book-identity";
 
 export interface DailyStats {
   date: string; // YYYY-MM-DD
@@ -95,14 +100,19 @@ export class ReadingStatsService {
 
   /** Get stats for a specific book */
   async getBookStats(bookId: string): Promise<BookStats> {
-    const sessions = await getReadingSessions(bookId);
     const books = await getBooks({ includeDeleted: true });
-    const book = books.find((b) => b.id === bookId);
+    const bookIdentity = createStatsBookIdentity(books);
+    const statsBookId = getCanonicalStatsBookId(bookIdentity, bookId);
+    const book = getCanonicalStatsBook(bookIdentity, bookId);
+    const bookIds = books
+      .filter((candidate) => getCanonicalStatsBookId(bookIdentity, candidate.id) === statsBookId)
+      .map((candidate) => candidate.id);
+    const sessions = (await Promise.all((bookIds.length > 0 ? bookIds : [bookId]).map((id) => getReadingSessions(id)))).flat();
 
     const totalTime = sessions.reduce((sum, s) => sum + s.totalActiveTime, 0);
 
     return {
-      bookId,
+      bookId: statsBookId,
       bookTitle: book?.meta.title || "Unknown",
       totalTime: totalTime / 60000,
       sessions: sessions.length,
@@ -115,6 +125,7 @@ export class ReadingStatsService {
   /** Get overall reading statistics */
   async getOverallStats(): Promise<OverallStats> {
     const books = await getBooks({ includeDeleted: true });
+    const bookIdentity = createStatsBookIdentity(books);
 
     let totalTime = 0;
     let totalSessions = 0;
@@ -125,7 +136,7 @@ export class ReadingStatsService {
 
     for (const book of books) {
       if (book.progress > 0) {
-        readBookIds.add(book.id);
+        readBookIds.add(getCanonicalStatsBookId(bookIdentity, book.id));
       }
 
       const sessions = await getReadingSessions(book.id);
@@ -135,7 +146,7 @@ export class ReadingStatsService {
         totalPages += session.pagesRead;
         totalCharactersRead += session.charactersRead ?? 0;
         readingDays.add(new Date(session.startedAt).toISOString().split("T")[0]);
-        readBookIds.add(book.id);
+        readBookIds.add(getCanonicalStatsBookId(bookIdentity, book.id));
       }
     }
 
@@ -177,22 +188,23 @@ export class ReadingStatsService {
   async getBookStatsForPeriod(start: Date, end: Date): Promise<PeriodBookStats[]> {
     const sessions = await getReadingSessionsByDateRange(start, end);
     const books = await getBooks({ includeDeleted: true });
-    const bookMap = new Map(books.map((b) => [b.id, b]));
+    const bookIdentity = createStatsBookIdentity(books);
 
     // Group reading time by book
     const timeByBook = new Map<string, number>();
     for (const session of sessions) {
-      const existing = timeByBook.get(session.bookId) || 0;
-      timeByBook.set(session.bookId, existing + session.totalActiveTime);
+      const statsBookId = getCanonicalStatsBookId(bookIdentity, session.bookId);
+      const existing = timeByBook.get(statsBookId) || 0;
+      timeByBook.set(statsBookId, existing + session.totalActiveTime);
     }
 
     // Build results sorted by total time descending
     const results: PeriodBookStats[] = [];
     for (const [bookId, totalMs] of timeByBook) {
-      const book = bookMap.get(bookId);
+      const book = getCanonicalStatsBook(bookIdentity, bookId);
       if (!book) continue;
       results.push({
-        bookId,
+        bookId: book.id,
         title: book.meta.title,
         author: book.meta.author,
         coverUrl: book.meta.coverUrl,


### PR DESCRIPTION
## Summary
- merge reading stats for duplicate book records that share the same file hash into the active/current book
- keep deleted-book historical reading data available without splitting top books after rename or reimport
- apply the canonical book identity to report facts, live session stats, and legacy reading stats service

## Tests
- pnpm --filter @readany/core test src/stats/fact-builder.test.ts src/stats/live-facts.test.ts src/stats/reading-stats.test.ts src/stats/reports-service.test.ts
- pnpm --filter @readany/core exec tsc --noEmit
- pnpm version:check
- git diff --check

Closes #351