### PR TITLE
fix(reader): 音量键翻页彻底修复 — Android 按键拦截 + 移除 volume-manager

### DIFF
--- a/packages/app-expo/app.config.js
+++ b/packages/app-expo/app.config.js
@@ -71,6 +71,7 @@ module.exports = {
       "expo-secure-store",
       "expo-sqlite",
       "expo-asset",
+      "./plugins/withVolumeKeyPaging",
       [
         "expo-camera",
         {

--- a/packages/app-expo/modules/volume-key-paging/android/build.gradle
+++ b/packages/app-expo/modules/volume-key-paging/android/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.volumekeypaging'
+version = '0.1.0'
+
+android {
+  namespace "expo.modules.volumekeypaging"
+  defaultConfig {
+    versionCode 1
+    versionName "0.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/packages/app-expo/modules/volume-key-paging/android/src/main/AndroidManifest.xml
+++ b/packages/app-expo/modules/volume-key-paging/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/packages/app-expo/modules/volume-key-paging/android/src/main/java/expo/modules/volumekeypaging/VolumeKeyPagingModule.kt
+++ b/packages/app-expo/modules/volume-key-paging/android/src/main/java/expo/modules/volumekeypaging/VolumeKeyPagingModule.kt
@@ -22,6 +22,7 @@ class VolumeKeyPagingModule : Module() {
       }
     }
     OnDestroy {
+      VolumeKeyPagingState.enabled = false
       VolumeKeyPagingState.emitter = null
     }
 

--- a/packages/app-expo/modules/volume-key-paging/android/src/main/java/expo/modules/volumekeypaging/VolumeKeyPagingModule.kt
+++ b/packages/app-expo/modules/volume-key-paging/android/src/main/java/expo/modules/volumekeypaging/VolumeKeyPagingModule.kt
@@ -1,0 +1,32 @@
+package expo.modules.volumekeypaging
+
+import androidx.core.os.bundleOf
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.lang.ref.WeakReference
+
+object VolumeKeyPagingState {
+  @Volatile var enabled = false
+  @Volatile var emitter: ((String) -> Unit)? = null
+}
+
+class VolumeKeyPagingModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("VolumeKeyPaging")
+    Events("VolumeKeyPaging")
+
+    OnCreate {
+      val weak = WeakReference(this@VolumeKeyPagingModule)
+      VolumeKeyPagingState.emitter = { direction ->
+        weak.get()?.sendEvent("VolumeKeyPaging", bundleOf("direction" to direction))
+      }
+    }
+    OnDestroy {
+      VolumeKeyPagingState.emitter = null
+    }
+
+    Function("setEnabled") { value: Boolean ->
+      VolumeKeyPagingState.enabled = value
+    }
+  }
+}

--- a/packages/app-expo/modules/volume-key-paging/expo-module.config.json
+++ b/packages/app-expo/modules/volume-key-paging/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.volumekeypaging.VolumeKeyPagingModule"]
+  }
+}

--- a/packages/app-expo/modules/volume-key-paging/index.ts
+++ b/packages/app-expo/modules/volume-key-paging/index.ts
@@ -1,0 +1,20 @@
+import { NativeModule, requireNativeModule } from "expo";
+import { Platform } from "react-native";
+
+type VolumeKeyPagingEvents = {
+  VolumeKeyPaging: (payload: { direction: "prev" | "next" }) => void;
+};
+
+declare class VolumeKeyPagingModule extends NativeModule<VolumeKeyPagingEvents> {
+  setEnabled(enabled: boolean): void;
+}
+
+const noop = {
+  setEnabled: () => {},
+  addListener: () => ({ remove: () => {} }),
+} as unknown as VolumeKeyPagingModule;
+
+const mod: VolumeKeyPagingModule =
+  Platform.OS === "android" ? requireNativeModule<VolumeKeyPagingModule>("VolumeKeyPaging") : noop;
+
+export default mod;

--- a/packages/app-expo/modules/volume-key-paging/index.ts
+++ b/packages/app-expo/modules/volume-key-paging/index.ts
@@ -14,7 +14,15 @@ const noop = {
   addListener: () => ({ remove: () => {} }),
 } as unknown as VolumeKeyPagingModule;
 
-const mod: VolumeKeyPagingModule =
-  Platform.OS === "android" ? requireNativeModule<VolumeKeyPagingModule>("VolumeKeyPaging") : noop;
+function resolveModule(): VolumeKeyPagingModule {
+  if (Platform.OS !== "android") return noop;
+  try {
+    return requireNativeModule<VolumeKeyPagingModule>("VolumeKeyPaging");
+  } catch {
+    return noop;
+  }
+}
+
+const mod: VolumeKeyPagingModule = resolveModule();
 
 export default mod;

