### PR TITLE
fix(mobile): prevent large book vectorization and sync OOM

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -1864,7 +1864,9 @@
           currentThemeColors.fg,
           currentThemeColors.primary,
         );
-        renderer.setStyles(themedStyles);
+        if (typeof renderer.setStyles === 'function') {
+          renderer.setStyles(themedStyles);
+        }
         syncCustomFontStylesForAllDocs(currentCustomFontFaceCSS);
       }
 
@@ -2149,6 +2151,8 @@ a { color: ${primary} !important; }
         for (const img of doc.querySelectorAll('img')) {
           img.style.maxWidth = '100%';
           img.style.height = 'auto';
+          img.style.webkitUserDrag = 'none';
+          img.style.touchAction = 'manipulation';
         }
       }
       const style = doc.createElement('style');
@@ -2156,6 +2160,10 @@ a { color: ${primary} !important; }
       style.textContent = `
         * { -webkit-touch-callout: none !important; -webkit-user-select: text !important; user-select: text !important; }
         html, body { background-color: ${bg} !important; color: ${fg} !important; }
+        img, picture, svg, image, canvas {
+          -webkit-user-drag: none !important;
+          touch-action: manipulation !important;
+        }
         p, div, span, blockquote, li, dd, dt, h1, h2, h3, h4, h5, h6, td, th, caption, figcaption, label { color: inherit !important; }
         a { color: ${primary} !important; }
         ::selection { background: rgba(250, 204, 21, 0.4) !important; }
@@ -2163,6 +2171,12 @@ a { color: ${primary} !important; }
       `;
       doc.head.appendChild(style);
       doc.addEventListener('contextmenu', (e) => { e.preventDefault(); e.stopPropagation(); return false; }, true);
+    }
+
+    function isImageOnlyAnchor(anchor) {
+      if (!anchor || !anchor.matches || !anchor.matches('a[href]')) return false;
+      if ((anchor.textContent || '').trim().length > 0) return false;
+      return !!anchor.querySelector('img, picture, svg, image, canvas');
     }
 
     // ─── Tap detection ───
@@ -2255,8 +2269,11 @@ a { color: ${primary} !important; }
         }
 
         const target = e.target || state.target;
-        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) {
-          if (!target.closest('a[href]')) hideFootnoteTip();
+        const interactiveTarget = target && target.closest
+          ? target.closest('a[href], audio, video, button, input, select, textarea')
+          : null;
+        if (interactiveTarget && !isImageOnlyAnchor(interactiveTarget)) {
+          if (!interactiveTarget.closest('a[href]')) hideFootnoteTip();
           return;
         }
 

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1864,7 +1864,9 @@
           currentThemeColors.fg,
           currentThemeColors.primary,
         );
-        renderer.setStyles(themedStyles);
+        if (typeof renderer.setStyles === 'function') {
+          renderer.setStyles(themedStyles);
+        }
         syncCustomFontStylesForAllDocs(currentCustomFontFaceCSS);
       }
 
@@ -2149,6 +2151,8 @@ a { color: ${primary} !important; }
         for (const img of doc.querySelectorAll('img')) {
           img.style.maxWidth = '100%';
           img.style.height = 'auto';
+          img.style.webkitUserDrag = 'none';
+          img.style.touchAction = 'manipulation';
         }
       }
       const style = doc.createElement('style');
@@ -2156,6 +2160,10 @@ a { color: ${primary} !important; }
       style.textContent = `
         * { -webkit-touch-callout: none !important; -webkit-user-select: text !important; user-select: text !important; }
         html, body { background-color: ${bg} !important; color: ${fg} !important; }
+        img, picture, svg, image, canvas {
+          -webkit-user-drag: none !important;
+          touch-action: manipulation !important;
+        }
         p, div, span, blockquote, li, dd, dt, h1, h2, h3, h4, h5, h6, td, th, caption, figcaption, label { color: inherit !important; }
         a { color: ${primary} !important; }
         ::selection { background: rgba(250, 204, 21, 0.4) !important; }
@@ -2163,6 +2171,12 @@ a { color: ${primary} !important; }
       `;
       doc.head.appendChild(style);
       doc.addEventListener('contextmenu', (e) => { e.preventDefault(); e.stopPropagation(); return false; }, true);
