### PR TITLE
fix(ai): retry custom endpoints without token limit

### DIFF
--- a/packages/app-expo/src/stores/settings-store.ts
+++ b/packages/app-expo/src/stores/settings-store.ts
@@ -78,7 +78,7 @@ const defaultAIConfig: AIConfig = {
   activeEndpointId: "default",
   activeModel: "",
   temperature: 0.7,
-  maxTokens: 4096,
+  maxTokens: 8192,
   slidingWindowSize: 8,
 };
 

--- a/packages/app-expo/src/stores/settings-store.ts
+++ b/packages/app-expo/src/stores/settings-store.ts
@@ -82,6 +82,17 @@ const defaultAIConfig: AIConfig = {
   slidingWindowSize: 8,
 };
 
+function migrateSettingsState(state: SettingsState): SettingsState {
+  if (state.aiConfig.maxTokens !== 4096) return state;
+  return {
+    ...state,
+    aiConfig: {
+      ...state.aiConfig,
+      maxTokens: defaultAIConfig.maxTokens,
+    },
+  };
+}
+
 async function fetchModelsFromEndpoint(endpoint: AIEndpoint): Promise<string[]> {
   if (!endpoint.apiKey && endpoint.provider !== "ollama" && endpoint.provider !== "lmstudio") {
     return [];
@@ -618,7 +629,7 @@ export const useSettingsStore = create<SettingsState>()(
         });
       },
     };
-  }),
+  }, undefined, migrateSettingsState),
 );
 
 // 在应用启动时加载 API keys

--- a/packages/app/src/components/settings/AISettings.tsx
+++ b/packages/app/src/components/settings/AISettings.tsx
@@ -764,13 +764,13 @@ export function AISettings() {
         {/* Max Tokens */}
         <div>
           <h3 className="mb-2 text-xs text-muted-foreground">
-            {t("settings.maxTokens", { value: aiConfig.maxTokens ?? 4096 })}
+            {t("settings.maxTokens", { value: aiConfig.maxTokens ?? 8192 })}
           </h3>
           <Slider
             min={1024}
             max={32768}
             step={1024}
-            value={[aiConfig.maxTokens ?? 4096]}
+            value={[aiConfig.maxTokens ?? 8192]}
             onValueChange={([v]) => updateAIConfig({ maxTokens: v })}
           />
           <div className="mt-2 flex justify-between text-xs text-muted-foreground">

--- a/packages/core/src/ai/__tests__/llm-provider.test.ts
+++ b/packages/core/src/ai/__tests__/llm-provider.test.ts
@@ -141,3 +141,72 @@ describe("getEndpointFetch Gemini thought signatures", () => {
     expect(toolCall.extra_content).toBeUndefined();
   });
 });
