### PR TITLE
fix: show footnote tips and clamp book progress

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -116,6 +116,28 @@
       padding: 20px;
     }
 
+    #footnote-tip {
+      position: absolute;
+      z-index: 80;
+      display: none;
+      overflow-y: auto;
+      border: 1px solid rgba(127, 127, 127, 0.24);
+      border-radius: 8px;
+      background: var(--bg, #1c1c1e);
+      color: var(--fg, #e8e8ed);
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+      padding: 12px 14px;
+      font-size: 15px;
+      line-height: 1.65;
+      text-align: left;
+      word-break: break-word;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    #footnote-tip[data-visible="true"] {
+      display: block;
+    }
+
     /* Suppress iOS selection callout */
     * {
       -webkit-touch-callout: none !important;
@@ -132,6 +154,7 @@
     <div id="pull-bookmark-indicator" aria-hidden="true" data-armed="false">
       <div class="pill" id="pull-bookmark-indicator-text"></div>
     </div>
+    <button id="footnote-tip" type="button" aria-hidden="true"></button>
     <div id="loading">
       <div class="spinner"></div>
       <div id="loading-text">Loading...</div>
@@ -175,6 +198,7 @@
     let bookmarkPullGestureActive = false;
     let pullBookmarkResetTimer = null;
     let refreshAnnotationsTimer = null;
+    let activeFootnoteTipKey = null;
     let bookmarkPullStateMeta = {
       bookmarked: false,
       pullToAdd: '下滑添加书签',
@@ -731,6 +755,176 @@
       return !!doc?.__readany_noteTapGuardUntil && doc.__readany_noteTapGuardUntil > Date.now();
     }
 
+    function isFootnoteMarkerText(text) {
+      const value = String(text || '').replace(/\s+/g, '').trim();
+      if (!value) return false;
+      if (value === '注' || value === '註') return true;
+      return /^[\[\(（【〔［]?(?:\d{1,4}|[一二三四五六七八九十百千万零〇两]{1,8}|[ivxlcdmIVXLCDM]{1,10})[\]\)）】〕］]?$/.test(value);
+    }
+
+    function getHrefFragmentId(href) {
+      const value = String(href || '');
+      const hashIndex = value.indexOf('#');
+      if (hashIndex < 0 || hashIndex === value.length - 1) return null;
+      try {
+        return decodeURIComponent(value.slice(hashIndex + 1));
+      } catch {
+        return value.slice(hashIndex + 1);
+      }
+    }
+
+    function findElementByFragmentId(doc, fragmentId) {
+      if (!doc || !fragmentId) return null;
+      const byId = doc.getElementById(fragmentId);
+      if (byId) return byId;
+      try {
+        return doc.getElementsByName(fragmentId)[0] || null;
+      } catch {
+        return null;
+      }
+    }
+
+    function isFootnoteLikeElement(element) {
+      if (!element) return false;
+      const haystack = [
+        element.id,
+        element.getAttribute && element.getAttribute('role'),
+        element.getAttribute && element.getAttribute('type'),
+        element.getAttribute && element.getAttribute('epub:type'),
+        element.className,
+      ].map((value) => String(value || '').toLowerCase()).join(' ');
+      return /\b(doc-)?(noteref|footnote|endnote|rearnote|note)\b|fn(ref)?|duokan-footnote|calibre-footnote/.test(haystack);
+    }
+
+    function isLikelyFootnoteLink(anchor, href) {
+      if (!anchor) return false;
+      const rawHref = anchor.getAttribute('href') || href || '';
+      const hrefLower = String(rawHref).toLowerCase();
+      if (
+        isFootnoteLikeElement(anchor) ||
+        isFootnoteLikeElement(anchor.closest && anchor.closest('sup, span, a, [role], [type], [epub\\:type]'))
+      ) {
+        return true;
+      }
+      if (/(^|[#/_-])(fn|footnote|endnote|note|noteref|duokan-footnote|calibre-footnote)/i.test(hrefLower)) {
+        return true;
+      }
+      return isFootnoteMarkerText(anchor.textContent || '') && !!getHrefFragmentId(rawHref);
+    }
+
+    function getFootnoteTipKey(anchor, href) {
+      return [
+        anchor?.ownerDocument?.location?.href || '',
+        anchor?.getAttribute?.('href') || href || '',
+        anchor?.textContent?.trim() || '',
+      ].join('::');
+    }
+
+    function getFootnoteElementText(element) {
+      if (!element) return '';
+      let cloned;
+      try {
+        cloned = element instanceof Range
+          ? element.cloneContents()
+          : (() => {
+              const fragment = document.createDocumentFragment();
+              fragment.appendChild(element.cloneNode(true));
+              return fragment;
+            })();
+      } catch {
+        return '';
+      }
+
+      for (const node of Array.from(cloned.querySelectorAll('script, style, rt, rp, a[href]'))) {
+        const text = node.textContent || '';
+        if (node.matches('a[href]') && !isFootnoteMarkerText(text)) continue;
+        node.remove();
+      }
+
+      return String(cloned.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 600);
+    }
+
+    async function resolveFootnoteTipText(anchor, href) {
+      const rawHref = anchor?.getAttribute?.('href') || href || '';
+      const sourceDoc = anchor?.ownerDocument;
+      const localTarget = findElementByFragmentId(sourceDoc, getHrefFragmentId(rawHref));
+      if (localTarget && (isFootnoteLikeElement(localTarget) || isLikelyFootnoteLink(anchor, href))) {
+        return getFootnoteElementText(localTarget);
+      }
+
+      if (!view || !href) return '';
+      try {
+        const resolved = typeof view.resolveNavigation === 'function'
+          ? await Promise.resolve(view.resolveNavigation(href))
+          : currentBook?.resolveHref
+            ? await Promise.resolve(currentBook.resolveHref(href))
+            : null;
+        const targetIndex = resolved && Number.isInteger(resolved.index) ? resolved.index : -1;
+        if (targetIndex < 0) return '';
+        const currentContent = getRendererContents().find((item) => item && item.index === targetIndex && item.doc);
+        const targetDoc =
+          currentContent?.doc ||
+          (currentBook?.sections?.[targetIndex]?.createDocument
+            ? await currentBook.sections[targetIndex].createDocument()
+            : null);
+        if (!targetDoc) return '';
+        const target = typeof resolved.anchor === 'function' ? resolved.anchor(targetDoc) : null;
+        return getFootnoteElementText(target);
+      } catch {
+        return '';
+      }
+    }
+
+    function hideFootnoteTip() {
+      const tip = document.getElementById('footnote-tip');
+      activeFootnoteTipKey = null;
+      if (!tip) return;
+      tip.dataset.visible = 'false';
+      tip.setAttribute('aria-hidden', 'true');
+      tip.textContent = '';
+    }
+
+    function positionFootnoteTip(anchor, text) {
+      const tip = document.getElementById('footnote-tip');
+      const container = document.getElementById('reader-container');
+      if (!tip || !container || !anchor || !text) return false;
+
+      const rect = anchor.getBoundingClientRect();
+      const iframe = anchor.ownerDocument?.defaultView?.frameElement;
+      const iframeRect = iframe ? iframe.getBoundingClientRect() : { left: 0, top: 0 };
+      const containerRect = container.getBoundingClientRect();
+      const scaleX = iframe && iframe.clientWidth > 0 ? iframeRect.width / iframe.clientWidth : 1;
+      const scaleY = iframe && iframe.clientHeight > 0 ? iframeRect.height / iframe.clientHeight : 1;
+      const anchorX = iframeRect.left + rect.left * scaleX + rect.width * scaleX / 2 - containerRect.left;
+      const anchorTop = iframeRect.top + rect.top * scaleY - containerRect.top;
+      const anchorBottom = anchorTop + rect.height * scaleY;
+      const width = Math.max(180, Math.min(340, containerRect.width - 32));
+      const maxLeft = Math.max(16, containerRect.width - width - 16);
+      const left = Math.max(16, Math.min(maxLeft, anchorX - width / 2));
+      const belowTop = anchorBottom + 12;
+      const belowSpace = containerRect.height - belowTop - 16;
+      const aboveSpace = anchorTop - 16;
+      const placeAbove = belowSpace < 120 && aboveSpace > belowSpace;
+      const maxHeight = placeAbove
+        ? Math.max(96, Math.min(240, aboveSpace - 10))
+        : Math.max(96, Math.min(240, belowSpace));
+
+      tip.textContent = text;
+      tip.style.left = `${left}px`;
+      tip.style.width = `${width}px`;
+      tip.style.maxHeight = `${maxHeight}px`;
+      tip.style.top = '';
+      tip.style.bottom = '';
+      if (placeAbove) {
+        tip.style.bottom = `${Math.max(16, containerRect.height - anchorTop + 10)}px`;
+      } else {
+        tip.style.top = `${Math.max(16, Math.min(containerRect.height - maxHeight - 16, belowTop))}px`;
+      }
+      tip.dataset.visible = 'true';
+      tip.setAttribute('aria-hidden', 'false');
+      return true;
+    }
+
     // Attach long-press note tooltip detection to each doc
     function attachNoteLongPress(doc) {
       if (doc.__readany_noteLongPress) return;
@@ -1066,6 +1260,7 @@
         var snippetTimer = null;
         el.addEventListener('relocate', (e) => {
           markLoaded();
+          hideFootnoteTip();
           const detail = e.detail;
           const previousSectionIndex = currentSectionIndex;
           if (tapNavigationInFlight) {
@@ -1177,6 +1372,31 @@
           const { value, index, range } = e.detail;
           if (!value || !range) return;
           postShowAnnotation(value, range);
+        });
+
+        el.addEventListener('link', (e) => {
+          const detail = e.detail || {};
+          const anchor = detail.a;
+          const href = detail.href;
+          if (!anchor || !isLikelyFootnoteLink(anchor, href)) return;
+
+          e.preventDefault();
+          const key = getFootnoteTipKey(anchor, href);
+          if (activeFootnoteTipKey === key) {
+            hideFootnoteTip();
+            return;
+          }
+
+          Promise.resolve(resolveFootnoteTipText(anchor, href))
+            .then((text) => {
+              if (!text) {
+                hideFootnoteTip();
+                return;
+              }
+              activeFootnoteTipKey = key;
+              if (!positionFootnoteTip(anchor, text)) hideFootnoteTip();
+            })
+            .catch(() => hideFootnoteTip());
         });
 
         container.appendChild(el);
@@ -1650,7 +1870,12 @@ a { color: ${primary} !important; }
         }
 
         const target = e.target || state.target;
-        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) return;
+        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) {
+          if (!target.closest('a[href]')) hideFootnoteTip();
+          return;
+        }
+
+        hideFootnoteTip();
 
         const sel = doc.getSelection();
         if (sel && !sel.isCollapsed && sel.toString().trim().length > 0) return;

--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -1425,7 +1425,6 @@
           renderer.setAttribute('max-column-count', '1');
           renderer.setAttribute('max-block-size', '100%');
           renderer.setAttribute('max-inline-size', '100%');
-          renderer.setAttribute('animated', '');
           // Default gap/margin
           const margin = msg.pageMargin || 16;
           const gapPercent = Math.max(1, Math.round((margin / 393) * 100));

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -116,6 +116,28 @@
       padding: 20px;
     }
 
+    #footnote-tip {
+      position: absolute;
+      z-index: 80;
+      display: none;
+      overflow-y: auto;
+      border: 1px solid rgba(127, 127, 127, 0.24);
+      border-radius: 8px;
+      background: var(--bg, #1c1c1e);
+      color: var(--fg, #e8e8ed);
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+      padding: 12px 14px;
+      font-size: 15px;
+      line-height: 1.65;
+      text-align: left;
+      word-break: break-word;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    #footnote-tip[data-visible="true"] {
+      display: block;
+    }
+
     /* Suppress iOS selection callout */
     * {
       -webkit-touch-callout: none !important;
@@ -132,6 +154,7 @@
     <div id="pull-bookmark-indicator" aria-hidden="true" data-armed="false">
       <div class="pill" id="pull-bookmark-indicator-text"></div>
     </div>
+    <button id="footnote-tip" type="button" aria-hidden="true"></button>
     <div id="loading">
       <div class="spinner"></div>
       <div id="loading-text">Loading...</div>
@@ -175,6 +198,7 @@
     let bookmarkPullGestureActive = false;
     let pullBookmarkResetTimer = null;
     let refreshAnnotationsTimer = null;
+    let activeFootnoteTipKey = null;
     let bookmarkPullStateMeta = {
       bookmarked: false,
       pullToAdd: '下滑添加书签',
@@ -731,6 +755,176 @@
       return !!doc?.__readany_noteTapGuardUntil && doc.__readany_noteTapGuardUntil > Date.now();
     }
 
+    function isFootnoteMarkerText(text) {
+      const value = String(text || '').replace(/\s+/g, '').trim();
+      if (!value) return false;
+      if (value === '注' || value === '註') return true;
+      return /^[\[\(（【〔［]?(?:\d{1,4}|[一二三四五六七八九十百千万零〇两]{1,8}|[ivxlcdmIVXLCDM]{1,10})[\]\)）】〕］]?$/.test(value);
+    }
+
+    function getHrefFragmentId(href) {
+      const value = String(href || '');
+      const hashIndex = value.indexOf('#');
+      if (hashIndex < 0 || hashIndex === value.length - 1) return null;
+      try {
+        return decodeURIComponent(value.slice(hashIndex + 1));
+      } catch {
+        return value.slice(hashIndex + 1);
+      }
+    }
+
+    function findElementByFragmentId(doc, fragmentId) {
+      if (!doc || !fragmentId) return null;
+      const byId = doc.getElementById(fragmentId);
+      if (byId) return byId;
+      try {
+        return doc.getElementsByName(fragmentId)[0] || null;
+      } catch {
+        return null;
+      }
+    }
+
+    function isFootnoteLikeElement(element) {
+      if (!element) return false;
+      const haystack = [
+        element.id,
+        element.getAttribute && element.getAttribute('role'),
+        element.getAttribute && element.getAttribute('type'),
+        element.getAttribute && element.getAttribute('epub:type'),
+        element.className,
+      ].map((value) => String(value || '').toLowerCase()).join(' ');
+      return /\b(doc-)?(noteref|footnote|endnote|rearnote|note)\b|fn(ref)?|duokan-footnote|calibre-footnote/.test(haystack);
+    }
+
+    function isLikelyFootnoteLink(anchor, href) {
+      if (!anchor) return false;
+      const rawHref = anchor.getAttribute('href') || href || '';
+      const hrefLower = String(rawHref).toLowerCase();
+      if (
+        isFootnoteLikeElement(anchor) ||
+        isFootnoteLikeElement(anchor.closest && anchor.closest('sup, span, a, [role], [type], [epub\\:type]'))
+      ) {
+        return true;
+      }
+      if (/(^|[#/_-])(fn|footnote|endnote|note|noteref|duokan-footnote|calibre-footnote)/i.test(hrefLower)) {
+        return true;
+      }
+      return isFootnoteMarkerText(anchor.textContent || '') && !!getHrefFragmentId(rawHref);
+    }
+
+    function getFootnoteTipKey(anchor, href) {
+      return [
+        anchor?.ownerDocument?.location?.href || '',
+        anchor?.getAttribute?.('href') || href || '',
+        anchor?.textContent?.trim() || '',
+      ].join('::');
+    }
+
+    function getFootnoteElementText(element) {
+      if (!element) return '';
+      let cloned;
+      try {
+        cloned = element instanceof Range
+          ? element.cloneContents()
+          : (() => {
+              const fragment = document.createDocumentFragment();
+              fragment.appendChild(element.cloneNode(true));
+              return fragment;
+            })();
+      } catch {
+        return '';
+      }
+
+      for (const node of Array.from(cloned.querySelectorAll('script, style, rt, rp, a[href]'))) {
+        const text = node.textContent || '';
+        if (node.matches('a[href]') && !isFootnoteMarkerText(text)) continue;
+        node.remove();
+      }
+
+      return String(cloned.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 600);
+    }
+
+    async function resolveFootnoteTipText(anchor, href) {
+      const rawHref = anchor?.getAttribute?.('href') || href || '';
+      const sourceDoc = anchor?.ownerDocument;
+      const localTarget = findElementByFragmentId(sourceDoc, getHrefFragmentId(rawHref));
+      if (localTarget && (isFootnoteLikeElement(localTarget) || isLikelyFootnoteLink(anchor, href))) {
+        return getFootnoteElementText(localTarget);
+      }
+
+      if (!view || !href) return '';
+      try {
+        const resolved = typeof view.resolveNavigation === 'function'
+          ? await Promise.resolve(view.resolveNavigation(href))
+          : currentBook?.resolveHref
+            ? await Promise.resolve(currentBook.resolveHref(href))
+            : null;
+        const targetIndex = resolved && Number.isInteger(resolved.index) ? resolved.index : -1;
+        if (targetIndex < 0) return '';
+        const currentContent = getRendererContents().find((item) => item && item.index === targetIndex && item.doc);
+        const targetDoc =
+          currentContent?.doc ||
+          (currentBook?.sections?.[targetIndex]?.createDocument
+            ? await currentBook.sections[targetIndex].createDocument()
+            : null);
+        if (!targetDoc) return '';
+        const target = typeof resolved.anchor === 'function' ? resolved.anchor(targetDoc) : null;
+        return getFootnoteElementText(target);
+      } catch {
+        return '';
+      }
+    }
+
+    function hideFootnoteTip() {
+      const tip = document.getElementById('footnote-tip');
+      activeFootnoteTipKey = null;
+      if (!tip) return;
+      tip.dataset.visible = 'false';
+      tip.setAttribute('aria-hidden', 'true');
+      tip.textContent = '';
+    }
+
+    function positionFootnoteTip(anchor, text) {
+      const tip = document.getElementById('footnote-tip');
+      const container = document.getElementById('reader-container');
+      if (!tip || !container || !anchor || !text) return false;
+
+      const rect = anchor.getBoundingClientRect();
+      const iframe = anchor.ownerDocument?.defaultView?.frameElement;
+      const iframeRect = iframe ? iframe.getBoundingClientRect() : { left: 0, top: 0 };
+      const containerRect = container.getBoundingClientRect();
+      const scaleX = iframe && iframe.clientWidth > 0 ? iframeRect.width / iframe.clientWidth : 1;
+      const scaleY = iframe && iframe.clientHeight > 0 ? iframeRect.height / iframe.clientHeight : 1;
+      const anchorX = iframeRect.left + rect.left * scaleX + rect.width * scaleX / 2 - containerRect.left;
+      const anchorTop = iframeRect.top + rect.top * scaleY - containerRect.top;
+      const anchorBottom = anchorTop + rect.height * scaleY;
+      const width = Math.max(180, Math.min(340, containerRect.width - 32));
+      const maxLeft = Math.max(16, containerRect.width - width - 16);
+      const left = Math.max(16, Math.min(maxLeft, anchorX - width / 2));
+      const belowTop = anchorBottom + 12;
+      const belowSpace = containerRect.height - belowTop - 16;
+      const aboveSpace = anchorTop - 16;
+      const placeAbove = belowSpace < 120 && aboveSpace > belowSpace;
+      const maxHeight = placeAbove
+        ? Math.max(96, Math.min(240, aboveSpace - 10))
+        : Math.max(96, Math.min(240, belowSpace));
+
+      tip.textContent = text;
+      tip.style.left = `${left}px`;
+      tip.style.width = `${width}px`;
+      tip.style.maxHeight = `${maxHeight}px`;
+      tip.style.top = '';
+      tip.style.bottom = '';
+      if (placeAbove) {
+        tip.style.bottom = `${Math.max(16, containerRect.height - anchorTop + 10)}px`;
+      } else {
+        tip.style.top = `${Math.max(16, Math.min(containerRect.height - maxHeight - 16, belowTop))}px`;
+      }
+      tip.dataset.visible = 'true';
+      tip.setAttribute('aria-hidden', 'false');
+      return true;
+    }
+
     // Attach long-press note tooltip detection to each doc
     function attachNoteLongPress(doc) {
       if (doc.__readany_noteLongPress) return;
@@ -1066,6 +1260,7 @@
         var snippetTimer = null;
         el.addEventListener('relocate', (e) => {
           markLoaded();
+          hideFootnoteTip();
           const detail = e.detail;
           const previousSectionIndex = currentSectionIndex;
           if (tapNavigationInFlight) {
@@ -1177,6 +1372,31 @@
           const { value, index, range } = e.detail;
           if (!value || !range) return;
           postShowAnnotation(value, range);
+        });
+
+        el.addEventListener('link', (e) => {
+          const detail = e.detail || {};
+          const anchor = detail.a;
+          const href = detail.href;
+          if (!anchor || !isLikelyFootnoteLink(anchor, href)) return;
+
+          e.preventDefault();
+          const key = getFootnoteTipKey(anchor, href);
+          if (activeFootnoteTipKey === key) {
+            hideFootnoteTip();
+            return;
+          }
+
+          Promise.resolve(resolveFootnoteTipText(anchor, href))
+            .then((text) => {
+              if (!text) {
+                hideFootnoteTip();
+                return;
+              }
+              activeFootnoteTipKey = key;
+              if (!positionFootnoteTip(anchor, text)) hideFootnoteTip();
+            })
+            .catch(() => hideFootnoteTip());
         });
 
         container.appendChild(el);
@@ -1650,7 +1870,12 @@ a { color: ${primary} !important; }
         }
 
         const target = e.target || state.target;
-        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) return;
+        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) {
+          if (!target.closest('a[href]')) hideFootnoteTip();
+          return;
+        }
+
+        hideFootnoteTip();
 
         const sel = doc.getSelection();
         if (sel && !sel.isCollapsed && sel.toString().trim().length > 0) return;

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1425,7 +1425,6 @@
           renderer.setAttribute('max-column-count', '1');
           renderer.setAttribute('max-block-size', '100%');
           renderer.setAttribute('max-inline-size', '100%');
-          renderer.setAttribute('animated', '');
           // Default gap/margin
           const margin = msg.pageMargin || 16;
           const gapPercent = Math.max(1, Math.round((margin / 393) * 100));

--- a/packages/app-expo/src/components/library/BookCard.tsx
+++ b/packages/app-expo/src/components/library/BookCard.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckIcon,
-  ClockIcon,
-  Loader2Icon,
-  MoreVerticalIcon,
-} from "@/components/ui/Icon";
+import { CheckIcon, ClockIcon, Loader2Icon, MoreVerticalIcon } from "@/components/ui/Icon";
 import { useColors } from "@/styles/theme";
 import { getPlatformService } from "@readany/core/services";
 /**
@@ -11,6 +6,7 @@ import { getPlatformService } from "@readany/core/services";
  * Cover (28:41), progress bar, vectorization overlay, tag badges, long-press action sheet.
  */
 import type { Book } from "@readany/core/types";
+import { getBookProgressPercent } from "@readany/core/utils";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -121,7 +117,7 @@ export const BookCard = memo(function BookCard({
     })();
   }, [book.meta.coverUrl]);
 
-  const progressPct = Math.round(book.progress * 100);
+  const progressPct = getBookProgressPercent(book.progress);
 
   const vecPct = vectorProgress
     ? vectorProgress.totalChunks > 0

--- a/packages/app-expo/src/screens/BookDetailsScreen.tsx
+++ b/packages/app-expo/src/screens/BookDetailsScreen.tsx
@@ -30,6 +30,7 @@ import {
   buildBookMetadataUpdate,
   createBookMetadataFormValues,
   createEmptyBookReview,
+  getBookProgressPercent,
   hasMissingBookMetadataAutoFillTargets,
   mergeMissingBookMetadataValues,
   splitEditableList,
@@ -434,7 +435,7 @@ export function BookDetailsScreen({ route }: Props) {
     );
   }
 
-  const progressPct = Math.round(book.progress * 100);
+  const progressPct = getBookProgressPercent(book.progress);
   const groupName = resolveGroupName(book, groups, t("sidebar.uncategorized", "未分类"));
   const reviewCount = values.reviews.filter((review) => review.content.trim()).length;
 

--- a/packages/app-expo/src/screens/stats/PeriodBookList.tsx
+++ b/packages/app-expo/src/screens/stats/PeriodBookList.tsx
@@ -1,5 +1,6 @@
 import { useColors } from "@/styles/theme";
 import type { PeriodBookStats } from "@readany/core/stats";
+import { getBookProgressPercent } from "@readany/core/utils";
 import { useTranslation } from "react-i18next";
 import { Image, Text, View } from "react-native";
 import { makeStyles } from "./stats-styles";
@@ -17,15 +18,14 @@ export function PeriodBookList({
   const s = makeStyles(colors);
 
   if (books.length === 0) {
-    return (
-      <Text style={s.periodBooksEmpty}>{t("stats.noBooksInPeriod")}</Text>
-    );
+    return <Text style={s.periodBooksEmpty}>{t("stats.noBooksInPeriod")}</Text>;
   }
 
   return (
     <View style={{ gap: 6 }}>
       {books.map((book) => {
         const coverUrl = resolvedCovers.get(book.bookId) || book.coverUrl;
+        const progressPct = getBookProgressPercent(book.progress);
         return (
           <View key={book.bookId} style={s.bookRow}>
             {coverUrl ? (
@@ -37,15 +37,17 @@ export function PeriodBookList({
             )}
             <View style={s.bookInfo}>
               <View style={s.bookTitleRow}>
-                <Text style={s.bookTitle} numberOfLines={1}>{book.title}</Text>
+                <Text style={s.bookTitle} numberOfLines={1}>
+                  {book.title}
+                </Text>
                 <Text style={s.bookTime}>{formatTime(book.totalTime)}</Text>
               </View>
               {book.author && <Text style={s.bookAuthor}>{book.author}</Text>}
               <View style={s.progressRow}>
                 <View style={s.progressTrack}>
-                  <View style={[s.progressFill, { width: `${Math.min(book.progress * 100, 100)}%` }]} />
+                  <View style={[s.progressFill, { width: `${progressPct}%` }]} />
                 </View>
-                <Text style={s.progressPercent}>{Math.round(book.progress * 100)}%</Text>
+                <Text style={s.progressPercent}>{progressPct}%</Text>
               </View>
             </View>
           </View>

--- a/packages/app/src/components/home/BookCard.tsx
+++ b/packages/app/src/components/home/BookCard.tsx
@@ -20,6 +20,7 @@ import { useLibraryStore } from "@/stores/library-store";
 import { useReaderStore } from "@/stores/reader-store";
 import { useVectorModelStore } from "@/stores/vector-model-store";
 import type { Book, VectorizeProgress } from "@readany/core/types";
+import { getBookProgressPercent } from "@readany/core/utils";
 import {
   Check,
   ChevronRight,
@@ -81,7 +82,7 @@ export const BookCard = memo(function BookCard({
   const menuBtnRef = useRef<HTMLButtonElement>(null);
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
   const suppressOpenUntilRef = useRef(0);
-  const progressPct = Math.round(book.progress * 100);
+  const progressPct = getBookProgressPercent(book.progress);
   const coverSrc = useResolvedSrc(book.meta.coverUrl);
   const syncVersion = useSyncVersion();
   const coverImageKey = coverSrc ? `${coverSrc}-${syncVersion}` : "";

--- a/packages/app/src/components/home/BookDetailsDialog.tsx
+++ b/packages/app/src/components/home/BookDetailsDialog.tsx
@@ -33,6 +33,7 @@ import {
   cn,
   createBookMetadataFormValues,
   createEmptyBookReview,
+  getBookProgressPercent,
   hasMissingBookMetadataAutoFillTargets,
   mergeMissingBookMetadataValues,
   splitEditableList,
@@ -359,7 +360,7 @@ export function BookDetailsDialog({ book, open, onOpenChange }: BookDetailsDialo
     );
   };
 
-  const progressPct = Math.round(book.progress * 100);
+  const progressPct = getBookProgressPercent(book.progress);
   const handleDialogOpenChange = (nextOpen: boolean) => {
     if (!nextOpen && values && hasMetadataChanges(values)) {
       if (autoSaveTimerRef.current !== null) {

--- a/packages/app/src/components/home/BookList.tsx
+++ b/packages/app/src/components/home/BookList.tsx
@@ -4,6 +4,7 @@ import { useResolvedSrc } from "@/hooks/use-resolved-src";
  */
 import { openDesktopBook } from "@/lib/library/open-book";
 import type { Book } from "@readany/core/types";
+import { getBookProgressPercent } from "@readany/core/utils";
 import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -19,7 +20,7 @@ interface BookListItemProps {
 function BookListItem({ book, onOpen }: BookListItemProps) {
   const { t } = useTranslation();
   const coverSrc = useResolvedSrc(book.meta.coverUrl);
-  const pct = Math.round(book.progress * 100);
+  const pct = getBookProgressPercent(book.progress);
   const isRemote = book.syncStatus === "remote";
   const isDownloading = book.syncStatus === "downloading";
 

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -2717,10 +2717,6 @@ function applyRendererSettings(
     applyReflowLayoutSettings(view, settings);
   }
 
-  if (!isFixedLayout) {
-    renderer.setAttribute("animated", "");
-  }
-
   // Apply CSS styles (skip font overrides for fixed layout)
   applyRendererStyles(view, settings, isFixedLayout, theme);
 }

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -230,11 +230,7 @@ function getTTSSegmentIdentity(cfi?: string | null, text?: string | null) {
   return `${cfi || ""}::${normalizeTTSSegmentText(text)}`;
 }
 
-function getIframeClickMetrics(
-  doc: Document,
-  container: HTMLElement | null,
-  clientX: number,
-) {
+function getIframeClickMetrics(doc: Document, container: HTMLElement | null, clientX: number) {
   const iframe = doc.defaultView?.frameElement as HTMLIFrameElement | null;
   if (!iframe || !container) return null;
 
@@ -256,6 +252,168 @@ function getIframeClickMetrics(
       left: containerRect.left,
       width: containerRect.width,
     },
+  };
+}
+
+function isFootnoteMarkerText(text: string): boolean {
+  const value = text.replace(/\s+/g, "").trim();
+  if (!value) return false;
+  if (value === "注" || value === "註") return true;
+  return /^[\[\(（【〔［]?(?:\d{1,4}|[一二三四五六七八九十百千万零〇两]{1,8}|[ivxlcdmIVXLCDM]{1,10})[\]\)）】〕］]?$/.test(
+    value,
+  );
+}
+
+function getHrefFragmentId(href?: string | null): string | null {
+  if (!href) return null;
+  const hashIndex = href.indexOf("#");
+  if (hashIndex < 0 || hashIndex === href.length - 1) return null;
+  try {
+    return decodeURIComponent(href.slice(hashIndex + 1));
+  } catch {
+    return href.slice(hashIndex + 1);
+  }
+}
+
+function findElementByFragmentId(doc: Document, fragmentId: string | null): Element | null {
+  if (!fragmentId) return null;
+  const byId = doc.getElementById(fragmentId);
+  if (byId) return byId;
+  return doc.getElementsByName(fragmentId)[0] ?? null;
+}
+
+function isFootnoteLikeElement(element: Element | null): boolean {
+  if (!element) return false;
+  const haystack = [
+    element.id,
+    element.getAttribute("role"),
+    element.getAttribute("type"),
+    element.getAttribute("epub:type"),
+    element.className,
+  ]
+    .map((value) => String(value || "").toLowerCase())
+    .join(" ");
+  return /\b(doc-)?(noteref|footnote|endnote|rearnote|note)\b|fn(ref)?|duokan-footnote|calibre-footnote/.test(
+    haystack,
+  );
+}
+
+function isLikelyFootnoteLink(anchor: HTMLAnchorElement, href?: string | null): boolean {
+  const rawHref = anchor.getAttribute("href") || href || "";
+  const hrefLower = rawHref.toLowerCase();
+  const markerText = isFootnoteMarkerText(anchor.textContent || "");
+  if (
+    isFootnoteLikeElement(anchor) ||
+    isFootnoteLikeElement(anchor.closest("sup, span, a, [role], [type], [epub\\:type]"))
+  ) {
+    return true;
+  }
+  if (
+    /(^|[#/_-])(fn|footnote|endnote|note|noteref|duokan-footnote|calibre-footnote)/i.test(hrefLower)
+  ) {
+    return true;
+  }
+  return markerText && Boolean(getHrefFragmentId(rawHref));
+}
+
+function getElementPreviewText(element: Element | Range | null): string {
+  if (!element) return "";
+  const cloned =
+    element instanceof Range
+      ? element.cloneContents()
+      : element.cloneNode(true) instanceof DocumentFragment
+        ? (element.cloneNode(true) as DocumentFragment)
+        : (() => {
+            const fragment = document.createDocumentFragment();
+            fragment.appendChild(element.cloneNode(true));
+            return fragment;
+          })();
+
+  for (const node of Array.from(cloned.querySelectorAll("script, style, rt, rp, a[href]"))) {
+    const text = node.textContent || "";
+    if (node.matches("a[href]") && !isFootnoteMarkerText(text)) continue;
+    node.remove();
+  }
+
+  return cleanText(cloned.textContent || "").slice(0, 600);
+}
+
+async function resolveFootnotePreviewText(
+  view: FoliateView | null,
+  anchor: HTMLAnchorElement,
+  href?: string | null,
+): Promise<string> {
+  const rawHref = anchor.getAttribute("href") || href || "";
+  const sourceDoc = anchor.ownerDocument;
+  const localTarget = findElementByFragmentId(sourceDoc, getHrefFragmentId(rawHref));
+  if (localTarget && (isFootnoteLikeElement(localTarget) || isLikelyFootnoteLink(anchor, href))) {
+    return getElementPreviewText(localTarget);
+  }
+
+  if (!view?.resolveNavigation || !href) return "";
+  try {
+    const resolved = await Promise.resolve(view.resolveNavigation(href));
+    const targetIndex = resolved?.index;
+    if (typeof targetIndex !== "number") return "";
+    const currentContent = view.renderer
+      ?.getContents?.()
+      ?.find((item: { index?: number }) => item.index === targetIndex);
+    const targetDoc =
+      (currentContent?.doc as Document | undefined) ??
+      (await view.book?.sections?.[targetIndex]?.createDocument?.());
+    if (!targetDoc) return "";
+    const target = typeof resolved.anchor === "function" ? resolved.anchor(targetDoc) : null;
+    return getElementPreviewText(target);
+  } catch {
+    return "";
+  }
+}
+
+function getFootnotePreviewKey(anchor: HTMLAnchorElement, href?: string | null): string {
+  return [
+    anchor.ownerDocument.location?.href || "",
+    anchor.getAttribute("href") || href || "",
+    anchor.textContent?.trim() || "",
+  ].join("::");
+}
+
+function getAnchorPreviewPosition(
+  anchor: HTMLAnchorElement,
+  container: HTMLElement | null,
+): Omit<FootnotePreview, "key" | "text"> | null {
+  if (!container) return null;
+  const rect = anchor.getBoundingClientRect();
+  const iframe = anchor.ownerDocument.defaultView?.frameElement as HTMLIFrameElement | null;
+  const iframeRect = iframe?.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  const scaleX =
+    iframe && iframe.clientWidth > 0 && iframeRect ? iframeRect.width / iframe.clientWidth : 1;
+  const scaleY =
+    iframe && iframe.clientHeight > 0 && iframeRect ? iframeRect.height / iframe.clientHeight : 1;
+  const anchorX =
+    (iframeRect?.left ?? 0) + rect.left * scaleX + (rect.width * scaleX) / 2 - containerRect.left;
+  const anchorTop = (iframeRect?.top ?? 0) + rect.top * scaleY - containerRect.top;
+  const anchorBottom = anchorTop + rect.height * scaleY;
+  const width = Math.max(180, Math.min(360, containerRect.width - 32));
+  const maxLeft = Math.max(16, containerRect.width - width - 16);
+  const left = Math.max(16, Math.min(maxLeft, anchorX - width / 2));
+  const belowTop = anchorBottom + 12;
+  const belowSpace = containerRect.height - belowTop - 16;
+  const aboveSpace = anchorTop - 16;
+  const placement = belowSpace < 120 && aboveSpace > belowSpace ? "above" : "below";
+  const maxHeight =
+    placement === "above"
+      ? Math.max(96, Math.min(260, aboveSpace - 10))
+      : Math.max(96, Math.min(260, belowSpace));
+  const top = Math.max(16, Math.min(containerRect.height - maxHeight - 16, belowTop));
+  return {
+    left,
+    width,
+    maxHeight,
+    placement,
+    ...(placement === "above"
+      ? { bottom: Math.max(16, containerRect.height - anchorTop + 10) }
+      : { top }),
   };
 }
 
@@ -404,6 +562,22 @@ interface FoliateViewerProps {
   onToggleChat?: () => void;
 }
 
+interface LinkEventDetail {
+  a?: HTMLAnchorElement;
+  href?: string;
+}
+
+interface FootnotePreview {
+  key: string;
+  text: string;
+  left: number;
+  width: number;
+  maxHeight: number;
+  placement: "above" | "below";
+  top?: number;
+  bottom?: number;
+}
+
 export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>(
   function FoliateViewer(
     {
@@ -430,6 +604,8 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
     const viewRef = useRef<FoliateView | null>(null);
     const isViewCreated = useRef(false);
     const [loading, setLoading] = useState(true);
+    const [footnotePreview, setFootnotePreview] = useState<FootnotePreview | null>(null);
+    const activeFootnoteKeyRef = useRef<string | null>(null);
 
     const isFixedLayout = isFixedLayoutBook(format, bookDoc);
     // Track when view is ready so hooks/events re-bind
@@ -1488,6 +1664,8 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
                 },
               }
             : rawDetail;
+        activeFootnoteKeyRef.current = null;
+        setFootnotePreview(null);
         onRelocate?.(detail);
 
         // Update reading context service
@@ -1585,6 +1763,33 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
     // Stable wrapper functions that delegate to latest impl via ref
     const docLoadHandler = useCallback((event: Event) => docLoadHandlerRef.current(event), []);
     const relocateHandler = useCallback((event: Event) => relocateHandlerRef.current(event), []);
+
+    const linkHandler = useCallback((event: Event) => {
+      const customEvent = event as CustomEvent<LinkEventDetail>;
+      const anchor = customEvent.detail?.a;
+      const href = customEvent.detail?.href;
+      if (!anchor || !isLikelyFootnoteLink(anchor, href)) return;
+
+      event.preventDefault();
+      annotationClickedRef.current = true;
+      const key = getFootnotePreviewKey(anchor, href);
+      if (activeFootnoteKeyRef.current === key) {
+        activeFootnoteKeyRef.current = null;
+        setFootnotePreview(null);
+        return;
+      }
+      void (async () => {
+        const text = await resolveFootnotePreviewText(viewRef.current, anchor, href);
+        const position = getAnchorPreviewPosition(anchor, containerRef.current);
+        if (!text || !position) {
+          activeFootnoteKeyRef.current = null;
+          setFootnotePreview(null);
+          return;
+        }
+        activeFootnoteKeyRef.current = key;
+        setFootnotePreview({ key, text, ...position });
+      })();
+    }, []);
 
     // --- Draw annotation handler ---
     // This is called by foliate-js when an annotation needs to be rendered
@@ -2152,6 +2357,7 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
       onRelocate: relocateHandler,
       onDrawAnnotation: drawAnnotationHandler,
       onShowAnnotation: showAnnotationHandler,
+      onLink: linkHandler,
     });
 
     // --- Open book ---
@@ -2231,6 +2437,7 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
           view.addEventListener("draw-annotation", drawAnnotationHandler);
           view.addEventListener("delete-annotation", deleteAnnotationHandler);
           view.addEventListener("show-annotation", showAnnotationHandler);
+          view.addEventListener("link", linkHandler);
           setViewReady(true);
 
           // Navigate to last location or start
@@ -2359,6 +2566,8 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
         const view = viewRef.current;
         if (!container) return;
         if (target !== container && target !== view) return;
+        activeFootnoteKeyRef.current = null;
+        setFootnotePreview(null);
 
         const rect = container.getBoundingClientRect();
         console.log("[ReaderTap][shell:post]", {
@@ -2391,6 +2600,22 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
         tabIndex={-1}
         onClick={handleViewerShellClick}
       >
+        {footnotePreview && (
+          <button
+            type="button"
+            className="absolute z-40 max-w-[min(360px,calc(100%-32px))] overflow-y-auto rounded-md border border-border bg-popover px-3.5 py-3 text-left text-sm leading-relaxed text-popover-foreground shadow-lg"
+            style={{
+              left: footnotePreview.left,
+              top: footnotePreview.top,
+              bottom: footnotePreview.bottom,
+              width: footnotePreview.width,
+              maxHeight: footnotePreview.maxHeight,
+            }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <span className="block whitespace-pre-wrap">{footnotePreview.text}</span>
+          </button>
+        )}
         {loading && (
           <div className="absolute inset-0 flex items-center justify-center bg-background">
             <div className="flex flex-col items-center gap-3">

--- a/packages/app/src/components/stats/PeriodBookList.tsx
+++ b/packages/app/src/components/stats/PeriodBookList.tsx
@@ -1,5 +1,6 @@
 import { useResolvedSrc } from "@/hooks/use-resolved-src";
 import type { PeriodBookStats } from "@readany/core/stats";
+import { getBookProgressPercent } from "@readany/core/utils";
 /**
  * PeriodBookList — shows books read in a time period with reading time and progress
  */
@@ -15,6 +16,7 @@ interface PeriodBookListItemProps {
 
 function PeriodBookListItem({ book }: PeriodBookListItemProps) {
   const coverSrc = useResolvedSrc(book.coverUrl);
+  const progressPct = getBookProgressPercent(book.progress);
 
   return (
     <div className="flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-muted/40">
@@ -43,12 +45,10 @@ function PeriodBookListItem({ book }: PeriodBookListItemProps) {
           <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
             <div
               className="h-full rounded-full bg-emerald-500 transition-all"
-              style={{ width: `${Math.min(book.progress * 100, 100)}%` }}
+              style={{ width: `${progressPct}%` }}
             />
           </div>
-          <span className="text-[10px] text-muted-foreground">
-            {Math.round(book.progress * 100)}%
-          </span>
+          <span className="text-[10px] text-muted-foreground">{progressPct}%</span>
         </div>
       </div>
     </div>

--- a/packages/core/src/ai/system-prompt.ts
+++ b/packages/core/src/ai/system-prompt.ts
@@ -8,6 +8,7 @@
  * 6. Response constraints
  */
 import type { Book, SemanticContext, Skill } from "../types";
+import { getBookProgressPercent } from "../utils/book-progress";
 
 interface PromptContext {
   book: Book | null;
@@ -59,7 +60,7 @@ function buildBookContextSection(book: Book | null): string {
     `- Title: ${book.meta.title}`,
     `- Author: ${book.meta.author}`,
     book.meta.language ? `- Language: ${book.meta.language}` : "",
-    `- Reading Progress: ${Math.round(book.progress * 100)}%`,
+    `- Reading Progress: ${getBookProgressPercent(book.progress)}%`,
   ]
     .filter(Boolean)
     .join("\n");
@@ -221,7 +222,9 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
 
   steps.push("3. **Register citations before answering** — If your answer uses book content:");
   steps.push("   - Call **addCitation** before writing the final response body");
-  steps.push("   - Wait for addCitation to return successfully before using the matching [N] marker");
+  steps.push(
+    "   - Wait for addCitation to return successfully before using the matching [N] marker",
+  );
   steps.push("   - This rule applies to BOTH indexed books and non-indexed fallback content");
   steps.push("4. **Synthesize and answer** — Only after citation registration, write your answer");
   steps.push("");
@@ -250,10 +253,14 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     steps.push("   - Plot events, character descriptions, or story details");
     steps.push("   - Any content retrieved via ragSearch, summarize, or content tools");
     steps.push("   - General knowledge not from this book does not need citation");
-    steps.push("   - Your own analysis does not need citation, but cite the content you're analyzing");
+    steps.push(
+      "   - Your own analysis does not need citation, but cite the content you're analyzing",
+    );
     steps.push("");
     steps.push("4. **Citation workflow with CFI:**");
-    steps.push("   - Step 1: Use ragSearch/ragContext or indexed analysis tools to retrieve content");
+    steps.push(
+      "   - Step 1: Use ragSearch/ragContext or indexed analysis tools to retrieve content",
+    );
     steps.push("   - Step 2: Extract chapterTitle, chapterIndex, and **CFI** from tool results");
     steps.push(
       "   - Step 3: Call addCitation with the extracted CFI and set citationIndex to the number you will use in [N]",
@@ -261,9 +268,7 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     steps.push(
       "     The citationIndex values MUST follow the final response marker order exactly: the source for [1] uses citationIndex=1, [2] uses citationIndex=2, etc. Never swap citationIndex values even if tool calls complete out of order.",
     );
-    steps.push(
-      "   - Step 4: Wait for addCitation to return a citation result successfully",
-    );
+    steps.push("   - Step 4: Wait for addCitation to return a citation result successfully");
     steps.push(
       "   - Step 5: Write your final response using [1], [2] to reference citations — each must match the citationIndex you set",
     );
@@ -366,7 +371,7 @@ function buildConstraintsSection(
   ];
 
   if (spoilerFree && book) {
-    const progress = Math.round(book.progress * 100);
+    const progress = getBookProgressPercent(book.progress);
     const chapter = semanticContext?.currentChapter || "unknown";
     lines.push("");
     lines.push("### Spoiler-Free Mode (ACTIVE)");

--- a/packages/core/src/export/annotation-exporter.ts
+++ b/packages/core/src/export/annotation-exporter.ts
@@ -1,11 +1,12 @@
-import { getPlatformService } from "../services/platform";
 /**
  * Annotation Exporter — export highlights and notes in multiple formats
  * Supports: Markdown, JSON, Obsidian (with frontmatter), Notion (clipboard-friendly)
  *
  * Cross-platform: uses IPlatformService for file download and clipboard operations.
  */
+import { getPlatformService } from "../services/platform";
 import type { Book, Highlight, Note } from "../types";
+import { getBookProgressPercent } from "../utils/book-progress";
 
 export type ExportFormat = "markdown" | "json" | "obsidian" | "notion";
 
@@ -166,7 +167,7 @@ export class AnnotationExporter {
       `author: "${book.meta.author}"`,
       "type: book-notes",
       `created: ${new Date().toISOString()}`,
-      `progress: ${Math.round(book.progress * 100)}%`,
+      `progress: ${getBookProgressPercent(book.progress)}%`,
       "tags:",
       "  - book",
       "  - reading-notes",
@@ -177,7 +178,7 @@ export class AnnotationExporter {
       "",
       "## Metadata",
       `- **Author:** [[${book.meta.author}]]`,
-      `- **Progress:** ${Math.round(book.progress * 100)}%`,
+      `- **Progress:** ${getBookProgressPercent(book.progress)}%`,
       `- **Exported:** ${new Date().toLocaleDateString()}`,
       "",
       "---",

--- a/packages/core/src/hooks/reader/useFoliateEvents.ts
+++ b/packages/core/src/hooks/reader/useFoliateEvents.ts
@@ -11,6 +11,7 @@ export interface FoliateEventHandlers {
   onRelocate?: (event: Event) => void;
   onDrawAnnotation?: (event: Event) => void;
   onShowAnnotation?: (event: Event) => void;
+  onLink?: (event: Event) => void;
   onExternalLink?: (event: Event) => void;
 }
 
@@ -19,6 +20,7 @@ export function useFoliateEvents(view: FoliateView | null, handlers?: FoliateEve
   const onRelocate = handlers?.onRelocate;
   const onDrawAnnotation = handlers?.onDrawAnnotation;
   const onShowAnnotation = handlers?.onShowAnnotation;
+  const onLink = handlers?.onLink;
   const onExternalLink = handlers?.onExternalLink;
 
   useEffect(() => {
@@ -28,6 +30,7 @@ export function useFoliateEvents(view: FoliateView | null, handlers?: FoliateEve
     if (onRelocate) view.addEventListener("relocate", onRelocate);
     if (onDrawAnnotation) view.addEventListener("draw-annotation", onDrawAnnotation);
     if (onShowAnnotation) view.addEventListener("show-annotation", onShowAnnotation);
+    if (onLink) view.addEventListener("link", onLink);
     if (onExternalLink) view.addEventListener("external-link", onExternalLink);
 
     return () => {
@@ -35,8 +38,9 @@ export function useFoliateEvents(view: FoliateView | null, handlers?: FoliateEve
       if (onRelocate) view.removeEventListener("relocate", onRelocate);
       if (onDrawAnnotation) view.removeEventListener("draw-annotation", onDrawAnnotation);
       if (onShowAnnotation) view.removeEventListener("show-annotation", onShowAnnotation);
+      if (onLink) view.removeEventListener("link", onLink);
       if (onExternalLink) view.removeEventListener("external-link", onExternalLink);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [view, onLoad, onRelocate, onDrawAnnotation, onShowAnnotation, onExternalLink]);
+  }, [view, onLoad, onRelocate, onDrawAnnotation, onShowAnnotation, onLink, onExternalLink]);
 }

--- a/packages/core/src/hooks/reader/useFoliateView.ts
+++ b/packages/core/src/hooks/reader/useFoliateView.ts
@@ -31,6 +31,8 @@ export interface FoliateView extends HTMLElement {
   getCFI(index: number, range?: Range): string;
   // biome-ignore lint: foliate-js uses loosely typed objects
   resolveCFI(cfi: string): any;
+  // biome-ignore lint: foliate-js navigation targets can be hrefs, CFIs, numbers, or fraction objects
+  resolveNavigation?(target: any): any;
 
   // Annotations
   // biome-ignore lint: foliate-js annotation format

--- a/packages/core/src/utils/book-progress.test.ts
+++ b/packages/core/src/utils/book-progress.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getBookProgressPercent, normalizeBookProgress } from "./book-progress";
+
+describe("book progress utils", () => {
+  it("normalizes invalid progress to zero", () => {
+    expect(normalizeBookProgress(undefined)).toBe(0);
+    expect(normalizeBookProgress(Number.NaN)).toBe(0);
+    expect(getBookProgressPercent(Number.NaN)).toBe(0);
+  });
+
+  it("clamps progress into the valid reading range", () => {
+    expect(getBookProgressPercent(-0.2)).toBe(0);
+    expect(getBookProgressPercent(0.42)).toBe(42);
+    expect(getBookProgressPercent(1.8)).toBe(100);
+  });
+});

--- a/packages/core/src/utils/book-progress.ts
+++ b/packages/core/src/utils/book-progress.ts
@@ -1,0 +1,9 @@
+export function normalizeBookProgress(progress: unknown): number {
+  const value = typeof progress === "number" ? progress : Number(progress);
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+export function getBookProgressPercent(progress: unknown): number {
+  return Math.round(normalizeBookProgress(progress) * 100);
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -53,4 +53,5 @@ export {
   normalizeReviews,
   splitEditableList,
 } from "./book-metadata";
+export { getBookProgressPercent, normalizeBookProgress } from "./book-progress";
 export type { BookMetadataFormValues, ExtractedBookMetadata } from "./book-metadata";


### PR DESCRIPTION
## Summary
- Show footnote-like links as an in-reader tip instead of navigating away, including repeated-tap dismissal and edge-aware positioning.
- Add the same footnote tip behavior to the mobile WebView reader and rebuild reader.html.
- Normalize invalid/new-book progress to safe 0-100% values across library/detail/stats/export/AI prompt surfaces.

## Tests
- pnpm --filter @readany/core test src/utils/book-progress.test.ts
- pnpm --filter app exec tsc --noEmit --pretty false
- pnpm --filter @readany/app-expo exec tsc --noEmit --pretty false
- pnpm --filter @readany/core exec tsc --noEmit --pretty false
- pnpm version:check
- git diff --check