### PR TITLE
fix(reader): show actions for existing highlights

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -662,7 +662,6 @@ interface FoliateViewerProps {
   onError?: (error: Error) => void;
   onSelection?: (selection: BookSelection | null) => void;
   onShowAnnotation?: (cfi: string, range: Range, index: number) => void;
-  onShowNotePanel?: (cfi: string) => void;
   onToggleSearch?: () => void;
   onToggleToc?: () => void;
   onToggleChat?: () => void;
@@ -699,7 +698,6 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
       onError,
       onSelection,
       onShowAnnotation,
-      onShowNotePanel,
       onToggleSearch,
       onToggleToc,
       onToggleChat,
@@ -2124,11 +2122,6 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
     const onShowAnnotationRef = useRef(onShowAnnotation);
     onShowAnnotationRef.current = onShowAnnotation;
 
-    // --- Show note panel handler ---
-    // This is called when user clicks on a wavy underline (note annotation)
-    const onShowNotePanelRef = useRef(onShowNotePanel);
-    onShowNotePanelRef.current = onShowNotePanel;
-
     const showAnnotationHandler = useCallback((event: Event) => {
       const detail = (event as CustomEvent).detail;
       const { value, index, range } = detail;
@@ -2139,13 +2132,8 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
       // show-annotation fires synchronously before the setTimeout(10ms) in pointerup
       annotationClickedRef.current = true;
 
-      // Check if this annotation has a note - if so, open note panel instead of popover
-      if (cfisWithNotes.has(value) && onShowNotePanelRef.current) {
-        onShowNotePanelRef.current(value);
-        return;
-      }
-
-      // Call the callback with annotation info
+      // Always show the same annotation popover for existing highlights, including
+      // highlights with notes, so actions like copy remain available.
       onShowAnnotationRef.current?.(value, range, index);
     }, []);
 

--- a/packages/app/src/components/reader/ReaderView.tsx
+++ b/packages/app/src/components/reader/ReaderView.tsx
@@ -1583,42 +1583,65 @@ export function ReaderView({ bookId, tabId }: ReaderViewProps) {
       setSelection(sel);
 
       // Position the popover
-      if (offsetRects.length > 0) {
-        const firstRect = offsetRects[0];
-        const offsetX = containerRect?.left ?? 0;
-        const offsetY = containerRect?.top ?? 0;
-        const containerW = containerRect?.width ?? 800;
-        const containerH = containerRect?.height ?? 600;
+      if (containerRect && offsetRects.length > 0) {
+        const visibleRects = offsetRects.filter(
+          (r) =>
+            r.width > 0 &&
+            r.height > 0 &&
+            r.right >= containerRect.left &&
+            r.left <= containerRect.right &&
+            r.bottom >= containerRect.top &&
+            r.top <= containerRect.bottom,
+        );
+        const rectsForPosition = visibleRects.length > 0 ? visibleRects : offsetRects;
+        const containerRelativeRects = rectsForPosition.map((r) => ({
+          top: r.top - containerRect.top,
+          bottom: r.bottom - containerRect.top,
+          left: r.left - containerRect.left,
+          right: r.right - containerRect.left,
+        }));
 
-        const popoverW = 190;
+        const topmostRect = containerRelativeRects.reduce((min, r) =>
+          r.top < min.top ? r : min,
+        );
+        const bottommostRect = containerRelativeRects.reduce((max, r) =>
+          r.bottom > max.bottom ? r : max,
+        );
+        const centerX = (topmostRect.left + topmostRect.right) / 2;
+
+        const containerW = containerRect.width;
+        const containerH = containerRect.height;
+        const popoverW = 200;
         const popoverH = 44;
+        const gap = 8;
+        const padding = 8;
+        const toolbarHeight = toolbarVisible ? 44 : 0;
 
-        let x = firstRect.left + firstRect.width / 2 - offsetX - popoverW / 2;
-        x = Math.max(4, Math.min(x, containerW - popoverW - 4));
+        let x = centerX - popoverW / 2;
+        x = Math.max(padding, Math.min(x, containerW - popoverW - padding));
 
-        let y = firstRect.top - popoverH - 4 - offsetY;
-        if (y < 4) {
-          y = firstRect.bottom + 8 - offsetY;
+        const yAbove = topmostRect.top - popoverH - gap;
+        const yBelow = bottommostRect.bottom + gap;
+        const aboveValid = yAbove >= toolbarHeight + padding;
+        const belowValid = yBelow + popoverH + padding <= containerH;
+
+        let y: number;
+        if (aboveValid && belowValid) {
+          const spaceAbove = topmostRect.top - toolbarHeight;
+          const spaceBelow = containerH - bottommostRect.bottom;
+          y = spaceAbove > spaceBelow ? yAbove : yBelow;
+        } else if (aboveValid) {
+          y = yAbove;
+        } else if (belowValid) {
+          y = yBelow;
+        } else {
+          y = Math.max(toolbarHeight + padding, Math.min(yAbove, yBelow));
         }
-        y = Math.max(4, Math.min(y, containerH - popoverH - 4));
 
         setSelectionPos({ x, y });
       }
     },
-    [highlights, bookId],
-  );
-
-  // Handle show-note-panel event (user clicked on wavy underline with note)
-  const handleShowNotePanel = useCallback(
-    (cfi: string) => {
-      // Find the highlight with this CFI
-      const highlight = highlights.find((h) => h.bookId === bookId && h.cfi === cfi);
-      if (!highlight) return;
-
-      // Start editing this highlight's note (this also opens the notebook panel)
-      useNotebookStore.getState().startEditNote(highlight);
-    },
-    [highlights, bookId],
+    [highlights, bookId, toolbarVisible],
   );
 
   const handleTranslate = useCallback(() => {
@@ -2756,7 +2779,6 @@ export function ReaderView({ bookId, tabId }: ReaderViewProps) {
                 onError={handleError}
                 onSelection={handleSelection}
                 onShowAnnotation={handleShowAnnotation}
-                onShowNotePanel={handleShowNotePanel}
                 onToggleSearch={handleToggleSearch}
                 onToggleToc={handleToggleToc}
                 onToggleChat={handleToggleChat}


### PR DESCRIPTION
## Summary
- Show the same selection action popover when clicking existing highlights, including highlights with notes.
- Fix popover placement by using the clicked range iframe and visible highlight rects.

## Test
- PATH=/Users/bealqiu/.nvm/versions/node/v20.20.0/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.codex/tmp/arg0/codex-arg0CZK6sK:/Users/bealqiu/.antigravity/antigravity/bin:/Users/bealqiu/.codebuddy/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/Library/pnpm:/Users/bealqiu/.rd/bin:/Users/bealqiu/.codeium/windsurf/bin:/Users/bealqiu/.nvm/versions/node/v14.21.3/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/opt/podman/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.cargo/bin:/Applications/Codex.app/Contents/Resources pnpm --filter app build

Fixes #395