### PR TITLE
fix(compat): add Promise.withResolvers polyfill for older WebView

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,3 +1,4 @@
+import "./polyfills";
 import { i18nReady } from "@readany/core/i18n";
 import { initI18nLanguage } from "@readany/core/i18n";
 /**

--- a/packages/app/src/polyfills.ts
+++ b/packages/app/src/polyfills.ts
@@ -1,0 +1,11 @@
+if (typeof Promise.withResolvers === "undefined") {
+  Promise.withResolvers = function <T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+}

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+declare interface PromiseConstructor {
+  withResolvers<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: unknown) => void;
+  };
+}
+
 // foliate-js is a pure JS library with no type declarations
 declare module "foliate-js/view.js";
 declare module "foliate-js/epub.js";


### PR DESCRIPTION
## Summary
Add a `Promise.withResolvers` polyfill for older WebView engines (Safari 15.x / macOS 12 Monterey).

Closes #477

## Root Cause
`Promise.withResolvers()` is an ES2024 feature (Chrome 119+, Safari 17.2+). Tauri on macOS 12 uses WKWebView based on Safari 15.x which does not support it. When importing a local book, the app crashes with `Promise.withResolvers is not a function`.

## Changes
- **`packages/app/src/polyfills.ts`** (new): Adds a standard `Promise.withResolvers` polyfill that creates a Promise and exposes its `resolve`/`reject` handles.
- **`packages/app/src/main.tsx`**: Imports the polyfill as the very first import, so it runs before any app code or lazy-loaded PDF.js modules.
- **`packages/app/src/vite-env.d.ts`**: Adds the TypeScript declaration for `PromiseConstructor.withResolvers` so the polyfill and all call sites type-check correctly.

## Verification
- Searched the codebase: `Promise.withResolvers` is used in bundled PDF.js assets and will now be polyfilled at startup.
- `pnpm install --frozen-lockfile` ✅
- `npm run build` ✅