### PR TITLE
Quality: Stack overflow risk in bytesToBase64 due to large spread operator

### DIFF
--- a/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
+++ b/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
@@ -19,12 +19,12 @@ export function getMobileVectorizeMimeType(format: string | undefined): string |
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  const chunkSize = 0x8000;
+  const chunkSize = 0x1000;
   let binary = "";
 
   for (let i = 0; i < bytes.length; i += chunkSize) {
     const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
+    binary += Array.from(chunk, (b) => String.fromCharCode(b)).join("");
   }
 
   return btoa(binary);


### PR DESCRIPTION
## Summary

Quality: Stack overflow risk in bytesToBase64 due to large spread operator

## Problem

**Severity**: `High` | **File**: `packages/app-expo/src/lib/rag/auto-vectorize-book.ts:L33`

The `bytesToBase64` function spreads a `Uint8Array` chunk of size `0x8000` (32768) into `String.fromCharCode(...)`. Most JavaScript engines have a maximum argument count limit (typically ~65536 but often lower in practice), and spreading such a large array will cause a 'Maximum call stack size exceeded' error for files larger than ~32KB.

## Solution

Replace the spread operator with a loop or use a smaller chunk size (e.g., 0x1000 or 4096). Alternatively, use `Array.from(chunk, b => String.fromCharCode(b)).join('')` or a TextDecoder-based approach to avoid stack overflow.

## Changes

- `packages/app-expo/src/lib/rag/auto-vectorize-book.ts` (modified)