### PR TITLE
fix: preserve sync tombstones for deleted groups

### DIFF
--- a/packages/core/src/sync/__tests__/simple-sync.integration.test.ts
+++ b/packages/core/src/sync/__tests__/simple-sync.integration.test.ts
@@ -36,6 +36,7 @@ vi.mock("../sync-files", () => syncFileMocks);
 const { applyChanges, collectChanges, runSimpleSync } = await import("../simple-sync");
 
 const TABLE_COLUMNS: Record<string, string[]> = {
+  book_groups: ["id", "name", "sort_order", "created_at", "updated_at"],
   books: [
     "id",
     "file_path",
@@ -184,6 +185,18 @@ class FakeSyncDb {
         .map(({ id, deleted_at }) => ({ id, deleted_at })) as T[];
     }
 
+    if (
+      normalized.startsWith(
+        "SELECT id, deleted_at FROM sync_tombstones WHERE table_name = ? AND id IN",
+      )
+    ) {
+      const [tableName, ...ids] = params.map(String);
+      const idSet = new Set(ids);
+      return [...this.tombstones.values()]
+        .filter((row) => row.table_name === tableName && idSet.has(row.id))
+        .map(({ id, deleted_at }) => ({ id, deleted_at })) as T[];
+    }
+
     const stateMatch = normalized.match(
       /^SELECT (\w+) AS id, (\w+) AS timestamp(, deleted_at AS deleted_at)? FROM (\w+) WHERE (\w+) IN \(/,
     );
@@ -211,6 +224,16 @@ class FakeSyncDb {
       normalized === "INSERT OR REPLACE INTO sync_metadata (key, value) VALUES ('last_sync_at', ?)"
     ) {
       this.syncMetadata.set("last_sync_at", String(params[0]));
+      return;
+    }
+
+    if (normalized.startsWith("INSERT INTO sync_tombstones")) {
+      const [id, tableName, deletedAt] = params;
+      this.tombstones.set(`${String(tableName)}:${String(id)}`, {
+        id: String(id),
+        table_name: String(tableName),
+        deleted_at: Number(deletedAt),
+      });
       return;
     }
 
@@ -380,6 +403,17 @@ function bookRow(overrides: Row = {}): Row {
   };
 }
 
+function groupRow(overrides: Row = {}): Row {
+  return {
+    id: "group-test",
+    name: "测试分组",
+    sort_order: 0,
+    created_at: 1000,
+    updated_at: 1000,
+    ...overrides,
+  };
+}
+
 function highlightRow(overrides: Row = {}): Row {
   return {
     id: "hl-1",
@@ -545,6 +579,42 @@ describe("simple sync convergence", () => {
 
     expect(payload.tables.books?.records).toHaveLength(1);
     expect(payload.tables.books?.deletedIds).toEqual([]);
+  });
+
+  it("keeps a remote group tombstone from being resurrected by an older device snapshot", async () => {
+    const target = new FakeSyncDb();
+    dbMocks.currentDb = target;
+    dbMocks.currentDeviceId = "device-local";
+
+    const deleted = await applyChanges({
+      deviceId: "device-a",
+      timestamp: 3000,
+      since: 0,
+      tables: {
+        book_groups: {
+          records: [],
+          deletedIds: ["group-test"],
+          deletedTimestamps: { "group-test": 3000 },
+        },
+      },
+    });
+
+    const staleRecord = await applyChanges({
+      deviceId: "device-b",
+      timestamp: 2000,
+      since: 0,
+      tables: {
+        book_groups: {
+          records: [groupRow({ updated_at: 2000 })],
+          deletedIds: [],
+        },
+      },
+    });
+
+    expect(deleted).toEqual({ applied: 1, skipped: 0 });
+    expect(staleRecord).toEqual({ applied: 0, skipped: 1 });
+    expect(target.get("book_groups", "group-test")).toBeUndefined();
+    expect(target.tombstones.get("book_groups:group-test")?.deleted_at).toBe(3000);
   });
 
   it("uploads a refreshed snapshot after receiving remote-only changes", async () => {

--- a/packages/core/src/sync/simple-sync.ts
+++ b/packages/core/src/sync/simple-sync.ts
@@ -372,7 +372,8 @@ export async function applyChanges(
 
           const deletedAt = tableData.deletedTimestamps?.[deletedId] ?? 0;
           if (!options.forceApply && deletedAt > 0) {
-            const localTs = existingRecords.get(String(deletedId))?.timestamp;
+            const localState = existingRecords.get(String(deletedId));
+            const localTs = localState?.timestamp;
             if (localTs !== undefined && localTs > deletedAt) {
               console.log(
                 `[SimpleSync] Skipping deletion of ${tableName}/${deletedId}: local record is newer (${localTs} > ${deletedAt})`,
@@ -382,8 +383,13 @@ export async function applyChanges(
             }
           }
           await db.execute(`DELETE FROM ${tableName} WHERE ${pk} = ?`, [deletedId]);
+          if (deletedAt > 0) {
+            await rememberRemoteTombstone(db, tableName, deletedId, deletedAt, payload.deviceId);
+          }
           applied++;
-          existingRecords.delete(String(deletedId));
+          existingRecords.set(String(deletedId), {
+            timestamp: deletedAt,
+          });
         }
 
         console.log(
@@ -458,6 +464,35 @@ function shouldApplyRemoteRecord(
   return (remoteDeletedAt ?? 0) > (localDeletedAt ?? 0);
 }
 
+async function rememberRemoteTombstone(
+  db: Awaited<ReturnType<typeof getDB>>,
+  tableName: string,
+  id: string,
+  deletedAt: number,
+  deviceId: string,
+): Promise<void> {
+  try {
+    await db.execute(
+      `INSERT INTO sync_tombstones (id, table_name, deleted_at, device_id)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(id, table_name) DO UPDATE SET
+         deleted_at = CASE
+           WHEN excluded.deleted_at > sync_tombstones.deleted_at
+           THEN excluded.deleted_at
+           ELSE sync_tombstones.deleted_at
+         END,
+         device_id = CASE
+           WHEN excluded.deleted_at > sync_tombstones.deleted_at
+           THEN excluded.device_id
+           ELSE sync_tombstones.device_id
+         END`,
+      [id, tableName, deletedAt, deviceId],
+    );
+  } catch {
+    // sync_tombstones may not exist on older schema variants.
+  }
+}
+
 async function loadExistingRecordStates(
   db: Awaited<ReturnType<typeof getDB>>,
   tableName: string,
@@ -490,6 +525,32 @@ async function loadExistingRecordStates(
         deletedAt: normalizeDeletedAt(row.deleted_at),
       });
     }
+  }
+
+  try {
+    for (let offset = 0; offset < ids.length; offset += chunkSize) {
+      const chunk = ids.slice(offset, offset + chunkSize);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const tombstones = await db.select<{ id: string; deleted_at: number }>(
+        `SELECT id, deleted_at
+         FROM sync_tombstones
+         WHERE table_name = ?
+           AND id IN (${placeholders})`,
+        [tableName, ...chunk],
+      );
+      for (const tombstone of tombstones) {
+        const id = String(tombstone.id);
+        const deletedAt = tombstone.deleted_at ?? 0;
+        const existing = states.get(id);
+        if (!existing || deletedAt > existing.timestamp) {
+          states.set(id, {
+            timestamp: deletedAt,
+          });
+        }
+      }
+    }
+  } catch {
+    // sync_tombstones may not exist on older schema variants.
   }
 
   return states;


### PR DESCRIPTION
## Summary
- persist remote tombstones locally when applying sync deletions
- use known tombstones when deciding whether to accept remote live records
- add a regression test for a deleted group being resurrected by an older device snapshot

## Testing
- pnpm --filter @readany/core test src/sync/__tests__/simple-sync.integration.test.ts
- pnpm --filter @readany/core exec tsc --noEmit
- pnpm version:check
- git diff --check