--- a/packages/app-expo/package.json
+++ b/packages/app-expo/package.json
@@ -101,7 +101,6 @@
     "react-native-tcp-socket": "^6.4.1",
     "react-native-track-player": "^4.1.2",
     "react-native-view-shot": "^4.0.3",
-    "react-native-volume-manager": "^2.0.8",
     "react-native-webview": "~13.15.0",
     "react-native-worklets": "0.5.1",
     "text-encoding": "^0.7.0",

--- a/packages/app-expo/plugins/withVolumeKeyPaging.js
+++ b/packages/app-expo/plugins/withVolumeKeyPaging.js
@@ -9,6 +9,7 @@ const DISPATCH = `
     val isVolume = keyCode == android.view.KeyEvent.KEYCODE_VOLUME_UP ||
       keyCode == android.view.KeyEvent.KEYCODE_VOLUME_DOWN
     if (expo.modules.volumekeypaging.VolumeKeyPagingState.enabled &&
+        expo.modules.volumekeypaging.VolumeKeyPagingState.emitter != null &&
         isVolume && hasWindowFocus() && !isInMultiWindowMode) {
       if (event.action == android.view.KeyEvent.ACTION_DOWN && event.repeatCount == 0) {
         val direction =
@@ -28,7 +29,7 @@ module.exports = function withVolumeKeyPaging(config) {
     }
     let src = cfg.modResults.contents;
     if (src.includes(MARKER)) return cfg; // 幂等
-    const anchor = /class\s+MainActivity\s*:\s*ReactActivity\s*\(\s*\)\s*\{/;
+    const anchor = /class\s+MainActivity\s*:\s*ReactActivity[\s\S]*?\{/;
     if (!anchor.test(src)) {
       throw new Error("withVolumeKeyPaging: 未找到 MainActivity 类声明锚点");
     }

--- a/packages/app-expo/plugins/withVolumeKeyPaging.js
+++ b/packages/app-expo/plugins/withVolumeKeyPaging.js
@@ -1,0 +1,39 @@
+const { withMainActivity } = require("@expo/config-plugins");
+
+const MARKER = "// volume-key-paging:dispatchKeyEvent";
+
+const DISPATCH = `
+  ${MARKER}
+  override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
+    val keyCode = event.keyCode
+    val isVolume = keyCode == android.view.KeyEvent.KEYCODE_VOLUME_UP ||
+      keyCode == android.view.KeyEvent.KEYCODE_VOLUME_DOWN
+    if (expo.modules.volumekeypaging.VolumeKeyPagingState.enabled &&
+        isVolume && hasWindowFocus() && !isInMultiWindowMode) {
+      if (event.action == android.view.KeyEvent.ACTION_DOWN && event.repeatCount == 0) {
+        val direction =
+          if (keyCode == android.view.KeyEvent.KEYCODE_VOLUME_UP) "prev" else "next"
+        expo.modules.volumekeypaging.VolumeKeyPagingState.emitter?.invoke(direction)
+      }
+      return true
+    }
+    return super.dispatchKeyEvent(event)
+  }
+`;
+
+module.exports = function withVolumeKeyPaging(config) {
+  return withMainActivity(config, (cfg) => {
+    if (cfg.modResults.language !== "kt") {
+      throw new Error("withVolumeKeyPaging: MainActivity 需为 Kotlin（SDK 54 默认 kt）");
+    }
+    let src = cfg.modResults.contents;
+    if (src.includes(MARKER)) return cfg; // 幂等
+    const anchor = /class\s+MainActivity\s*:\s*ReactActivity\s*\(\s*\)\s*\{/;
+    if (!anchor.test(src)) {
+      throw new Error("withVolumeKeyPaging: 未找到 MainActivity 类声明锚点");
+    }
+    src = src.replace(anchor, (m) => `${m}\n${DISPATCH}`);
+    cfg.modResults.contents = src;
+    return cfg;
+  });
+};

--- a/packages/app-expo/src/screens/ReaderScreen.tsx
+++ b/packages/app-expo/src/screens/ReaderScreen.tsx
@@ -33,6 +33,7 @@ import {
 import { useMissingBookPromptStore } from "@/stores/missing-book-prompt-store";
 import { useTheme } from "@/styles/ThemeContext";
 import { useColors, withOpacity } from "@/styles/theme";
+import { useIsFocused } from "@react-navigation/native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { readingContextService } from "@readany/core/ai/reading-context-service";
 import { runWithDbRetry } from "@readany/core/db/write-retry";
@@ -55,9 +56,10 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
+  AppState,
+  type AppStateStatus,
   Easing,
   Modal,
-  NativeModules,
   Platform,
   Pressable,
   ScrollView,
@@ -150,7 +152,6 @@ import {
   CONTROLS_TIMEOUT,
   SCREEN_HEIGHT,
   SCREEN_WIDTH,
-  getVolumeManager,
 } from "./reader/reader-constants";
 import { BatteryIcon, ListIcon, SettingsIcon } from "./reader/reader-icons";
 import { makeStyles, noteTooltipMdStyles } from "./reader/reader-styles";
@@ -311,10 +312,8 @@ export function ReaderScreen({ route, navigation }: Props) {
   const updateReadSettings = useSettingsStore((s) => s.updateReadSettings);
   const translationConfig = useSettingsStore((s) => s.translationConfig);
   const aiConfig = useSettingsStore((s) => s.aiConfig);
-  const settingViewMode = readSettings.viewMode;
   const showTopTitleProgress = readSettings.showTopTitleProgress !== false;
   const showBottomTimeBattery = readSettings.showBottomTimeBattery !== false;
-  const volumeButtonsPageTurn = readSettings.volumeButtonsPageTurn === true;
 
   // Track OS-level accessibility font scale; re-renders when the user
   // changes the system font size while the reader is open.
@@ -508,6 +507,16 @@ export function ReaderScreen({ route, navigation }: Props) {
   // Also read ttsPlayState from store for volume paging guard
   const ttsPlayState = useTTSStore((s) => s.playState);
   const ttsConfig = useTTSStore((s) => s.config);
+
+  // Focus & foreground state for volume paging whitelist
+  const isFocused = useIsFocused();
+  const [appActive, setAppActive] = useState(true);
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (s: AppStateStatus) =>
+      setAppActive(s === "active"),
+    );
+    return () => sub.remove();
+  }, []);
 
   // Load reader HTML asset
   useEffect(() => {
@@ -883,23 +892,39 @@ export function ReaderScreen({ route, navigation }: Props) {
   }, [noteTooltip]);
 
   // ── Volume button paging ─────────────────────────────────────────────────
-  const volumeButtonPagingActive =
-    Platform.OS !== "web" &&
-    Platform.OS !== "windows" &&
-    !!NativeModules.VolumeManager &&
-    !!getVolumeManager() &&
-    volumeButtonsPageTurn &&
-    webViewReady &&
-    !showSearch &&
-    !showTOC &&
-    !showSettings &&
-    !showNotebook &&
-    !showTTS &&
-    ttsPlayState === "stopped";
+  const isPureReadingContext = useMemo(
+    () =>
+      Platform.OS === "android" &&
+      readSettings.volumeButtonsPageTurn === true &&
+      webViewReady &&
+      !loading &&
+      !error &&
+      !isReimporting &&
+      !showSearch &&
+      !showTOC &&
+      !showSettings &&
+      !showNotebook &&
+      !showTTS &&
+      !showTranslation &&
+      !showChapterTranslation &&
+      chapterTranslation.state.status === "idle" &&
+      !selection &&
+      !noteViewHighlight &&
+      !noteTooltip &&
+      ttsPlayState === "stopped" &&
+      isFocused &&
+      appActive,
+    // 维护约定：任何新增遮盖正文/输入态/导航跳转，必须在此追加判定。
+    [
+      readSettings.volumeButtonsPageTurn, webViewReady, loading, error, isReimporting,
+      showSearch, showTOC, showSettings, showNotebook, showTTS,
+      showTranslation, showChapterTranslation, chapterTranslation.state.status,
+      selection, noteViewHighlight, noteTooltip, ttsPlayState, isFocused, appActive,
+    ],
+  );
 
   useVolumeButtonPaging({
-    active: volumeButtonPagingActive,
-    settingViewMode,
+    active: isPureReadingContext,
     onPrev: () => bridge.goPrev(),
     onNext: () => bridge.goNext(),
   });

--- a/packages/app-expo/src/screens/reader/ReaderSettingsPanel.tsx
+++ b/packages/app-expo/src/screens/reader/ReaderSettingsPanel.tsx
@@ -5,7 +5,7 @@ import { XIcon } from "@/components/ui/Icon";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
 import { useColors } from "@/styles/theme";
 import type { ReadSettings } from "@readany/core/types";
-import { ActivityIndicator, Modal, Pressable, ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Modal, Platform, Pressable, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "./reader-styles";
@@ -212,17 +212,24 @@ export function ReaderSettingsPanel({ visible, readSettings, bookId, onClose, on
               </TouchableOpacity>
             </View>
           </View>
-          <View style={s.settingRow}>
-            <Text style={s.settingLabel}>{t("settings.volumeButtonsPageTurn")}</Text>
-            <TouchableOpacity
-              style={[s.settingToggleBtn, !!volumeButtonsPageTurn && s.settingToggleBtnActive]}
-              onPress={() => onUpdateSetting("volumeButtonsPageTurn", !volumeButtonsPageTurn)}
-            >
-              <Text style={[s.settingToggleText, !!volumeButtonsPageTurn && s.settingToggleTextActive]}>
-                {volumeButtonsPageTurn ? t("settings.enabled") : t("settings.disabled")}
-              </Text>
-            </TouchableOpacity>
-          </View>
+          {Platform.OS === "android" && (
+            <View style={s.settingRow}>
+              <View style={s.settingLabelBlock}>
+                <Text style={s.settingLabel}>{t("settings.volumeButtonsPageTurn")}</Text>
+                <Text style={s.settingHint}>
+                  {t("settings.volumeButtonsPageTurnDesc", "开启后阅读时音量键用于上下翻页")}
+                </Text>
+              </View>
+              <TouchableOpacity
+                style={[s.settingToggleBtn, !!volumeButtonsPageTurn && s.settingToggleBtnActive]}
+                onPress={() => onUpdateSetting("volumeButtonsPageTurn", !volumeButtonsPageTurn)}
+              >
+                <Text style={[s.settingToggleText, !!volumeButtonsPageTurn && s.settingToggleTextActive]}>
+                  {volumeButtonsPageTurn ? t("settings.enabled") : t("settings.disabled")}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
           <View style={s.settingRow}>
             <Text style={s.settingLabel}>{t("settings.showTopTitleProgress")}</Text>
             <TouchableOpacity

--- a/packages/app-expo/src/screens/reader/ReaderSettingsPanel.tsx
+++ b/packages/app-expo/src/screens/reader/ReaderSettingsPanel.tsx
@@ -39,6 +39,7 @@ export function ReaderSettingsPanel({ visible, readSettings, bookId, onClose, on
     paragraphSpacing: settingParagraphSpacing,
     pageMargin: settingPageMargin,
     viewMode: settingViewMode,
+    volumeButtonsPageTurn,
     showTopTitleProgress,
     showBottomTimeBattery,
     followSystemFontScale,
@@ -210,6 +211,17 @@ export function ReaderSettingsPanel({ visible, readSettings, bookId, onClose, on
                 </Text>
               </TouchableOpacity>
             </View>
+          </View>
+          <View style={s.settingRow}>
+            <Text style={s.settingLabel}>{t("settings.volumeButtonsPageTurn")}</Text>
+            <TouchableOpacity
+              style={[s.settingToggleBtn, !!volumeButtonsPageTurn && s.settingToggleBtnActive]}
+              onPress={() => onUpdateSetting("volumeButtonsPageTurn", !volumeButtonsPageTurn)}
+            >
+              <Text style={[s.settingToggleText, !!volumeButtonsPageTurn && s.settingToggleTextActive]}>
+                {volumeButtonsPageTurn ? t("settings.enabled") : t("settings.disabled")}
+              </Text>
+            </TouchableOpacity>
           </View>
           <View style={s.settingRow}>
             <Text style={s.settingLabel}>{t("settings.showTopTitleProgress")}</Text>

--- a/packages/app-expo/src/screens/reader/reader-constants.ts
+++ b/packages/app-expo/src/screens/reader/reader-constants.ts
@@ -1,7 +1,7 @@
 /**
  * Constants and utility types shared by ReaderScreen and its sub-modules.
  */
-import { Dimensions, NativeEventEmitter, NativeModules } from "react-native";
+import { Dimensions } from "react-native";
 
 export const SCREEN_WIDTH = Dimensions.get("window").width;
 export const SCREEN_HEIGHT = Dimensions.get("window").height;
@@ -11,60 +11,6 @@ export const FONT_THEMES = [
   { id: "system", labelKey: "reader.fontThemeSystem", fallback: "System" },
   { id: "literata", labelKey: "reader.fontThemeLiterata", fallback: "Literata" },
 ];
-
-// ─── Volume Manager ───
-
-export type VolumeManagerNativeModule = {
-  showNativeVolumeUI?: (config: { enabled: boolean }) => Promise<void>;
-  getVolume?: () => Promise<{ volume?: number }>;
-  setVolume?: (
-    value: number,
-    config?: { showUI?: boolean; playSound?: boolean; type?: string },
-  ) => Promise<void>;
-};
-
-export type VolumeManagerLike = {
-  showNativeVolumeUI: (config: { enabled: boolean }) => Promise<void>;
-  getVolume: () => Promise<{ volume?: number }>;
-  setVolume: (
-    value: number,
-    config?: { showUI?: boolean; playSound?: boolean; type?: string },
-  ) => Promise<void>;
-  addVolumeListener: (callback: (result: { volume?: number }) => void) => { remove: () => void };
-};
-
-let cachedVolumeManager: VolumeManagerLike | null | undefined;
-
-export function getVolumeManager(): VolumeManagerLike | null {
-  if (cachedVolumeManager !== undefined) {
-    return cachedVolumeManager;
-  }
-
-  const nativeModule = NativeModules.VolumeManager as VolumeManagerNativeModule | undefined;
-  if (
-    !nativeModule ||
-    typeof nativeModule.getVolume !== "function" ||
-    typeof nativeModule.setVolume !== "function" ||
-    typeof nativeModule.showNativeVolumeUI !== "function"
-  ) {
-    cachedVolumeManager = null;
-    return cachedVolumeManager;
-  }
-
-  const eventEmitter = new NativeEventEmitter(NativeModules.VolumeManager);
-  cachedVolumeManager = {
-    showNativeVolumeUI: (config) => nativeModule.showNativeVolumeUI!(config),
-    getVolume: () => nativeModule.getVolume!(),
-    setVolume: (value, config) => nativeModule.setVolume!(value, config),
-    addVolumeListener: (callback) => {
-      const subscription = eventEmitter.addListener("RNVMEventVolume", callback);
-      return {
-        remove: () => subscription.remove(),
-      };
-    },
-  };
-  return cachedVolumeManager;
-}
 
 export function formatReaderClock(date: Date) {
   return date.toLocaleTimeString([], {

--- a/packages/app-expo/src/screens/reader/useVolumeButtonPaging.ts
+++ b/packages/app-expo/src/screens/reader/useVolumeButtonPaging.ts
@@ -1,144 +1,37 @@
-/**
- * useVolumeButtonPaging — intercepts hardware volume buttons for page turning.
- * When active, suppresses the system volume UI and restores volume after each press.
- */
-import { Platform, NativeModules } from "react-native";
 import { useEffect, useRef } from "react";
-import { getVolumeManager } from "./reader-constants";
+import { Platform } from "react-native";
+import VolumeKeyPaging from "../../../modules/volume-key-paging";
 
-export interface UseVolumeButtonPagingOptions {
+const THROTTLE_MS = 120;
+
+type Params = {
   active: boolean;
-  settingViewMode: string;
   onPrev: () => void;
   onNext: () => void;
-}
+};
 
-export function useVolumeButtonPaging({
-  active,
-  settingViewMode,
-  onPrev,
-  onNext,
-}: UseVolumeButtonPagingOptions) {
-  const lastKnownHardwareVolumeRef = useRef<number | null>(null);
-  const pendingVolumeRestoreRef = useRef<number | null>(null);
-  const lastVolumeButtonHandledAtRef = useRef(0);
+export function useVolumeButtonPaging({ active, onPrev, onNext }: Params) {
+  const lastHandledAtRef = useRef(0);
+  const onPrevRef = useRef(onPrev);
+  const onNextRef = useRef(onNext);
+  onPrevRef.current = onPrev;
+  onNextRef.current = onNext;
 
-  // DEV: log config changes
   useEffect(() => {
-    if (__DEV__) {
-      console.log("[ReaderScreen][VolumeNav] config", {
-        hasNativeModule: !!NativeModules.VolumeManager,
-        hasVolumeManagerBridge: !!getVolumeManager(),
-        volumeButtonPagingActive: active,
-      });
-    }
+    if (Platform.OS !== "android") return;
+    VolumeKeyPaging.setEnabled(active);
+    return () => VolumeKeyPaging.setEnabled(false);
   }, [active]);
 
   useEffect(() => {
-    const volumeManager = getVolumeManager();
-    if (!active) {
-      pendingVolumeRestoreRef.current = null;
-      return;
-    }
-
-    let cancelled = false;
-    let volumeListener: { remove: () => void } | null = null;
-
-    const restoreSystemVolume = async (targetVolume: number) => {
-      if (!volumeManager) return;
-      pendingVolumeRestoreRef.current = targetVolume;
-      try {
-        await volumeManager.setVolume(targetVolume, {
-          showUI: false,
-          playSound: false,
-          type: "music",
-        });
-      } catch (error) {
-        pendingVolumeRestoreRef.current = null;
-        console.warn("[ReaderScreen][VolumeNav] restore-volume failed", error);
-      }
-    };
-
-    const enableVolumeButtonPaging = async () => {
-      if (!volumeManager) return;
-      try {
-        await volumeManager.showNativeVolumeUI({ enabled: false });
-        const initialVolume = await volumeManager.getVolume();
-        if (cancelled) return;
-
-        lastKnownHardwareVolumeRef.current =
-          typeof initialVolume.volume === "number" ? initialVolume.volume : null;
-
-        if (__DEV__) {
-          console.log("[ReaderScreen][VolumeNav] enabled", {
-            initialVolume: lastKnownHardwareVolumeRef.current,
-            viewMode: settingViewMode,
-          });
-        }
-
-        volumeListener = volumeManager.addVolumeListener((result) => {
-          const nextVolume =
-            typeof result.volume === "number" && Number.isFinite(result.volume)
-              ? result.volume
-              : null;
-          if (cancelled || nextVolume == null) return;
-
-          const pendingRestore = pendingVolumeRestoreRef.current;
-          if (pendingRestore != null && Math.abs(nextVolume - pendingRestore) < 0.0001) {
-            pendingVolumeRestoreRef.current = null;
-            lastKnownHardwareVolumeRef.current = nextVolume;
-            if (__DEV__) {
-              console.log("[ReaderScreen][VolumeNav] restore-event", { volume: nextVolume });
-            }
-            return;
-          }
-
-          const previousVolume = lastKnownHardwareVolumeRef.current;
-          lastKnownHardwareVolumeRef.current = nextVolume;
-          if (previousVolume == null) return;
-
-          const delta = nextVolume - previousVolume;
-          if (Math.abs(delta) < 0.0001) return;
-
-          const now = Date.now();
-          if (now - lastVolumeButtonHandledAtRef.current < 120) return;
-          lastVolumeButtonHandledAtRef.current = now;
-
-          const direction = delta > 0 ? "prev" : "next";
-          if (__DEV__) {
-            console.log("[ReaderScreen][VolumeNav] hardware-press", {
-              direction,
-              previousVolume,
-              nextVolume,
-              delta,
-            });
-          }
-
-          if (direction === "prev") {
-            onPrev();
-          } else {
-            onNext();
-          }
-
-          void restoreSystemVolume(previousVolume);
-        });
-      } catch (error) {
-        console.warn("[ReaderScreen][VolumeNav] unavailable", error);
-      }
-    };
-
-    void enableVolumeButtonPaging();
-
-    return () => {
-      cancelled = true;
-      volumeListener?.remove();
-      pendingVolumeRestoreRef.current = null;
-      const vm = getVolumeManager();
-      if (vm) {
-        void vm.showNativeVolumeUI({ enabled: true }).catch((error) => {
-          console.warn("[ReaderScreen][VolumeNav] restore-native-ui failed", error);
-        });
-      }
-    };
-  }, [active, settingViewMode, onPrev, onNext]);
+    if (Platform.OS !== "android") return;
+    const sub = VolumeKeyPaging.addListener("VolumeKeyPaging", ({ direction }) => {
+      const now = Date.now();
+      if (now - lastHandledAtRef.current < THROTTLE_MS) return;
+      lastHandledAtRef.current = now;
+      if (direction === "prev") onPrevRef.current();
+      else onNextRef.current();
+    });
+    return () => sub.remove();
+  }, []);
 }

--- a/packages/core/src/i18n/locales/en/settings.json
+++ b/packages/core/src/i18n/locales/en/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "Top Title & Progress",
     "showBottomTimeBattery": "Bottom Time & Battery",
     "volumeButtonsPageTurn": "Volume Buttons Turn Pages",
+    "volumeButtonsPageTurnDesc": "While reading, volume keys turn pages",
     "followSystemFontScale": "Follow System Font Scale",
     "followSystemFontScaleDesc": "Auto-scale by the OS accessibility font size",
     "fixedLayoutNotice": "PDF is a fixed layout format. Font and layout settings are not available.",

--- a/packages/core/src/i18n/locales/es/settings.json
+++ b/packages/core/src/i18n/locales/es/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "Título y progreso superior",
     "showBottomTimeBattery": "Hora y batería inferior",
     "volumeButtonsPageTurn": "Botones de volumen cambian página",
+    "volumeButtonsPageTurnDesc": "Durante la lectura, los botones de volumen pasan página",
     "followSystemFontScale": "Seguir escala de fuente del sistema",
     "followSystemFontScaleDesc": "Escalar automáticamente según el tamaño de fuente de accesibilidad del SO",
     "fixedLayoutNotice": "PDF es un formato de diseño fijo. Los ajustes de fuente y diseño no están disponibles.",

--- a/packages/core/src/i18n/locales/fr/settings.json
+++ b/packages/core/src/i18n/locales/fr/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "Titre et progression en haut",
     "showBottomTimeBattery": "Heure et batterie en bas",
     "volumeButtonsPageTurn": "Tourner les pages avec les boutons de volume",
+    "volumeButtonsPageTurnDesc": "En lecture, les boutons de volume tournent les pages",
     "followSystemFontScale": "Suivre l'échelle de police système",
     "followSystemFontScaleDesc": "Mise à l'échelle auto selon la taille de police d'accessibilité du système",
     "fixedLayoutNotice": "Le PDF est un format à mise en page fixe. Les paramètres de police et mise en page ne sont pas disponibles.",

--- a/packages/core/src/i18n/locales/ja/settings.json
+++ b/packages/core/src/i18n/locales/ja/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "上部タイトル＆進捗表示",
     "showBottomTimeBattery": "下部時刻＆バッテリー表示",
     "volumeButtonsPageTurn": "音量ボタンでページ送り",
+    "volumeButtonsPageTurnDesc": "読書中は音量ボタンでページ送りします",
     "followSystemFontScale": "システムフォントサイズに従う",
     "followSystemFontScaleDesc": "OSのアクセシビリティフォントサイズで自動調整",
     "fixedLayoutNotice": "PDFは固定レイアウト形式です。フォントとレイアウト設定は利用できません。",

--- a/packages/core/src/i18n/locales/ko/settings.json
+++ b/packages/core/src/i18n/locales/ko/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "상단 제목 및 진행률",
     "showBottomTimeBattery": "하단 시간 및 배터리",
     "volumeButtonsPageTurn": "볼륨 버튼으로 페이지 넘기기",
+    "volumeButtonsPageTurnDesc": "독서 중 볼륨 버튼으로 페이지를 넘깁니다",
     "followSystemFontScale": "시스템 글꼴 크기 따르기",
     "followSystemFontScaleDesc": "OS 접근성 글꼴 크기에 따라 자동 조정",
     "fixedLayoutNotice": "PDF는 고정 레이아웃 형식이에요. 글꼴 및 레이아웃 설정을 사용할 수 없어요.",

--- a/packages/core/src/i18n/locales/zh-TW/settings.json
+++ b/packages/core/src/i18n/locales/zh-TW/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "頂部標題與進度",
     "showBottomTimeBattery": "底部時間與電量",
     "volumeButtonsPageTurn": "音量鍵翻頁",
+    "volumeButtonsPageTurnDesc": "開啟後閱讀時音量鍵用於上下翻頁",
     "followSystemFontScale": "跟隨系統字型大小",
     "followSystemFontScaleDesc": "按系統輔助功能字型大小自動放大",
     "fixedLayoutNotice": "PDF 為固定排版格式，字型和排版設定不可用。",

--- a/packages/core/src/i18n/locales/zh/settings.json
+++ b/packages/core/src/i18n/locales/zh/settings.json
@@ -67,6 +67,7 @@
     "showTopTitleProgress": "顶部标题与进度",
     "showBottomTimeBattery": "底部时间与电量",
     "volumeButtonsPageTurn": "音量键翻页",
+    "volumeButtonsPageTurnDesc": "开启后阅读时音量键用于上下翻页",
     "followSystemFontScale": "跟随系统字号",
     "followSystemFontScaleDesc": "按系统辅助功能字号自动放大",
     "fixedLayoutNotice": "PDF 为固定布局格式，字体和排版设置不可用。",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,9 +424,6 @@ importers:
       react-native-view-shot:
         specifier: ^4.0.3
         version: 4.0.3(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      react-native-volume-manager:
-        specifier: ^2.0.8
-        version: 2.0.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-webview:
         specifier: ~13.15.0
         version: 13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -7754,12 +7751,6 @@ packages:
 
   react-native-view-shot@4.0.3:
     resolution: {integrity: sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==}
-    peerDependencies:
-      react: 19.1.0
-      react-native: '*'
-
-  react-native-volume-manager@2.0.8:
-    resolution: {integrity: sha512-aZM47/mYkdQ4CbXpKYO6Ajiczv7fxbQXZ9c0H8gRuQUaS3OCz/MZABer6o9aDWq0KMNsQ7q7GVFLRPnSSeeMmw==}
     peerDependencies:
       react: 19.1.0
       react-native: '*'
@@ -18235,11 +18226,6 @@ snapshots:
   react-native-view-shot@4.0.3(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       html2canvas: 1.4.1
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
-
-  react-native-volume-manager@2.0.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
-    dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 


### PR DESCRIPTION
本 PR 从最初的「补设置开关」(#379) 升级为音量键翻页的**彻底修复**，同时根治 #382 的 Android 14+ 崩溃。

Closes #379
Closes #382

## #382 根因
`react-native-volume-manager@2.0.8` 的 `registerVolumeReceiver()` 调 `registerReceiver` 缺 Android 14 (API 34) 必需的 `RECEIVER_NOT_EXPORTED` flag → 未捕获 `SecurityException` 原生闪退。上游 v2.1.1/main/npm latest 均未修，升级无解。

## 方案
Android 改用原生 `dispatchKeyEvent` 拦截音量键翻页（不再注册音量广播 → 根除 #382 崩溃 + 现状「监听音量」架构的 4 个固有缺陷：音量到顶/底失灵、广播回环误判、与 TTS 抢 `STREAM_MUSIC`、库内裸露点），并移除 `react-native-volume-manager` 依赖。

- 本地 expo module `VolumeKeyPaging`（android-only）：进程级 `VolumeKeyPagingState` (enabled + emitter) 桥接 Activity 按键拦截与 JS。
- config plugin 注入 `MainActivity.dispatchKeyEvent`，全限定名引用 State（规避 variant 包名）。
- JS hook 订阅事件调 `goPrev/goNext`，门控用白名单 `isPureReadingContext`。

## iOS 说明
本 PR 移除 iOS 的音量键翻页。`react-native-volume-manager` 在新架构 (RN 0.81) 下 iOS 本就崩溃 (upstream #43，作者声明 not compatible with new arch)；iOS 无公开音量键事件 API（业界皆 Android-only）。设置开关加 `Platform.OS==='android'` 守卫，iOS 不展示。如需 iOS 支持请另行原生实现。

## 精确生效范围
仅当：Android · 开关开 · WebView 就绪且内容已加载无错 · 无任何覆盖层/翻译/选区/笔记浮层 · 整章翻译空闲 · TTS stopped · 阅读页聚焦且 App 前台（原生再判窗口聚焦且非分屏）。工具栏展开仍翻页；书首尾消费不翻；TTS 暂停时音量键调系统音量。

## 设计决策（供 review）
- 方向：音量+ → 上一页、音量− → 下一页（沿用现有行为，与 KOReader 等一致）；本期不提供方向反转设置。
- 工具栏展开时仍翻页（正文未被遮盖）。
- TTS：仅 `ttsPlayState='stopped'` 时翻页；TTS 播放/暂停时音量键留给系统调音量。
- 书首/书末：消费按键但不翻、不弹音量条（与中间页行为一致）。
- 默认关闭（opt-in）。
- 待你拍板：① `showNotebook` 门控项疑似遗留态（已保留作防御，是否清理可另开 issue）；② 副标题文案 `volumeButtonsPageTurnDesc` 是否合适。

## 已知 limitation
激活态下蓝牙/有线耳机 AVRCP 线控无法翻页（经 MediaSession 不走 Activity keyevent）。

## 维护成本提示
config plugin 注入 `dispatchKeyEvent` 依赖 Expo SDK / MainActivity 模板，大版本升级需回归。

## 验证
注入命中 + bridgeless 事件通路经独立最小项目 spike 用 adb 实测端到端跑通（按键→拦截→JS 收到事件→音量条抑制）；多角度 code review + 修复（生命周期守卫/注入容错/锚点兼容）。完整真机回归建议在 EAS 云构建（Linux）验证（贡献者本地为 Windows，因无关库 react-native-static-server 的 CMake 问题无法完整编译）。


## 范围说明
- 设置面板溢出隐患 #381 **不在本 PR 范围**，留作后续单独处理。
- 评论区早期讨论（如 2026-06-06「改动仅 +12 行补 toggle、风险极低」）基于本 PR **升级前的旧方案**，已过时；请以本 body 与最新评论为准。
