### PR TITLE
fix(chat): enable AI response text selection

### DIFF
--- a/packages/app/src/components/chat/MarkdownRenderer.tsx
+++ b/packages/app/src/components/chat/MarkdownRenderer.tsx
@@ -1,4 +1,5 @@
 import { getPlatformService } from "@readany/core/services";
+import { cn } from "@readany/core/utils";
 import type { CitationPart } from "@readany/core/types/message";
 /**
  * MarkdownRenderer — renders AI markdown responses with:
@@ -646,7 +647,7 @@ export const MarkdownRenderer = React.memo(function MarkdownRenderer({
 
   return (
     <CitationContext.Provider value={{ citations, onCitationClick }}>
-      <div className={className} data-md-scope={isStreaming ? scopeId : undefined}>
+      <div className={cn("select-text", className)} data-md-scope={isStreaming ? scopeId : undefined}>
         <Markdown
           remarkPlugins={remarkPlugins}
           rehypePlugins={rehypePlugins}

--- a/packages/app/src/components/chat/PartRenderer.tsx
+++ b/packages/app/src/components/chat/PartRenderer.tsx
@@ -110,7 +110,7 @@ function TextPartView({
     // Even if no text yet, show cursor when streaming
     if (isStreaming) {
       return (
-        <div className="chat-markdown max-w-none text-sm leading-relaxed">
+        <div className="chat-markdown select-text max-w-none text-sm leading-relaxed">
           <span className="inline-block h-4 w-[3px] animate-pulse rounded-sm bg-primary" />
         </div>
       );
@@ -119,7 +119,7 @@ function TextPartView({
   }
 
   return (
-    <div className="chat-markdown max-w-none text-sm leading-relaxed">
+    <div className="chat-markdown select-text max-w-none text-sm leading-relaxed">
       <MarkdownRenderer
         content={throttledText}
         isStreaming={isStreaming}


### PR DESCRIPTION
## Summary
Enable text selection and copy in AI chat responses.

Closes #471

## Root Cause
The app sets `body { user-select: none; }` globally, and the AI chat response components did not override this. As a result, users could not select or copy any text from AI-generated responses.

## Changes
- **`packages/app/src/components/chat/PartRenderer.tsx`**: Added `select-text` class to text part wrappers so AI response paragraphs are selectable.
- **`packages/app/src/components/chat/MarkdownRenderer.tsx`**: Added `select-text` class to the markdown root container so rendered markdown content (code blocks, lists, etc.) is selectable and copyable.

## Verification
- `pnpm install --frozen-lockfile` ✅
- `npm run build` ✅