+
+describe("getEndpointFetch custom endpoint compatibility", () => {
+  it("retries without token limit when a custom endpoint rejects max_completion_tokens over 100", async () => {
+    const requestBodies: Record<string, unknown>[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      let bodyText = "";
+      if (typeof init?.body === "string") {
+        bodyText = init.body;
+      } else if (input instanceof Request) {
+        bodyText = await input.clone().text();
+      }
+      requestBodies.push(JSON.parse(bodyText) as Record<string, unknown>);
+
+      if (requestBodies.length === 1) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "参数错误超过100个",
+              type: "invalid_request_error",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const endpoint = makeEndpoint();
+    const endpointFetch = getEndpointFetch(endpoint, "gpt-5.5");
+    const response = await endpointFetch(endpoint.baseUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.5",
+        messages: [{ role: "user", content: "总结我最近的阅读" }],
+        max_completion_tokens: 4096,
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "getReadingStats",
+              parameters: {
+                type: "object",
+                properties: {
+                  reasoning: { type: "string" },
+                  days: { type: "number" },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(response.ok).toBe(true);
+    expect(requestBodies).toHaveLength(2);
+    expect(requestBodies[0]?.max_completion_tokens).toBe(4096);
+    expect(requestBodies[1]?.max_completion_tokens).toBeUndefined();
+    expect(requestBodies[1]?.messages).toEqual(requestBodies[0]?.messages);
+    expect(requestBodies[1]?.tools).toEqual(requestBodies[0]?.tools);
+  });
+});

--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -42,6 +42,41 @@ beforeEach(() => {
 });
 
 describe("streamReadingAgent tool registration", () => {
+  it("keeps library-level reading stats requests under a focused tool set", async () => {
+    createReactAgentMock.mockReturnValue({
+      streamEvents: vi.fn(() => ({
+        [Symbol.asyncIterator]: async function* () {
+          // no-op stream
+        },
+      })),
+    });
+
+    for await (const _event of streamReadingAgent(
+      {
+        aiConfig: makeAIConfig(),
+        book: null,
+        bookId: null,
+        semanticContext: null,
+        enabledSkills: [],
+        isVectorized: false,
+        getAvailableTools,
+      },
+      "总结我最近的阅读",
+    )) {
+      // drain stream
+    }
+
+    const call = createReactAgentMock.mock.calls[createReactAgentMock.mock.calls.length - 1]?.[0];
+    const toolNames = (call.tools as ToolDefinition[]).map((tool) => tool.name);
+
+    expect(toolNames).toContain("getReadingStats");
+    expect(toolNames).toContain("listBooks");
+    expect(toolNames).not.toContain("tagBooks");
+    expect(toolNames).not.toContain("manageBookTags");
+    expect(toolNames).not.toContain("updateBookMetadata");
+    expect(toolNames).not.toContain("manageBookGroups");
+  });
+
   it("registers fallback tools when only bookId is available", async () => {
     createReactAgentMock.mockReturnValue({
       streamEvents: vi.fn(() => ({

--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -42,41 +42,6 @@ beforeEach(() => {
 });
 
 describe("streamReadingAgent tool registration", () => {
-  it("keeps library-level reading stats requests under a focused tool set", async () => {
-    createReactAgentMock.mockReturnValue({
-      streamEvents: vi.fn(() => ({
-        [Symbol.asyncIterator]: async function* () {
-          // no-op stream
-        },
-      })),
-    });
-
-    for await (const _event of streamReadingAgent(
-      {
-        aiConfig: makeAIConfig(),
-        book: null,
-        bookId: null,
-        semanticContext: null,
-        enabledSkills: [],
-        isVectorized: false,
-        getAvailableTools,
-      },
-      "总结我最近的阅读",
-    )) {
-      // drain stream
-    }
-
-    const call = createReactAgentMock.mock.calls[createReactAgentMock.mock.calls.length - 1]?.[0];
-    const toolNames = (call.tools as ToolDefinition[]).map((tool) => tool.name);
-
-    expect(toolNames).toContain("getReadingStats");
-    expect(toolNames).toContain("listBooks");
-    expect(toolNames).not.toContain("tagBooks");
-    expect(toolNames).not.toContain("manageBookTags");
-    expect(toolNames).not.toContain("updateBookMetadata");
-    expect(toolNames).not.toContain("manageBookGroups");
-  });
-
   it("registers fallback tools when only bookId is available", async () => {
     createReactAgentMock.mockReturnValue({
       streamEvents: vi.fn(() => ({

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
  *
  * Architecture:
  * 1. Uses LangGraph's createReactAgent for automatic tool-calling loop (no hard iteration limit)
- * 2. Uses getAvailableTools() and registers a focused subset of tools
+ * 2. Uses getAvailableTools() to register all available tools
  * 3. Builds proper Zod schemas from ToolDefinition.parameters
  * 4. Real streaming via streamEvents API
  * 5. System prompt from system-prompt.ts
@@ -96,200 +96,8 @@ function buildZodSchema(
   return z.object(shape);
 }
 
-const MAX_TOOL_SCHEMA_PARAMETERS = 90;
-
-const TOOL_GROUPS = {
-  libraryRead: [
-    "listBooks",
-    "searchAllHighlights",
-    "searchAllNotes",
-    "getReadingStats",
-    "getSkills",
-    "mindmap",
-  ],
-  libraryWrite: [
-    "classifyBooks",
-    "tagBooks",
-    "manageBookTags",
-    "updateBookMetadata",
-    "manageBookGroups",
-  ],
-  readingContext: [
-    "getCurrentChapter",
-    "getSelection",
-    "getReadingProgress",
-    "getRecentHighlights",
-    "getSurroundingContext",
-  ],
-  indexedContent: [
-    "ragSearch",
-    "ragToc",
-    "ragContext",
-    "summarize",
-    "extractEntities",
-    "findQuotes",
-    "addCitation",
-  ],
-  indexedAnalysis: ["analyzeArguments", "compareSections"],
-  fallbackContent: ["fallbackToc", "fallbackSearch", "fallbackChapterContext", "addCitation"],
-  annotations: ["getAnnotations", "addCitation"],
-} as const;
-
-function hasAnyKeyword(input: string, keywords: string[]): boolean {
-  return keywords.some((keyword) => input.includes(keyword));
-}
-
 function countToolParameters(tools: ToolDefinition[]): number {
   return tools.reduce((sum, tool) => sum + Object.keys(tool.parameters ?? {}).length, 0);
-}
-
-function addToolGroup(
-  selected: ToolDefinition[],
-  toolsByName: Map<string, ToolDefinition>,
-  names: readonly string[],
-): void {
-  for (const name of names) {
-    const tool = toolsByName.get(name);
-    if (tool && !selected.some((existing) => existing.name === tool.name)) {
-      selected.push(tool);
-    }
-  }
-}
-
-function addRelevantSkillTools(
-  selected: ToolDefinition[],
-  allTools: ToolDefinition[],
-  input: string,
-): void {
-  const builtInNames = new Set<string>(Object.values(TOOL_GROUPS).flat());
-  for (const tool of allTools) {
-    if (builtInNames.has(tool.name)) continue;
-    const searchable = `${tool.name} ${tool.description}`.toLowerCase();
-    if (!searchable || !input) continue;
-    if (
-      input.includes(tool.name.toLowerCase()) ||
-      searchable.split(/\s+/).some((word) => word.length >= 4 && input.includes(word))
-    ) {
-      selected.push(tool);
-    }
-  }
-}
-
-function trimToolsToParameterBudget(tools: ToolDefinition[]): ToolDefinition[] {
-  const selected: ToolDefinition[] = [];
-  let parameterCount = 0;
-
-  for (const tool of tools) {
-    if (selected.some((existing) => existing.name === tool.name)) continue;
-    const nextCount = parameterCount + Object.keys(tool.parameters ?? {}).length;
-    if (selected.length > 0 && nextCount > MAX_TOOL_SCHEMA_PARAMETERS) continue;
-    selected.push(tool);
-    parameterCount = nextCount;
-  }
-
-  return selected;
-}
-
-function selectToolsForRequest(options: {
-  tools: ToolDefinition[];
-  userInput: string;
-  hasBook: boolean;
-  isVectorized: boolean;
-}): ToolDefinition[] {
-  const input = options.userInput.toLowerCase();
-  const toolsByName = new Map(options.tools.map((tool) => [tool.name, tool]));
-  const selected: ToolDefinition[] = [];
-
-  const asksReadingStats = hasAnyKeyword(input, [
-    "阅读",
-    "最近",
-    "统计",
-    "时长",
-    "读了",
-    "读书",
-    "reading",
-    "stats",
-    "statistics",
-    "activity",
-    "habit",
-    "progress",
-  ]);
-  const asksHighlights = hasAnyKeyword(input, [
-    "高亮",
-    "划线",
-    "标注",
-    "摘录",
-    "highlight",
-    "annotation",
-    "quote",
-  ]);
-  const asksNotes = hasAnyKeyword(input, ["笔记", "想法", "note", "notes"]);
-  const asksLibrary = hasAnyKeyword(input, ["书库", "书架", "书籍", "书", "library", "books"]);
-  const asksSkill = hasAnyKeyword(input, ["技能", "流程", "sop", "skill"]);
-  const asksMindmap = hasAnyKeyword(input, ["思维导图", "脑图", "mindmap"]);
-  const asksBookManagement = hasAnyKeyword(input, [
-    "标签",
-    "分类",
-    "归类",
-    "分组",
-    "改名",
-    "元数据",
-    "封面",
-    "tag",
-    "classify",
-    "category",
-    "group",
-    "metadata",
-    "cover",
-  ]);
-  const asksArgumentAnalysis = hasAnyKeyword(input, [
-    "论点",
-    "论证",
-    "比较",
-    "对比",
-    "argument",
-    "compare",
-    "comparison",
-  ]);
-
-  if (options.hasBook) {
-    addToolGroup(selected, toolsByName, TOOL_GROUPS.readingContext);
-    addToolGroup(
-      selected,
-      toolsByName,
-      options.isVectorized ? TOOL_GROUPS.indexedContent : TOOL_GROUPS.fallbackContent,
-    );
-    if (asksArgumentAnalysis) {
-      addToolGroup(selected, toolsByName, TOOL_GROUPS.indexedAnalysis);
-    }
-    if (asksHighlights || asksNotes) {
-      addToolGroup(selected, toolsByName, TOOL_GROUPS.annotations);
-    }
-  }
-
-  if (!options.hasBook || asksReadingStats || asksLibrary || asksHighlights || asksNotes) {
-    if (asksReadingStats) addToolGroup(selected, toolsByName, ["getReadingStats", "listBooks"]);
-    if (asksHighlights) addToolGroup(selected, toolsByName, ["searchAllHighlights"]);
-    if (asksNotes) addToolGroup(selected, toolsByName, ["searchAllNotes"]);
-    if (asksLibrary) addToolGroup(selected, toolsByName, ["listBooks"]);
-  }
-
-  if (!options.hasBook && selected.length === 0) {
-    addToolGroup(selected, toolsByName, [
-      "listBooks",
-      "getReadingStats",
-      "searchAllHighlights",
-      "searchAllNotes",
-    ]);
-  }
-
-  if (asksSkill) addToolGroup(selected, toolsByName, ["getSkills"]);
-  if (asksMindmap) addToolGroup(selected, toolsByName, ["mindmap"]);
-  if (asksBookManagement) addToolGroup(selected, toolsByName, TOOL_GROUPS.libraryWrite);
-  addRelevantSkillTools(selected, options.tools, input);
-
-  const focusedTools = selected.length > 0 ? selected : options.tools;
-  return trimToolsToParameterBudget(focusedTools);
 }
 
 // --- Tool Executor (error-safe wrapper) ---
@@ -400,28 +208,17 @@ export async function* streamReadingAgent(
     // Check abort after async operation
     if (isAborted()) return;
 
-    // Register a focused subset of tools via injected getAvailableTools.
-    // Some OpenAI-compatible providers reject requests whose tool schemas expose
-    // more than 100 top-level parameters, especially on the follow-up request
-    // after a tool result. Keeping the active toolset focused also improves
-    // model choice and avoids accidental write-tool calls.
+    // Register all available tools via injected getAvailableTools.
     const effectiveBookId = book?.id || bookId || null;
-    const allTools = getAvailableTools({
+    const tools = getAvailableTools({
       bookId: effectiveBookId,
       isVectorized,
       enabledSkills,
-    });
-    const tools = selectToolsForRequest({
-      tools: allTools,
-      userInput,
-      hasBook: Boolean(effectiveBookId),
-      isVectorized,
     });
     console.log(
       "[ReadingAgent] tools",
       JSON.stringify({
         registered: tools.length,
-        available: allTools.length,
         parameters: countToolParameters(tools),
         names: tools.map((tool) => tool.name),
       }),

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
  *
  * Architecture:
  * 1. Uses LangGraph's createReactAgent for automatic tool-calling loop (no hard iteration limit)
- * 2. Uses getAvailableTools() to register ALL tools (RAG, analysis, context)
+ * 2. Uses getAvailableTools() and registers a focused subset of tools
  * 3. Builds proper Zod schemas from ToolDefinition.parameters
  * 4. Real streaming via streamEvents API
  * 5. System prompt from system-prompt.ts
@@ -94,6 +94,202 @@ function buildZodSchema(
   }
 
   return z.object(shape);
+}
+
+const MAX_TOOL_SCHEMA_PARAMETERS = 90;
+
+const TOOL_GROUPS = {
+  libraryRead: [
+    "listBooks",
+    "searchAllHighlights",
+    "searchAllNotes",
+    "getReadingStats",
+    "getSkills",
+    "mindmap",
+  ],
+  libraryWrite: [
+    "classifyBooks",
+    "tagBooks",
+    "manageBookTags",
+    "updateBookMetadata",
+    "manageBookGroups",
+  ],
+  readingContext: [
+    "getCurrentChapter",
+    "getSelection",
+    "getReadingProgress",
+    "getRecentHighlights",
+    "getSurroundingContext",
+  ],
+  indexedContent: [
+    "ragSearch",
+    "ragToc",
+    "ragContext",
+    "summarize",
+    "extractEntities",
+    "findQuotes",
+    "addCitation",
+  ],
+  indexedAnalysis: ["analyzeArguments", "compareSections"],
+  fallbackContent: ["fallbackToc", "fallbackSearch", "fallbackChapterContext", "addCitation"],
+  annotations: ["getAnnotations", "addCitation"],
+} as const;
+
+function hasAnyKeyword(input: string, keywords: string[]): boolean {
+  return keywords.some((keyword) => input.includes(keyword));
+}
+
+function countToolParameters(tools: ToolDefinition[]): number {
+  return tools.reduce((sum, tool) => sum + Object.keys(tool.parameters ?? {}).length, 0);
+}
+
+function addToolGroup(
+  selected: ToolDefinition[],
+  toolsByName: Map<string, ToolDefinition>,
+  names: readonly string[],
+): void {
+  for (const name of names) {
+    const tool = toolsByName.get(name);
+    if (tool && !selected.some((existing) => existing.name === tool.name)) {
+      selected.push(tool);
+    }
+  }
+}
+
+function addRelevantSkillTools(
+  selected: ToolDefinition[],
+  allTools: ToolDefinition[],
+  input: string,
+): void {
+  const builtInNames = new Set<string>(Object.values(TOOL_GROUPS).flat());
+  for (const tool of allTools) {
+    if (builtInNames.has(tool.name)) continue;
+    const searchable = `${tool.name} ${tool.description}`.toLowerCase();
+    if (!searchable || !input) continue;
+    if (
+      input.includes(tool.name.toLowerCase()) ||
+      searchable.split(/\s+/).some((word) => word.length >= 4 && input.includes(word))
+    ) {
+      selected.push(tool);
+    }
+  }
+}
+
+function trimToolsToParameterBudget(tools: ToolDefinition[]): ToolDefinition[] {
+  const selected: ToolDefinition[] = [];
+  let parameterCount = 0;
+
+  for (const tool of tools) {
+    if (selected.some((existing) => existing.name === tool.name)) continue;
+    const nextCount = parameterCount + Object.keys(tool.parameters ?? {}).length;
+    if (selected.length > 0 && nextCount > MAX_TOOL_SCHEMA_PARAMETERS) continue;
+    selected.push(tool);
+    parameterCount = nextCount;
+  }
+
+  return selected;
+}
+
+function selectToolsForRequest(options: {
+  tools: ToolDefinition[];
+  userInput: string;
+  hasBook: boolean;
+  isVectorized: boolean;
+}): ToolDefinition[] {
+  const input = options.userInput.toLowerCase();
+  const toolsByName = new Map(options.tools.map((tool) => [tool.name, tool]));
+  const selected: ToolDefinition[] = [];
+
+  const asksReadingStats = hasAnyKeyword(input, [
+    "阅读",
+    "最近",
+    "统计",
+    "时长",
+    "读了",
+    "读书",
+    "reading",
+    "stats",
+    "statistics",
+    "activity",
+    "habit",
+    "progress",
+  ]);
+  const asksHighlights = hasAnyKeyword(input, [
+    "高亮",
+    "划线",
+    "标注",
+    "摘录",
+    "highlight",
+    "annotation",
+    "quote",
+  ]);
+  const asksNotes = hasAnyKeyword(input, ["笔记", "想法", "note", "notes"]);
+  const asksLibrary = hasAnyKeyword(input, ["书库", "书架", "书籍", "书", "library", "books"]);
+  const asksSkill = hasAnyKeyword(input, ["技能", "流程", "sop", "skill"]);
+  const asksMindmap = hasAnyKeyword(input, ["思维导图", "脑图", "mindmap"]);
+  const asksBookManagement = hasAnyKeyword(input, [
+    "标签",
+    "分类",
+    "归类",
+    "分组",
+    "改名",
+    "元数据",
+    "封面",
+    "tag",
+    "classify",
+    "category",
+    "group",
+    "metadata",
+    "cover",
+  ]);
+  const asksArgumentAnalysis = hasAnyKeyword(input, [
+    "论点",
+    "论证",
+    "比较",
+    "对比",
+    "argument",
+    "compare",
+    "comparison",
+  ]);
+
+  if (options.hasBook) {
+    addToolGroup(selected, toolsByName, TOOL_GROUPS.readingContext);
+    addToolGroup(
+      selected,
+      toolsByName,
+      options.isVectorized ? TOOL_GROUPS.indexedContent : TOOL_GROUPS.fallbackContent,
+    );
+    if (asksArgumentAnalysis) {
+      addToolGroup(selected, toolsByName, TOOL_GROUPS.indexedAnalysis);
+    }
+    if (asksHighlights || asksNotes) {
+      addToolGroup(selected, toolsByName, TOOL_GROUPS.annotations);
+    }
+  }
+
+  if (!options.hasBook || asksReadingStats || asksLibrary || asksHighlights || asksNotes) {
+    if (asksReadingStats) addToolGroup(selected, toolsByName, ["getReadingStats", "listBooks"]);
+    if (asksHighlights) addToolGroup(selected, toolsByName, ["searchAllHighlights"]);
+    if (asksNotes) addToolGroup(selected, toolsByName, ["searchAllNotes"]);
+    if (asksLibrary) addToolGroup(selected, toolsByName, ["listBooks"]);
+  }
+
+  if (!options.hasBook && selected.length === 0) {
+    addToolGroup(selected, toolsByName, [
+      "listBooks",
+      "getReadingStats",
+      "searchAllHighlights",
+      "searchAllNotes",
+    ]);
+  }
+
+  if (asksSkill) addToolGroup(selected, toolsByName, ["getSkills"]);
+  if (asksMindmap) addToolGroup(selected, toolsByName, ["mindmap"]);
+  if (asksBookManagement) addToolGroup(selected, toolsByName, TOOL_GROUPS.libraryWrite);
+  addRelevantSkillTools(selected, options.tools, input);
+
+  const focusedTools = selected.length > 0 ? selected : options.tools;
+  return trimToolsToParameterBudget(focusedTools);
 }
 
 // --- Tool Executor (error-safe wrapper) ---
@@ -204,13 +400,32 @@ export async function* streamReadingAgent(
     // Check abort after async operation
     if (isAborted()) return;
 
-    // Register ALL tools via injected getAvailableTools
+    // Register a focused subset of tools via injected getAvailableTools.
+    // Some OpenAI-compatible providers reject requests whose tool schemas expose
+    // more than 100 top-level parameters, especially on the follow-up request
+    // after a tool result. Keeping the active toolset focused also improves
+    // model choice and avoids accidental write-tool calls.
     const effectiveBookId = book?.id || bookId || null;
-    const tools = getAvailableTools({
+    const allTools = getAvailableTools({
       bookId: effectiveBookId,
       isVectorized,
       enabledSkills,
     });
+    const tools = selectToolsForRequest({
+      tools: allTools,
+      userInput,
+      hasBook: Boolean(effectiveBookId),
+      isVectorized,
+    });
+    console.log(
+      "[ReadingAgent] tools",
+      JSON.stringify({
+        registered: tools.length,
+        available: allTools.length,
+        parameters: countToolParameters(tools),
+        names: tools.map((tool) => tool.name),
+      }),
+    );
 
     // Build system prompt
     const systemPrompt = buildSystemPrompt({

--- a/packages/core/src/ai/llm-provider.ts
+++ b/packages/core/src/ai/llm-provider.ts
@@ -141,6 +141,99 @@ function summarizeChatRequestBody(bodyText: string): Record<string, unknown> | u
   };
 }
 
+function removeTokenLimitFields(bodyText: string): string | undefined {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(bodyText);
+  } catch {
+    return undefined;
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+
+  const record = payload as Record<string, unknown>;
+  let changed = false;
+  for (const key of ["max_completion_tokens", "max_tokens"]) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      delete record[key];
+      changed = true;
+    }
+  }
+
+  return changed ? JSON.stringify(record) : undefined;
+}
+
+function requestBodyHasLargeTokenLimit(summary: Record<string, unknown> | undefined): boolean {
+  const maxTokens = summary?.maxTokens;
+  return typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 100;
+}
+
+function shouldRetryWithoutTokenLimit(args: {
+  endpoint: AIEndpoint;
+  response: Response;
+  responseText: string;
+  requestBodySummary: Record<string, unknown> | undefined;
+}): boolean {
+  if (args.endpoint.provider !== "custom") return false;
+  if (args.response.status !== 400) return false;
+  if (!requestBodyHasLargeTokenLimit(args.requestBodySummary)) return false;
+  return /超过\s*100|over\s*100|exceed(?:s|ed)?\s*100|greater than\s*100/i.test(args.responseText);
+}
+
+async function readRequestBodyText(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<string | undefined> {
+  if (typeof init?.body === "string") return init.body;
+  if (!isRequestLike(input)) return undefined;
+
+  try {
+    return await input.clone().text();
+  } catch {
+    return undefined;
+  }
+}
+
+function withRequestBodyText(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  bodyText: string,
+): { input: RequestInfo | URL; init?: RequestInit } {
+  const headers = mergeRequestHeaders(input, init) ?? new Headers();
+  headers.delete("content-length");
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+
+  if (init) {
+    return {
+      input,
+      init: {
+        ...init,
+        headers,
+        body: bodyText,
+      },
+    };
+  }
+
+  if (isRequestLike(input)) {
+    return {
+      input: new Request(input, {
+        headers,
+        body: bodyText,
+      }),
+      init,
+    };
+  }
+
+  return {
+    input,
+    init: {
+      method: "POST",
+      headers,
+      body: bodyText,
+    },
+  };
+}
+
 async function getRequestBodySummary(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -325,6 +418,10 @@ export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof g
       requestMethod.toUpperCase() === "POST"
         ? await getRequestBodySummary(requestInput, requestInit)
         : undefined;
+    const requestBodyText =
+      requestMethod.toUpperCase() === "POST"
+        ? await readRequestBodyText(requestInput, requestInit)
+        : undefined;
 
     logAIEndpointDebug("request", endpoint, {
       action: "langchain-chat",
@@ -340,10 +437,11 @@ export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof g
 
       if (!response.ok) {
         let responseBodyPreview = "";
+        let responseText = "";
         let responseLength: number | undefined;
 
         try {
-          const responseText = await response.clone().text();
+          responseText = await response.clone().text();
           responseLength = responseText.length;
           responseBodyPreview = summarizeDebugText(responseText, 600);
         } catch (readError) {
@@ -351,6 +449,45 @@ export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof g
             readError instanceof Error ? readError.message : String(readError),
             200,
           );
+        }
+
+        if (
+          requestBodyText &&
+          shouldRetryWithoutTokenLimit({
+            endpoint,
+            response,
+            responseText,
+            requestBodySummary,
+          })
+        ) {
+          const retryBody = removeTokenLimitFields(requestBodyText);
+          if (retryBody) {
+            const retryRequest = withRequestBodyText(requestInput, requestInit, retryBody);
+            const retryBodySummary = summarizeChatRequestBody(retryBody);
+            logAIEndpointDebug("request", endpoint, {
+              action: "langchain-chat-retry-without-token-limit",
+              method: requestMethod,
+              requestUrl,
+              model,
+              requestBodySummary: retryBodySummary,
+              responseBodyPreview,
+            });
+            const retryResponse = await baseFetch(retryRequest.input, retryRequest.init);
+            const retryContentType = retryResponse.headers.get("content-type");
+            if (retryResponse.ok) {
+              logAIEndpointDebug("response", endpoint, {
+                action: "langchain-chat-retry-without-token-limit",
+                method: requestMethod,
+                requestUrl,
+                model,
+                status: retryResponse.status,
+                statusText: retryResponse.statusText,
+                contentType: retryContentType,
+                requestBodySummary: retryBodySummary,
+              });
+            }
+            return retryResponse;
+          }
         }
 
         logAIEndpointDebug("error", endpoint, {

--- a/packages/core/src/ai/llm-provider.ts
+++ b/packages/core/src/ai/llm-provider.ts
@@ -66,6 +66,99 @@ function sanitizeCustomHeaders(headers?: Headers): Headers | undefined {
   return sanitized;
 }
 
+function countToolSchemaParameters(tools: unknown): number {
+  if (!Array.isArray(tools)) return 0;
+  return tools.reduce((sum, tool) => {
+    if (!tool || typeof tool !== "object") return sum;
+    const fn = (tool as Record<string, unknown>).function;
+    if (!fn || typeof fn !== "object") return sum;
+    const parameters = (fn as Record<string, unknown>).parameters;
+    if (!parameters || typeof parameters !== "object") return sum;
+    const properties = (parameters as Record<string, unknown>).properties;
+    if (!properties || typeof properties !== "object") return sum;
+    return sum + Object.keys(properties).length;
+  }, 0);
+}
+
+function summarizeChatRequestBody(bodyText: string): Record<string, unknown> | undefined {
+  if (!bodyText) return undefined;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(bodyText);
+  } catch {
+    return { bodyLength: bodyText.length, parseable: false };
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return { bodyLength: bodyText.length, parseable: true, type: typeof payload };
+  }
+
+  const record = payload as Record<string, unknown>;
+  const messages = Array.isArray(record.messages) ? record.messages : [];
+  const roles = messages.map((message) =>
+    message && typeof message === "object"
+      ? String((message as Record<string, unknown>).role ?? "")
+      : "",
+  );
+  const assistantToolCallCount = messages.reduce((count, message) => {
+    if (!message || typeof message !== "object") return count;
+    const toolCalls = (message as Record<string, unknown>).tool_calls;
+    return count + (Array.isArray(toolCalls) ? toolCalls.length : 0);
+  }, 0);
+  const tools = Array.isArray(record.tools) ? record.tools : [];
+
+  return {
+    bodyLength: bodyText.length,
+    topLevelKeys: Object.keys(record).sort(),
+    topLevelKeyCount: Object.keys(record).length,
+    model: record.model,
+    stream: record.stream,
+    maxTokens: record.max_tokens ?? record.max_completion_tokens,
+    temperature: record.temperature,
+    toolChoice: record.tool_choice,
+    parallelToolCalls: record.parallel_tool_calls,
+    messages: {
+      count: messages.length,
+      roles,
+      lastRole: roles[roles.length - 1] || "",
+      toolMessages: roles.filter((role) => role === "tool").length,
+      assistantToolCallCount,
+    },
+    tools: {
+      count: tools.length,
+      parameterCount: countToolSchemaParameters(tools),
+      names: tools
+        .map((tool) => {
+          if (!tool || typeof tool !== "object") return "";
+          const fn = (tool as Record<string, unknown>).function;
+          return fn && typeof fn === "object"
+            ? String((fn as Record<string, unknown>).name ?? "")
+            : "";
+        })
+        .filter(Boolean),
+    },
+  };
+}
+
+async function getRequestBodySummary(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Record<string, unknown> | undefined> {
+  if (typeof init?.body === "string") {
+    return summarizeChatRequestBody(init.body);
+  }
+
+  if (!isRequestLike(input)) return undefined;
+  try {
+    return summarizeChatRequestBody(await input.clone().text());
+  } catch (error) {
+    return {
+      bodyReadError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 const GEMINI_THOUGHT_SIGNATURE_BYPASS = "skip_thought_signature_validator";
 
 function shouldPatchGeminiThoughtSignatures(
@@ -228,11 +321,17 @@ export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof g
       }
     }
 
+    const requestBodySummary =
+      requestMethod.toUpperCase() === "POST"
+        ? await getRequestBodySummary(requestInput, requestInit)
+        : undefined;
+
     logAIEndpointDebug("request", endpoint, {
       action: "langchain-chat",
       method: requestMethod,
       requestUrl,
       model,
+      requestBodySummary,
     });
 
     try {
@@ -264,6 +363,7 @@ export function getEndpointFetch(endpoint: AIEndpoint, model?: string): typeof g
           contentType,
           responseLength,
           responseBodyPreview,
+          requestBodySummary,
         });
         return response;
       }

--- a/packages/core/src/ai/llm-provider.ts
+++ b/packages/core/src/ai/llm-provider.ts
@@ -599,7 +599,7 @@ export async function createChatModelFromEndpoint(
   const apiKey = endpoint.apiKey || "local-model";
 
   const temperature = options.temperature ?? 0.7;
-  const maxTokens = options.maxTokens ?? 4096;
+  const maxTokens = options.maxTokens ?? 8192;
   const streaming = options.streaming ?? true;
   const endpointFetch = getEndpointFetch(endpoint, model);
 

--- a/packages/core/src/ai/request-debug.ts
+++ b/packages/core/src/ai/request-debug.ts
@@ -5,6 +5,7 @@ interface AIEndpointDebugExtras {
   method?: string;
   requestUrl?: string;
   model?: string;
+  requestBodySummary?: unknown;
   status?: number;
   statusText?: string;
   contentType?: string | null;
@@ -41,6 +42,7 @@ export function logAIEndpointDebug(
     hasApiKey: Boolean(endpoint.apiKey),
     method: extras.method || "",
     model: extras.model || "",
+    requestBodySummary: extras.requestBodySummary,
     status: extras.status,
     statusText: extras.statusText,
     contentType: extras.contentType,

--- a/packages/core/src/stores/settings-store.ts
+++ b/packages/core/src/stores/settings-store.ts
@@ -80,7 +80,7 @@ const defaultAIConfig: AIConfig = {
   activeEndpointId: "default",
   activeModel: "",
   temperature: 0.7,
-  maxTokens: 4096,
+  maxTokens: 8192,
   slidingWindowSize: 8,
 };
 

--- a/packages/core/src/stores/settings-store.ts
+++ b/packages/core/src/stores/settings-store.ts
@@ -84,6 +84,17 @@ const defaultAIConfig: AIConfig = {
   slidingWindowSize: 8,
 };
 
+function migrateSettingsState(state: SettingsState): SettingsState {
+  if (state.aiConfig.maxTokens !== 4096) return state;
+  return {
+    ...state,
+    aiConfig: {
+      ...state.aiConfig,
+      maxTokens: defaultAIConfig.maxTokens,
+    },
+  };
+}
+
 /**
  * Fetch available models from an AI provider endpoint.
  * Supports OpenAI-compatible (/v1/models), Anthropic, and Google Gemini.
@@ -473,5 +484,5 @@ export const useSettingsStore = create<SettingsState>()(
         translationConfig: defaultTranslationConfig,
         aiConfig: defaultAIConfig,
       }),
-  })),
+  }), undefined, migrateSettingsState),
 );


### PR DESCRIPTION
## Summary
- retry custom OpenAI-compatible chat requests without max token fields when the endpoint rejects large token limits with the confusing 'over 100 parameters' error
- add safe request-body summary diagnostics for AI endpoint requests
- raise the default max tokens from 4096 to 8192
- keep the full AI tool set registered; the earlier tool-filtering experiment has been removed

## Tests
- pnpm --filter @readany/core exec vitest run src/ai/__tests__/llm-provider.test.ts src/ai/__tests__/reading-agent-tools.test.ts src/ai/__tests__/tools.test.ts
- pnpm --filter @readany/core exec tsc --noEmit
- pnpm --filter @readany/app-expo exec tsc --noEmit
- pnpm --filter app exec tsc --noEmit
- git diff --check