### PR TITLE
fix(mobile): 修复 AI 输入框被键盘遮挡

### DIFF
--- a/packages/app-expo/src/components/chat/ChatInput.tsx
+++ b/packages/app-expo/src/components/chat/ChatInput.tsx
@@ -1,4 +1,11 @@
-import { BrainIcon, EyeOffIcon, SendIcon, StopCircleIcon, XIcon } from "@/components/ui/Icon";
+import {
+  BrainIcon,
+  ChevronDownIcon,
+  EyeOffIcon,
+  SendIcon,
+  StopCircleIcon,
+  XIcon,
+} from "@/components/ui/Icon";
 import { useKeyboardInsets } from "@/hooks/use-keyboard-insets";
 import { fontSize as fs, radius, useColors, withOpacity } from "@/styles/theme";
 import type { ThemeColors } from "@/styles/theme";
@@ -10,6 +17,7 @@ import type { AttachedQuote } from "@readany/core/types";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Keyboard,
   Platform,
   StyleSheet,
   Text,
@@ -31,6 +39,7 @@ interface ChatInputProps {
   quotes?: AttachedQuote[];
   onRemoveQuote?: (id: string) => void;
   placeholder?: string;
+  keyboardBottomOffset?: number;
 }
 
 const SINGLE_LINE_INPUT_HEIGHT = 46;
