### PR TITLE
fix(reader): keep highlight actions visible

### DIFF
--- a/packages/app/src/components/reader/SelectionPopover.tsx
+++ b/packages/app/src/components/reader/SelectionPopover.tsx
@@ -93,6 +93,16 @@ export function SelectionPopover({
     { icon: Languages, label: t("reader.translate"), onClick: onTranslate },
     { icon: Sparkles, label: t("reader.askAI"), onClick: onAskAI },
     { icon: Headphones, label: t("tts.speakSelection"), onClick: onSpeak },
+    ...(annotated
+      ? [
+          {
+            icon: Trash2,
+            label: t("notebook.deleteHighlight"),
+            onClick: onRemoveHighlight,
+            isDestructive: true,
+          },
+        ]
+      : []),
   ];
 
   useLayoutEffect(() => {
@@ -153,46 +163,30 @@ export function SelectionPopover({
                 )}
               </button>
             ))}
-            {annotated && (
-              <>
-                <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
-                <button
-                  type="button"
-                  className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                  title={t("notebook.deleteHighlight")}
-                  aria-label={t("notebook.deleteHighlight")}
-                  onClick={onRemoveHighlight}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </>
-            )}
           </div>
         )}
 
-        {!annotated && (
-          <div className="flex items-center gap-0.5 rounded-lg border border-border bg-background p-1 shadow-lg">
-            {buttons.map((btn) => (
-              <button
-                type="button"
-                key={btn.label}
-                className={cn(
-                  "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
-                  btn.disabled ? "cursor-not-allowed opacity-40" : "hover:bg-muted",
-                  btn.isHighlight && showColors && !isPdf && "bg-muted",
-                  btn.icon === Trash2 &&
-                    !btn.disabled &&
-                    "hover:bg-destructive/10 hover:text-destructive",
-                )}
-                title={btn.label}
-                onClick={btn.disabled ? undefined : btn.onClick}
-                disabled={btn.disabled}
-              >
-                <btn.icon className="h-4 w-4" />
-              </button>
-            ))}
-          </div>
-        )}
+        <div className="flex items-center gap-0.5 rounded-lg border border-border bg-background p-1 shadow-lg">
+          {buttons.map((btn) => (
+            <button
+              type="button"
+              key={btn.label}
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
+                btn.disabled ? "cursor-not-allowed opacity-40" : "hover:bg-muted",
+                btn.isHighlight && showColors && !isPdf && "bg-muted",
+                btn.isDestructive &&
+                  !btn.disabled &&
+                  "text-muted-foreground hover:bg-destructive/10 hover:text-destructive",
+              )}
+              title={btn.label}
+              onClick={btn.disabled ? undefined : btn.onClick}
+              disabled={btn.disabled}
+            >
+              <btn.icon className="h-4 w-4" />
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Render the main selection action row when clicking existing highlights, so copy/translate/AI/speak remain available.
- Keep highlight deletion available by moving the delete action into the main action row.

## Test
- PATH=/Users/bealqiu/.nvm/versions/node/v20.20.0/bin:$PATH pnpm --filter app build

Refs #395