+    }
+
+    function isImageOnlyAnchor(anchor) {
+      if (!anchor || !anchor.matches || !anchor.matches('a[href]')) return false;
+      if ((anchor.textContent || '').trim().length > 0) return false;
+      return !!anchor.querySelector('img, picture, svg, image, canvas');
     }
 
     // ─── Tap detection ───
@@ -2255,8 +2269,11 @@ a { color: ${primary} !important; }
         }
 
         const target = e.target || state.target;
-        if (target && target.closest && target.closest('a[href], audio, video, button, input, select, textarea')) {
-          if (!target.closest('a[href]')) hideFootnoteTip();
+        const interactiveTarget = target && target.closest
+          ? target.closest('a[href], audio, video, button, input, select, textarea')
+          : null;
+        if (interactiveTarget && !isImageOnlyAnchor(interactiveTarget)) {
+          if (!interactiveTarget.closest('a[href]')) hideFootnoteTip();
           return;
         }
 

--- a/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
+++ b/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
@@ -1,22 +1,21 @@
 import { getPlatformService } from "@readany/core/services";
 import type { Book } from "@readany/core/types";
+import * as FileSystem from "expo-file-system/legacy";
 import { queueBook as queueAutoVectorize } from "./auto-vectorize-service";
 
-const MOBILE_AUTO_VECTORIZER_MAX_BYTES = 12 * 1024 * 1024;
+export const MOBILE_AUTO_VECTORIZER_MAX_BYTES = 12 * 1024 * 1024;
 
 const MIME_TYPES: Record<string, string> = {
   epub: "application/epub+zip",
-  pdf: "application/pdf",
-  mobi: "application/x-mobipocket-ebook",
-  azw: "application/vnd.amazon.ebook",
-  azw3: "application/vnd.amazon.ebook",
-  cbz: "application/vnd.comicbook+zip",
-  cbr: "application/vnd.comicbook+zip",
-  fb2: "application/x-fictionbook+xml",
-  fbz: "application/x-zip-compressed-fb2",
   txt: "text/plain",
-  umd: "application/octet-stream",
+  // Mobile UMD imports are converted and stored as EPUB before vectorization.
+  umd: "application/epub+zip",
 };
+
+export function getMobileVectorizeMimeType(format: string | undefined): string | null {
+  const normalized = String(format || "").toLowerCase();
+  return MIME_TYPES[normalized] ?? null;
+}
 
 function bytesToBase64(bytes: Uint8Array): string {
   const chunkSize = 0x8000;
@@ -30,7 +29,7 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
-async function resolveBookPath(filePath: string): Promise<string> {
+export async function resolveMobileBookPath(filePath: string): Promise<string> {
   if (
     filePath.startsWith("/") ||
     filePath.startsWith("file://") ||
@@ -45,19 +44,54 @@ async function resolveBookPath(filePath: string): Promise<string> {
   return platform.joinPath(appData, filePath);
 }
 
+export async function getMobileBookFileSize(filePath: string): Promise<number | null> {
+  const info = await FileSystem.getInfoAsync(filePath);
+  if (!info.exists || info.isDirectory) return null;
+  return typeof info.size === "number" ? info.size : null;
+}
+
+export async function inspectMobileBookForVectorize(book: Book): Promise<{
+  absPath: string;
+  mimeType: string | null;
+  size: number | null;
+  canVectorize: boolean;
+  reason?: "unsupported-format" | "missing-file" | "too-large";
+}> {
+  const absPath = await resolveMobileBookPath(book.filePath);
+  const mimeType = getMobileVectorizeMimeType(book.format);
+  if (!mimeType) {
+    return { absPath, mimeType, size: null, canVectorize: false, reason: "unsupported-format" };
+  }
+
+  const size = await getMobileBookFileSize(absPath);
+  if (size == null) {
+    return { absPath, mimeType, size, canVectorize: false, reason: "missing-file" };
+  }
+  if (size <= 0 || size > MOBILE_AUTO_VECTORIZER_MAX_BYTES) {
+    return { absPath, mimeType, size, canVectorize: false, reason: "too-large" };
+  }
+
+  return { absPath, mimeType, size, canVectorize: true };
+}
+
 export async function queueBookForAutoVectorize(book: Book): Promise<boolean> {
   const platform = getPlatformService();
-  const absPath = await resolveBookPath(book.filePath);
-  const bytes = await platform.readFile(absPath);
-
-  if (bytes.byteLength > MOBILE_AUTO_VECTORIZER_MAX_BYTES) {
+  const info = await inspectMobileBookForVectorize(book);
+  if (!info.canVectorize || !info.mimeType) {
     console.warn(
-      `[AutoVectorize] Skip large synced download: ${book.meta.title} (${bytes.byteLength} bytes)`,
+      `[AutoVectorize] Skip mobile book: ${book.meta.title} (${info.reason}, size=${info.size ?? "unknown"}, format=${book.format})`,
     );
     return false;
   }
 
-  const format = String(book.format || "").toLowerCase();
-  queueAutoVectorize(book, bytesToBase64(bytes), MIME_TYPES[format] || "application/epub+zip");
+  const bytes = await platform.readFile(info.absPath);
+  if (bytes.byteLength > MOBILE_AUTO_VECTORIZER_MAX_BYTES) {
+    console.warn(
+      `[AutoVectorize] Skip mobile book after read: ${book.meta.title} (${bytes.byteLength} bytes)`,
+    );
+    return false;
+  }
+
+  queueAutoVectorize(book, bytesToBase64(bytes), info.mimeType);
   return true;
 }

--- a/packages/app-expo/src/lib/sync/sync-adapter-mobile.ts
+++ b/packages/app-expo/src/lib/sync/sync-adapter-mobile.ts
@@ -9,7 +9,11 @@ import * as Crypto from "expo-crypto";
 import { Directory, File, Paths } from "expo-file-system";
 import { Platform } from "react-native";
 
+const MAX_MOBILE_BUFFERED_TRANSFER_BYTES = 16 * 1024 * 1024;
+
 export class MobileSyncAdapter implements ISyncAdapter {
+  readonly maxBufferedTransferBytes = MAX_MOBILE_BUFFERED_TRANSFER_BYTES;
+
   async vacuumInto(targetPath: string): Promise<void> {
     const SQLite = await import("expo-sqlite");
     const db = await SQLite.openDatabaseAsync("readany.db");

--- a/packages/app-expo/src/screens/library/useVectorizationQueue.ts
+++ b/packages/app-expo/src/screens/library/useVectorizationQueue.ts
@@ -1,16 +1,29 @@
 import type { ExtractorRef } from "@/components/rag/ExtractorWebView";
+import {
+  MOBILE_AUTO_VECTORIZER_MAX_BYTES,
+  inspectMobileBookForVectorize,
+} from "@/lib/rag/auto-vectorize-book";
 import { triggerVectorizeBook } from "@/lib/rag/vectorize-trigger";
+import type { RootStackParamList } from "@/navigation/RootNavigator";
 import { useVectorModelStore } from "@/stores/vector-model-store";
-import { getPlatformService } from "@readany/core/services";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { Book } from "@readany/core/types";
 import * as FileSystem from "expo-file-system/legacy";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert } from "react-native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import type { RootStackParamList } from "@/navigation/RootNavigator";
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+}
 
 interface UseVectorizationQueueOptions {
   extractorRef: React.RefObject<ExtractorRef | null>;
@@ -30,41 +43,48 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
   } | null>(null);
   const isProcessingRef = useRef(false);
 
-  const processOneBook = useCallback(async (book: Book) => {
-    setVectorizingBookId(book.id);
-    setVectorizingBookTitle(book.meta.title);
-    setVectorProgress({ status: "chunking", processedChunks: 0, totalChunks: 0 });
+  const processOneBook = useCallback(
+    async (book: Book) => {
+      setVectorizingBookId(book.id);
+      setVectorizingBookTitle(book.meta.title);
+      setVectorProgress({ status: "chunking", processedChunks: 0, totalChunks: 0 });
 
-    try {
-      if (!extractorRef.current) {
-        throw new Error("Extractor WebView not ready");
+      try {
+        if (!extractorRef.current) {
+          throw new Error("Extractor WebView not ready");
+        }
+
+        const info = await inspectMobileBookForVectorize(book);
+        if (!info.canVectorize || !info.mimeType) {
+          throw new Error(`Book cannot be vectorized on mobile: ${info.reason ?? "unknown"}`);
+        }
+
+        const base64 = await FileSystem.readAsStringAsync(info.absPath, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+
+        const chapters = await extractorRef.current.extractChapters(base64, info.mimeType);
+        if (!chapters || chapters.length === 0) {
+          throw new Error("No chapters extracted from book");
+        }
+
+        await triggerVectorizeBook(book.id, book.filePath, chapters, (progress) => {
+          setVectorProgress(progress);
+        });
+
+        setVectorProgress({ status: "completed", processedChunks: 1, totalChunks: 1 });
+        await new Promise((resolve) => setTimeout(resolve, 800));
+      } catch (err) {
+        console.error(
+          `[useVectorizationQueue] Vectorization failed for "${book.meta.title}":`,
+          err,
+        );
+        setVectorProgress({ status: "error", processedChunks: 0, totalChunks: 0 });
+        await new Promise((resolve) => setTimeout(resolve, 1500));
       }
-
-      const platform = getPlatformService();
-      const appData = await platform.getAppDataDir();
-      const absPath = await platform.joinPath(appData, book.filePath);
-
-      const base64 = await FileSystem.readAsStringAsync(absPath, {
-        encoding: FileSystem.EncodingType.Base64,
-      });
-
-      const chapters = await extractorRef.current.extractChapters(base64, "application/epub+zip");
-      if (!chapters || chapters.length === 0) {
-        throw new Error("No chapters extracted from book");
-      }
-
-      await triggerVectorizeBook(book.id, book.filePath, chapters, (progress) => {
-        setVectorProgress(progress);
-      });
-
-      setVectorProgress({ status: "completed", processedChunks: 1, totalChunks: 1 });
-      await new Promise((resolve) => setTimeout(resolve, 800));
-    } catch (err) {
-      console.error(`[useVectorizationQueue] Vectorization failed for "${book.meta.title}":`, err);
-      setVectorProgress({ status: "error", processedChunks: 0, totalChunks: 0 });
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-    }
-  }, [extractorRef]);
+    },
+    [extractorRef],
+  );
 
   const processQueue = useCallback(async () => {
     if (isProcessingRef.current) return;
@@ -72,8 +92,9 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
 
     try {
       while (vectorQueueRef.current.length > 0) {
-        const nextBook = vectorQueueRef.current[0]!;
-        vectorQueueRef.current = vectorQueueRef.current.slice(1);
+        const [nextBook, ...remainingBooks] = vectorQueueRef.current;
+        if (!nextBook) break;
+        vectorQueueRef.current = remainingBooks;
         setVectorQueue([...vectorQueueRef.current]);
         await processOneBook(nextBook);
       }
@@ -86,6 +107,52 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
 
   const handleVectorize = useCallback(
     (book: Book) => {
+      const prepareAndQueue = async () => {
+        const info = await inspectMobileBookForVectorize(book);
+        if (info.reason === "unsupported-format") {
+          Alert.alert(
+            t("vectorize.unsupportedFormatTitle", "Unsupported format"),
+            t(
+              "vectorize.unsupportedFormatDesc",
+              "Mobile vectorization currently supports EPUB, TXT, and UMD books.",
+            ),
+          );
+          return;
+        }
+        if (info.reason === "missing-file") {
+          Alert.alert(
+            t("common.error", "Error"),
+            t(
+              "vectorize.missingFileDesc",
+              "The local book file is missing. Please download or re-import it.",
+            ),
+          );
+          return;
+        }
+        if (info.reason === "too-large") {
+          Alert.alert(
+            t("vectorize.fileTooLargeTitle", "Book is too large"),
+            t("vectorize.fileTooLargeDesc", {
+              defaultValue:
+                "This book is {{size}}. Mobile vectorization is limited to {{limit}} to avoid running out of memory.",
+              size: info.size != null ? formatBytes(info.size) : t("common.unknown", "unknown"),
+              limit: formatBytes(MOBILE_AUTO_VECTORIZER_MAX_BYTES),
+            }),
+          );
+          return;
+        }
+
+        const alreadyQueued = vectorQueueRef.current.some((b) => b.id === book.id);
+        if (alreadyQueued || vectorizingBookId === book.id) return;
+
+        vectorQueueRef.current = [...vectorQueueRef.current, book];
+        setVectorQueue([...vectorQueueRef.current]);
+
+        if (!isProcessingRef.current) {
+          processQueue();
+        }
+      };
+
       const hasCapability = useVectorModelStore.getState().hasVectorCapability();
       if (!hasCapability) {
         Alert.alert(t("settings.vectorModel"), t("vectorize.notConfiguredDesc"), [
@@ -98,15 +165,13 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
         return;
       }
 
-      const alreadyQueued = vectorQueueRef.current.some((b) => b.id === book.id);
-      if (alreadyQueued || vectorizingBookId === book.id) return;
-
-      vectorQueueRef.current = [...vectorQueueRef.current, book];
-      setVectorQueue([...vectorQueueRef.current]);
-
-      if (!isProcessingRef.current) {
-        processQueue();
-      }
+      prepareAndQueue().catch((err) => {
+        console.error(`[useVectorizationQueue] Failed to prepare "${book.meta.title}":`, err);
+        Alert.alert(
+          t("common.error", "Error"),
+          t("vectorize.prepareFailed", "Failed to prepare vectorization."),
+        );
+      });
     },
     [nav, t, vectorizingBookId, processQueue],
   );

--- a/packages/core/src/sync/__tests__/sync-files.test.ts
+++ b/packages/core/src/sync/__tests__/sync-files.test.ts
@@ -14,6 +14,7 @@ const mockAdapter = {
   fileExists: vi.fn(),
   readFileBytes: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   getFileSize: vi.fn().mockResolvedValue(null),
+  maxBufferedTransferBytes: undefined as number | undefined,
   writeFileBytes: vi.fn(),
   copyFile: vi.fn(),
   deleteFile: vi.fn(),
@@ -56,6 +57,7 @@ describe("sync-files", () => {
     vi.clearAllMocks();
     mockSelect.mockResolvedValue([]);
     mockAdapter.listFiles.mockResolvedValue([]);
+    mockAdapter.maxBufferedTransferBytes = undefined;
   });
 
   afterEach(() => {
@@ -126,6 +128,32 @@ describe("sync-files", () => {
         "/appdata/books/book-1.epub",
         expect.any(Function),
       );
+      expect(mockAdapter.readFileBytes).not.toHaveBeenCalled();
+      expect(backend.put).not.toHaveBeenCalled();
+    });
+
+    it("does not buffer oversized uploads when the platform sets a transfer limit", async () => {
+      mockSelect.mockResolvedValue([
+        {
+          id: "book-1",
+          file_path: "books/book-1.epub",
+          file_hash: "h1",
+          cover_url: null,
+          title: "Huge Book",
+        },
+      ]);
+
+      mockAdapter.fileExists.mockResolvedValue(true);
+      mockAdapter.getFileSize.mockResolvedValue(20 * 1024 * 1024);
+      mockAdapter.maxBufferedTransferBytes = 16 * 1024 * 1024;
+
+      const backend = createMockBackend({
+        listDir: vi.fn().mockResolvedValue([]),
+      });
+
+      const result = await syncFiles(backend);
+      expect(result.filesUploaded).toBe(0);
+      expect(result.filesUploadFailed).toBe(1);
       expect(mockAdapter.readFileBytes).not.toHaveBeenCalled();
       expect(backend.put).not.toHaveBeenCalled();
     });

--- a/packages/core/src/sync/sync-adapter.ts
+++ b/packages/core/src/sync/sync-adapter.ts
@@ -33,6 +33,9 @@ export interface ISyncAdapter {
   /** Get file size in bytes, or null when unavailable. */
   getFileSize(filePath: string): Promise<number | null>;
 
+  /** Max bytes this platform can safely buffer for fallback sync transfers. */
+  maxBufferedTransferBytes?: number;
+
   /** Write Uint8Array to a file */
   writeFileBytes(filePath: string, data: Uint8Array): Promise<void>;
 

--- a/packages/core/src/sync/sync-files.ts
+++ b/packages/core/src/sync/sync-files.ts
@@ -73,6 +73,12 @@ function isDirectFileTransferUnsupported(error: unknown): boolean {
   return /does not support direct file|Platform does not support direct file/i.test(message);
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+  return `${bytes} B`;
+}
+
 async function makeTempTransferPath(finalPath: string): Promise<string> {
   const adapter = getSyncAdapter();
   const tempDir = await adapter.getTempDir();
@@ -90,6 +96,7 @@ async function uploadFileToRemote(
   localPath: string,
   onProgress?: (loaded: number, total: number) => void,
 ): Promise<number | null> {
+  const adapter = getSyncAdapter();
   if (backend.putFile) {
     try {
       await backend.putFile(remotePath, localPath, onProgress);
@@ -102,7 +109,15 @@ async function uploadFileToRemote(
     }
   }
 
-  const adapter = getSyncAdapter();
+  if (adapter.maxBufferedTransferBytes != null) {
+    const fileSize = await adapter.getFileSize(localPath);
+    if (fileSize != null && fileSize > adapter.maxBufferedTransferBytes) {
+      throw new Error(
+        `Buffered upload would exceed platform memory limit for ${remotePath}: ${formatBytes(fileSize)} > ${formatBytes(adapter.maxBufferedTransferBytes)}`,
+      );
+    }
+  }
+
   const data = await adapter.readFileBytes(localPath);
   onProgress?.(0, data.length);
   await backend.put(remotePath, data);


### PR DESCRIPTION
## Summary
- Add a shared mobile vectorization preflight that resolves the local file path, checks supported formats, and checks file size before reading book bytes or converting to base64.
- Use that preflight for both automatic vectorization after download/import and manual vectorization from the library screen, with user-facing alerts for unsupported, missing, or oversized files.
- Add a mobile sync adapter buffered-transfer limit and stop fallback uploads from reading oversized files into JS/RN memory when direct file upload is unavailable.

## Analysis
The reported Android OOM stack points at React Native Networking base64 encoding a very large payload. There were two risky paths:
1. `queueBookForAutoVectorize()` read the full synced book before checking the 12 MB vectorization limit. A large PDF/EPUB downloaded from WebDAV could hit 100%, then immediately be read into memory for auto-vectorization and crash.
2. Core sync fallback upload read the entire local file into a `Uint8Array` when the backend could not do direct file transfer. On mobile this can push large books through RN Networking as base64.

This PR moves those checks before the expensive read and makes oversized mobile fallback uploads fail gracefully instead of taking the app down. It also avoids sending unsupported formats such as PDF to the EPUB extractor.

Fixes #157
Fixes #210
Refs #412

## Validation
- `pnpm exec biome check packages/core/src/sync/sync-adapter.ts packages/core/src/sync/sync-files.ts packages/core/src/sync/__tests__/sync-files.test.ts packages/app-expo/src/lib/sync/sync-adapter-mobile.ts packages/app-expo/src/lib/rag/auto-vectorize-book.ts packages/app-expo/src/screens/library/useVectorizationQueue.ts`
- `pnpm --filter @readany/core test -- sync-files`
- `pnpm --filter @readany/app-expo exec tsc --noEmit`