@@ -44,6 +53,7 @@ export function ChatInput({
   quotes = [],
   onRemoveQuote,
   placeholder,
+  keyboardBottomOffset = 0,
 }: ChatInputProps) {
   const [text, setText] = useState("");
   const [deepThinking, setDeepThinking] = useState(false);
@@ -54,15 +64,18 @@ export function ChatInput({
   const s = makeStyles(colors);
   const inputRef = useRef<TextInput>(null);
   const keyboardInsets = useKeyboardInsets();
-  const bottomPadding =
-    Platform.OS === "ios" && keyboardInsets.isVisible
-      ? keyboardInsets.bottomInset + 8
-      : Math.max(4, Math.min(keyboardInsets.safeAreaBottom, 8));
+  const effectiveKeyboardBottomOffset = keyboardBottomOffset ?? keyboardInsets.safeAreaBottom;
+  const visibleKeyboardPadding =
+    Platform.OS === "ios"
+      ? Math.max(8, keyboardInsets.rawHeight - effectiveKeyboardBottomOffset + 14)
+      : 8;
+  const bottomPadding = keyboardInsets.isVisible
+    ? visibleKeyboardPadding
+    : Math.max(4, Math.min(keyboardInsets.safeAreaBottom, 8));
 
   const handleSend = useCallback(() => {
     const trimmed = text.trim();
     if (!trimmed && quotes.length === 0) return;
-    inputRef.current?.blur();
     onSend(trimmed, deepThinking, spoilerFree, quotes.length > 0 ? quotes : undefined);
     setInputHeight(SINGLE_LINE_INPUT_HEIGHT);
     setText("");
@@ -160,23 +173,36 @@ export function ChatInput({
             </TouchableOpacity>
           </View>
 
-          {isStreaming ? (
-            <TouchableOpacity style={s.sendBtn} onPress={onStop} activeOpacity={0.7}>
-              <StopCircleIcon size={16} color={colors.destructive} />
-            </TouchableOpacity>
-          ) : (
-            <TouchableOpacity
-              style={[s.sendBtn, canSend && s.sendBtnActive]}
-              onPress={handleSend}
-              disabled={!canSend}
-              activeOpacity={0.7}
-            >
-              <SendIcon
-                size={14}
-                color={canSend ? colors.primaryForeground : colors.mutedForeground}
-              />
-            </TouchableOpacity>
-          )}
+          <View style={s.actionButtons}>
+            {keyboardInsets.isVisible && (
+              <TouchableOpacity
+                style={s.sendBtn}
+                onPress={Keyboard.dismiss}
+                activeOpacity={0.7}
+                accessibilityLabel={t("chat.dismissKeyboard", "收起键盘")}
+              >
+                <ChevronDownIcon size={15} color={colors.mutedForeground} />
+              </TouchableOpacity>
+            )}
+
+            {isStreaming ? (
+              <TouchableOpacity style={s.sendBtn} onPress={onStop} activeOpacity={0.7}>
+                <StopCircleIcon size={16} color={colors.destructive} />
+              </TouchableOpacity>
+            ) : (
+              <TouchableOpacity
+                style={[s.sendBtn, canSend && s.sendBtnActive]}
+                onPress={handleSend}
+                disabled={!canSend}
+                activeOpacity={0.7}
+              >
+                <SendIcon
+                  size={14}
+                  color={canSend ? colors.primaryForeground : colors.mutedForeground}
+                />
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
       </View>
       {deepThinking && (
@@ -258,6 +284,13 @@ const makeStyles = (colors: ThemeColors) =>
       flexDirection: "row",
       alignItems: "center",
       gap: 6,
+      flexShrink: 1,
+    },
+    actionButtons: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      marginLeft: 8,
     },
     deepThinkBtn: {
       flexDirection: "row",

--- a/packages/app-expo/src/components/chat/MessageList.tsx
+++ b/packages/app-expo/src/components/chat/MessageList.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, ChevronDownIcon, CopyIcon } from "@/components/ui/Icon";
 import { fontSize as fs, radius, useColors, withOpacity } from "@/styles/theme";
 import type { ThemeColors } from "@/styles/theme";
 import type { CitationPart, MessageV2, QuotePart, TextPart } from "@readany/core/types/message";
+import * as Clipboard from "expo-clipboard";
 /**
  * MessageList — FlatList message renderer matching app-mobile MessageList.
  * Scroll-to-bottom button, streaming gap indicator.
@@ -12,6 +13,8 @@ import {
   FlatList,
   Keyboard,
   Modal,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   Platform,
   Pressable,
   StyleSheet,
@@ -20,7 +23,6 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import * as Clipboard from "expo-clipboard";
 import { PartRenderer } from "./PartRenderer";
 import { StreamingIndicator } from "./StreamingIndicator";
 
@@ -60,14 +62,7 @@ export function MessageList({
   const isAtBottomRef = useRef(true);
   const [showScrollDown, setShowScrollDown] = useState(false);
 
-  // Track last part count for auto-scroll dependency
   const lastMsg = messages[messages.length - 1];
-  const lastMsgPartsCount = lastMsg?.parts?.length ?? 0;
-  const lastMsgTextLength =
-    lastMsg?.parts?.reduce(
-      (acc, p) => acc + (p.type === "text" ? (p as TextPart).text?.length || 0 : 0),
-      0,
-    ) ?? 0;
 
   // Auto-scroll when new messages arrive or parts update
   useEffect(() => {
@@ -119,7 +114,7 @@ export function MessageList({
     };
   }, [messages.length]);
 
-  const handleScroll = useCallback((e: any) => {
+  const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
     const nearBottom =
       contentSize.height - contentOffset.y - layoutMeasurement.height < BOTTOM_THRESHOLD;
@@ -166,7 +161,7 @@ export function MessageList({
     (!lastMsg || lastMsg.role !== "assistant" || lastMsg.parts.length === 0);
 
   return (
-    <View style={s.container}>
+    <View style={s.container} onTouchStart={Keyboard.dismiss}>
       <FlatList
         ref={flatListRef}
         data={messages}
@@ -174,6 +169,7 @@ export function MessageList({
         renderItem={renderMessage}
         contentContainerStyle={s.listContent}
         onScroll={handleScroll}
+        onScrollBeginDrag={Keyboard.dismiss}
         scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
@@ -305,11 +301,7 @@ function MessageBubble({
 
     return (
       <View style={s.userRow}>
-        <Pressable
-          style={s.userBubble}
-          onLongPress={triggerLongPress}
-          delayLongPress={300}
-        >
+        <Pressable style={s.userBubble} onLongPress={triggerLongPress} delayLongPress={300}>
           {quoteParts.length > 0 && (
             <View style={{ gap: 4, marginBottom: textParts.length > 0 ? 6 : 0 }}>
               {quoteParts.map((q) => (
@@ -370,9 +362,7 @@ function MessageBubble({
         ))}
       </Pressable>
       {showGapIndicator && <StreamingIndicator step="thinking" />}
-      {!isStreaming && (
-        <CopyButton onPress={copyText} colors={colors} />
-      )}
+      {!isStreaming && <CopyButton onPress={copyText} colors={colors} />}
     </View>
   );
 }
@@ -431,12 +421,7 @@ function SelectableTextModal({
   }, [text]);
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="fade"
-      onRequestClose={onClose}
-    >
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <Pressable
         style={{ flex: 1, backgroundColor: "rgba(0,0,0,0.5)", justifyContent: "flex-end" }}
         onPress={onClose}

--- a/packages/app-expo/src/hooks/use-keyboard-insets.ts
+++ b/packages/app-expo/src/hooks/use-keyboard-insets.ts
@@ -1,31 +1,64 @@
 import { useEffect, useMemo, useState } from "react";
-import { Keyboard, Platform } from "react-native";
+import { Dimensions, Keyboard, type KeyboardEvent, Platform } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type KeyboardState = {
   height: number;
+  rawHeight: number;
   visible: boolean;
 };
 
+function getRawKeyboardHeight(event: KeyboardEvent | undefined) {
+  const coordinates = event?.endCoordinates;
+  const keyboardMetrics = Keyboard.metrics?.();
+  const reportedHeight = coordinates?.height ?? 0;
+  const metricsHeight = keyboardMetrics?.height ?? 0;
+  const screenY = coordinates?.screenY;
+  const windowOverlap =
+    typeof screenY === "number" ? Math.max(0, Dimensions.get("window").height - screenY) : 0;
+  const screenOverlap =
+    reportedHeight === 0 && metricsHeight === 0 && typeof screenY === "number"
+      ? Math.max(0, Dimensions.get("screen").height - screenY)
+      : 0;
+  return Math.max(reportedHeight, metricsHeight, windowOverlap, screenOverlap);
+}
+
 export function useKeyboardInsets() {
   const safeAreaInsets = useSafeAreaInsets();
-  const [keyboard, setKeyboard] = useState<KeyboardState>({ height: 0, visible: false });
+  const [keyboard, setKeyboard] = useState<KeyboardState>({
+    height: 0,
+    rawHeight: 0,
+    visible: false,
+  });
 
   useEffect(() => {
-    const showEvent = Platform.OS === "ios" ? "keyboardWillChangeFrame" : "keyboardDidShow";
-    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const showEvents =
+      Platform.OS === "ios"
+        ? (["keyboardWillChangeFrame", "keyboardDidChangeFrame", "keyboardDidShow"] as const)
+        : (["keyboardDidShow"] as const);
+    const hideEvents =
+      Platform.OS === "ios"
+        ? (["keyboardWillHide", "keyboardDidHide"] as const)
+        : (["keyboardDidHide"] as const);
 
-    const showSubscription = Keyboard.addListener(showEvent, (event) => {
-      const height = Math.max(0, event.endCoordinates.height - safeAreaInsets.bottom);
-      setKeyboard({ height, visible: height > 0 });
-    });
-    const hideSubscription = Keyboard.addListener(hideEvent, () => {
-      setKeyboard({ height: 0, visible: false });
-    });
+    const updateKeyboard = (event: KeyboardEvent) => {
+      const rawHeight = getRawKeyboardHeight(event);
+      const height = Math.max(0, rawHeight - safeAreaInsets.bottom);
+      setKeyboard({ height, rawHeight, visible: rawHeight > 0 });
+    };
+    const hideKeyboard = () => {
+      setKeyboard({ height: 0, rawHeight: 0, visible: false });
+    };
+
+    const subscriptions = [
+      ...showEvents.map((eventName) => Keyboard.addListener(eventName, updateKeyboard)),
+      ...hideEvents.map((eventName) => Keyboard.addListener(eventName, hideKeyboard)),
+    ];
 
     return () => {
-      showSubscription.remove();
-      hideSubscription.remove();
+      for (const subscription of subscriptions) {
+        subscription.remove();
+      }
     };
   }, [safeAreaInsets.bottom]);
 
@@ -34,8 +67,9 @@ export function useKeyboardInsets() {
       bottomInset: keyboard.height,
       height: keyboard.height,
       isVisible: keyboard.visible,
+      rawHeight: keyboard.rawHeight,
       safeAreaBottom: safeAreaInsets.bottom,
     }),
-    [keyboard.height, keyboard.visible, safeAreaInsets.bottom],
+    [keyboard.height, keyboard.rawHeight, keyboard.visible, safeAreaInsets.bottom],
   );
 }

--- a/packages/app-expo/src/navigation/TabNavigator.tsx
+++ b/packages/app-expo/src/navigation/TabNavigator.tsx
@@ -46,7 +46,7 @@ export function TabNavigator() {
       safeAreaInsets={{ ...insets, bottom: bottomInset }}
       screenOptions={{
         headerShown: false,
-        tabBarHideOnKeyboard: true,
+        tabBarHideOnKeyboard: false,
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.mutedForeground,
         tabBarLabelStyle: {

--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -12,9 +12,7 @@ import {
   Animated,
   Image,
   Keyboard,
-  KeyboardAvoidingView,
   Modal,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -133,10 +131,7 @@ export function BookChatScreen({ route, navigation }: Props) {
     () => (activeThreadId ? threads.find((t) => t.id === activeThreadId) : null),
     [threads, activeThreadId],
   );
-  const bookThreads = useMemo(
-    () => getThreadsForContext(bookId),
-    [bookId, getThreadsForContext, threads],
-  );
+  const bookThreads = getThreadsForContext(bookId);
   const groupedThreads = useMemo(() => {
     const grouped = groupThreadsByTime(bookThreads);
     const sections: { key: string; label: string; threads: typeof bookThreads }[] = [
@@ -149,13 +144,20 @@ export function BookChatScreen({ route, navigation }: Props) {
     const olderByMonth = new Map<string, typeof bookThreads>();
     for (const thread of grouped.older) {
       const monthLabel = getMonthLabel(thread.updatedAt);
-      if (!olderByMonth.has(monthLabel)) olderByMonth.set(monthLabel, []);
-      olderByMonth.get(monthLabel)!.push(thread);
+      let monthThreads = olderByMonth.get(monthLabel);
+      if (!monthThreads) {
+        monthThreads = [];
+        olderByMonth.set(monthLabel, monthThreads);
+      }
+      monthThreads.push(thread);
     }
 
     const sortedMonths = [...olderByMonth.keys()].sort((a, b) => b.localeCompare(a));
     for (const month of sortedMonths) {
-      sections.push({ key: month, label: month, threads: olderByMonth.get(month)! });
+      const monthThreads = olderByMonth.get(month);
+      if (monthThreads) {
+        sections.push({ key: month, label: month, threads: monthThreads });
+      }
     }
     return sections;
   }, [bookThreads, t]);
@@ -223,31 +225,10 @@ export function BookChatScreen({ route, navigation }: Props) {
   const { isStreaming, currentMessage, currentStep, error, sendMessage, stopStream } =
     useStreamingChat({ book, bookId });
 
-  // Listen for keyboard events to fix scroll issues
-  useEffect(() => {
-    const keyboardDidShow = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardDidShow" : "keyboardDidShow",
-      () => {
-        setTimeout(() => {}, 100);
-      },
-    );
-    const keyboardDidHide = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardDidHide" : "keyboardDidHide",
-      () => {
-        setTimeout(() => {}, 100);
-      },
-    );
-
-    return () => {
-      keyboardDidShow.remove();
-      keyboardDidHide.remove();
-    };
-  }, []);
-
   const messagesV2: MessageV2[] = useMemo(() => {
     if (!activeThread) return [];
     return convertToMessageV2(activeThread.messages);
-  }, [activeThread?.messages]);
+  }, [activeThread]);
 
   const allMessages = useMemo(
     () => mergeMessagesWithStreaming(messagesV2, currentMessage, isStreaming),
@@ -538,12 +519,7 @@ export function BookChatScreen({ route, navigation }: Props) {
             </View>
           </View>
 
-          <KeyboardAvoidingView
-            style={s.content}
-            behavior={Platform.OS === "ios" ? "padding" : "height"}
-            enabled={Platform.OS !== "ios"}
-            keyboardVerticalOffset={0}
-          >
+          <View style={s.content}>
             <View style={s.content}>
               {allMessages.length > 0 ? (
                 <MessageList
@@ -553,7 +529,7 @@ export function BookChatScreen({ route, navigation }: Props) {
                   onCitationClick={handleCitationClick}
                 />
               ) : (
-                <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+                <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
                   <View style={[s.emptyContainer, isTabletLandscape && s.emptyContainerCompact]}>
                     <View style={s.emptyInner}>
                       <Image
@@ -588,10 +564,19 @@ export function BookChatScreen({ route, navigation }: Props) {
               placeholder={t("chat.askAboutBook", "询问关于这本书的问题...")}
               quotes={quotes}
               onRemoveQuote={handleRemoveQuote}
+              keyboardBottomOffset={insets.bottom}
             />
-          </KeyboardAvoidingView>
+          </View>
         </View>
       </View>
+
+      {error && (
+        <View style={s.errorBanner}>
+          <Text style={s.errorText} numberOfLines={2}>
+            {error.message}
+          </Text>
+        </View>
+      )}
 
       {!isTabletLandscape && (
         <View
@@ -710,6 +695,19 @@ const makeStyles = (
     suggestionText: {
       fontSize: fs.sm,
       color: colors.foreground,
+    },
+    errorBanner: {
+      position: "absolute",
+      bottom: 80,
+      left: 16,
+      right: 16,
+      backgroundColor: withOpacity(colors.destructive, 0.9),
+      borderRadius: radius.lg,
+      padding: 12,
+    },
+    errorText: {
+      fontSize: fs.sm,
+      color: colors.primaryForeground,
     },
     sidebarBackdrop: {
       ...StyleSheet.absoluteFillObject,

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -1,4 +1,5 @@
 import type { RootStackParamList } from "@/navigation/RootNavigator";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 /**
@@ -11,14 +12,13 @@ import {
   Animated,
   Image,
   Keyboard,
-  KeyboardAvoidingView,
   Modal,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
+  TouchableWithoutFeedback,
   View,
 } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
@@ -78,6 +78,7 @@ export function ChatScreen() {
   const { t } = useTranslation();
   const colors = useColors();
   const insets = useSafeAreaInsets();
+  const tabBarHeight = useBottomTabBarHeight();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const layout = useResponsiveLayout();
   const isTabletLandscape = layout.isTabletLandscape;
@@ -167,34 +168,7 @@ export function ChatScreen() {
     if (!initialized) loadAllThreads();
   }, [initialized, loadAllThreads]);
 
-  const generalThreads = useMemo(() => getThreadsForContext(), [threads, getThreadsForContext]);
-
-  // Listen for keyboard events to fix scroll issues
-  useEffect(() => {
-    const keyboardDidShow = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardDidShow" : "keyboardDidShow",
-      () => {
-        // Scroll to bottom when keyboard shows
-        setTimeout(() => {
-          // This will be handled by MessageList component
-        }, 100);
-      },
-    );
-    const keyboardDidHide = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardDidHide" : "keyboardDidHide",
-      () => {
-        // Ensure proper layout after keyboard hides
-        setTimeout(() => {
-          // This will be handled by MessageList component
-        }, 100);
-      },
-    );
-
-    return () => {
-      keyboardDidShow.remove();
-      keyboardDidHide.remove();
-    };
-  }, []);
+  const generalThreads = getThreadsForContext();
 
   // Streaming chat
   const { isStreaming, currentMessage, currentStep, error, sendMessage, stopStream } =
@@ -298,14 +272,19 @@ export function ChatScreen() {
     const olderByMonth = new Map<string, typeof generalThreads>();
     for (const thread of grouped.older) {
       const monthLabel = getMonthLabel(thread.updatedAt);
-      if (!olderByMonth.has(monthLabel)) {
-        olderByMonth.set(monthLabel, []);
+      let monthThreads = olderByMonth.get(monthLabel);
+      if (!monthThreads) {
+        monthThreads = [];
+        olderByMonth.set(monthLabel, monthThreads);
       }
-      olderByMonth.get(monthLabel)!.push(thread);
+      monthThreads.push(thread);
     }
     const sortedMonths = [...olderByMonth.keys()].sort((a, b) => b.localeCompare(a));
     for (const month of sortedMonths) {
-      sections.push({ key: month, label: month, threads: olderByMonth.get(month)! });
+      const monthThreads = olderByMonth.get(month);
+      if (monthThreads) {
+        sections.push({ key: month, label: month, threads: monthThreads });
+      }
     }
 
     return sections;
@@ -481,12 +460,7 @@ export function ChatScreen() {
           </View>
 
           {/* Content */}
-          <KeyboardAvoidingView
-            style={s.content}
-            behavior={Platform.OS === "ios" ? "padding" : "height"}
-            enabled={Platform.OS !== "ios"}
-            keyboardVerticalOffset={0}
-          >
+          <View style={s.content}>
             <View style={s.content}>
               {allMessages.length > 0 ? (
                 <MessageList
@@ -495,15 +469,24 @@ export function ChatScreen() {
                   currentStep={currentStep}
                 />
               ) : (
-                <EmptyState
-                  colors={colors}
-                  onSuggestionPress={handleSend}
-                  compact={isTabletLandscape}
-                />
+                <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+                  <View style={s.content}>
+                    <EmptyState
+                      colors={colors}
+                      onSuggestionPress={handleSend}
+                      compact={isTabletLandscape}
+                    />
+                  </View>
+                </TouchableWithoutFeedback>
               )}
             </View>
-            <ChatInput onSend={handleSend} onStop={stopStream} isStreaming={isStreaming} />
-          </KeyboardAvoidingView>
+            <ChatInput
+              onSend={handleSend}
+              onStop={stopStream}
+              isStreaming={isStreaming}
+              keyboardBottomOffset={tabBarHeight}
+            />
+          </View>
         </View>
       </View>
 


### PR DESCRIPTION
## Summary
- 修复移动端 AI 输入框在键盘打开时仍被遮挡一截的问题
- 输入栏改为使用键盘 raw height + 缓冲距离让位，并按页面底部布局扣除对应 offset
- AI Tab 页输入栏会减掉底部 TabBar 的布局预留高度，避免键盘打开时位置过高
- 阅读器里的书籍 AI 页只扣除底部 safe area，避免多算高度
- 不再隐藏/恢复底部 TabBar，避免键盘收起时导航栏闪烁
- 增强键盘高度检测：同时监听 iOS will/did/changeFrame 事件，并用 Keyboard.metrics() 兜底
- 键盘打开时在发送按钮旁展示收起键盘按钮
- 支持点击 AI 空状态背景/消息区域、拖动消息列表时收起键盘
- 发送消息后不再强制 blur，避免输入框高度/位置突然重排
- 清理空转键盘监听，并补齐书籍 AI 页错误提示

## Test
- pnpm exec biome check packages/app-expo/src/navigation/TabNavigator.tsx packages/app-expo/src/hooks/use-keyboard-insets.ts packages/app-expo/src/components/chat/ChatInput.tsx packages/app-expo/src/components/chat/MessageList.tsx packages/app-expo/src/screens/ChatScreen.tsx packages/app-expo/src/screens/BookChatScreen.tsx
- pnpm --filter @readany/app-expo exec tsc --noEmit --pretty false
- git diff --check