### PR TITLE
Fix chat streaming persistence across navigation

### DIFF
--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -112,15 +112,13 @@ export function BookChatScreen({ route, navigation }: Props) {
     setQuotes((prev) => prev.filter((q) => q.id !== id));
   }, []);
 
-  const {
-    threads,
-    loadThreads,
-    getActiveThreadId,
-    setBookActiveThread,
-    createThread,
-    removeThread,
-    getThreadsForContext,
-  } = useChatStore();
+  const threads = useChatStore((s) => s.threads);
+  const loadThreads = useChatStore((s) => s.loadThreads);
+  const getActiveThreadId = useChatStore((s) => s.getActiveThreadId);
+  const setBookActiveThread = useChatStore((s) => s.setBookActiveThread);
+  const createThread = useChatStore((s) => s.createThread);
+  const removeThread = useChatStore((s) => s.removeThread);
+  const getThreadsForContext = useChatStore((s) => s.getThreadsForContext);
 
   useEffect(() => {
     loadThreads(bookId);

--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -132,6 +132,13 @@ export function BookChatScreen({ route, navigation }: Props) {
     [threads, activeThreadId],
   );
   const bookThreads = getThreadsForContext(bookId);
+  const firstBookThreadId = bookThreads[0]?.id;
+  useEffect(() => {
+    if (!activeThreadId && firstBookThreadId) {
+      setBookActiveThread(bookId, firstBookThreadId);
+    }
+  }, [activeThreadId, bookId, firstBookThreadId, setBookActiveThread]);
+
   const groupedThreads = useMemo(() => {
     const grouped = groupThreadsByTime(bookThreads);
     const sections: { key: string; label: string; threads: typeof bookThreads }[] = [
@@ -230,9 +237,10 @@ export function BookChatScreen({ route, navigation }: Props) {
     return convertToMessageV2(activeThread.messages);
   }, [activeThread]);
 
+  const activeCurrentMessage = activeThread?.id === currentMessage?.threadId ? currentMessage : null;
   const allMessages = useMemo(
-    () => mergeMessagesWithStreaming(messagesV2, currentMessage, isStreaming),
-    [currentMessage, isStreaming, messagesV2],
+    () => mergeMessagesWithStreaming(messagesV2, activeCurrentMessage, isStreaming),
+    [activeCurrentMessage, isStreaming, messagesV2],
   );
 
   const handleSend = useCallback(

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -154,15 +154,13 @@ export function ChatScreen() {
   }, [backdropAnim, isTabletLandscape, sidebarAnim, sidebarWidth]);
 
   // Chat store
-  const {
-    threads,
-    generalActiveThreadId,
-    loadAllThreads,
-    removeThread,
-    setGeneralActiveThread,
-    getThreadsForContext,
-    initialized,
-  } = useChatStore();
+  const threads = useChatStore((s) => s.threads);
+  const generalActiveThreadId = useChatStore((s) => s.generalActiveThreadId);
+  const initialized = useChatStore((s) => s.initialized);
+  const loadAllThreads = useChatStore((s) => s.loadAllThreads);
+  const removeThread = useChatStore((s) => s.removeThread);
+  const setGeneralActiveThread = useChatStore((s) => s.setGeneralActiveThread);
+  const getThreadsForContext = useChatStore((s) => s.getThreadsForContext);
 
   useEffect(() => {
     if (!initialized) loadAllThreads();

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -179,8 +179,9 @@ export function ChatScreen() {
     ? threads.find((th) => th.id === generalActiveThreadId)
     : null;
 
+  const activeCurrentMessage = activeThread?.id === currentMessage?.threadId ? currentMessage : null;
   const displayMessages = convertToMessageV2(activeThread?.messages || []);
-  const allMessages = mergeMessagesWithStreaming(displayMessages, currentMessage, isStreaming);
+  const allMessages = mergeMessagesWithStreaming(displayMessages, activeCurrentMessage, isStreaming);
 
   // Handlers
   const handleSend = useCallback(

--- a/packages/app/src/components/chat/ChatPage.tsx
+++ b/packages/app/src/components/chat/ChatPage.tsx
@@ -275,7 +275,8 @@ export function ChatPage() {
   }, []);
 
   const displayMessages = convertToMessageV2(activeThread?.messages || []);
-  const allMessages = mergeMessagesWithStreaming(displayMessages, currentMessage, isStreaming);
+  const activeCurrentMessage = activeThread?.id === currentMessage?.threadId ? currentMessage : null;
+  const allMessages = mergeMessagesWithStreaming(displayMessages, activeCurrentMessage, isStreaming);
 
   const exportTitle = activeThread?.title || t("chat.aiAssistant");
 

--- a/packages/app/src/components/chat/ChatPage.tsx
+++ b/packages/app/src/components/chat/ChatPage.tsx
@@ -52,7 +52,9 @@ function ThreadsSidebar({
   onSelect: (threadId: string) => void;
 }) {
   const { t } = useTranslation();
-  const { getThreadsForContext, getActiveThreadId, removeThread } = useChatStore();
+  const getThreadsForContext = useChatStore((s) => s.getThreadsForContext);
+  const getActiveThreadId = useChatStore((s) => s.getActiveThreadId);
+  const removeThread = useChatStore((s) => s.removeThread);
   const generalThreads = getThreadsForContext();
   const activeThreadId = getActiveThreadId();
 
@@ -204,14 +206,12 @@ function EmptyState({ onSuggestionClick }: { onSuggestionClick: (text: string) =
 
 export function ChatPage() {
   const { t } = useTranslation();
-  const {
-    threads,
-    loadAllThreads,
-    initialized,
-    createThread,
-    setGeneralActiveThread,
-    getActiveThreadId,
-  } = useChatStore();
+  const threads = useChatStore((s) => s.threads);
+  const initialized = useChatStore((s) => s.initialized);
+  const loadAllThreads = useChatStore((s) => s.loadAllThreads);
+  const createThread = useChatStore((s) => s.createThread);
+  const setGeneralActiveThread = useChatStore((s) => s.setGeneralActiveThread);
+  const getActiveThreadId = useChatStore((s) => s.getActiveThreadId);
   const { bookTitle } = useChatReaderStore();
 
   // /chats page should only use general threads - always pass undefined for bookId

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -70,6 +70,13 @@ export function ChatPanel({ book, onNavigateToCitation }: ChatPanelProps) {
   const activeThreadId = bookId ? getActiveThreadId(bookId) : null;
   const activeThread = threads.find((t) => t.id === activeThreadId);
   const bookThreads = bookId ? getThreadsForContext(bookId) : [];
+  const firstBookThreadId = bookThreads[0]?.id;
+
+  useEffect(() => {
+    if (bookId && !activeThreadId && firstBookThreadId) {
+      setBookActiveThread(bookId, firstBookThreadId);
+    }
+  }, [activeThreadId, bookId, firstBookThreadId, setBookActiveThread]);
 
   const [showThreadList, setShowThreadList] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
@@ -196,7 +203,8 @@ export function ChatPanel({ book, onNavigateToCitation }: ChatPanelProps) {
 
   // Build message list with streaming message
   const storeMessages = convertToMessageV2(displayMessages);
-  const allMessages = mergeMessagesWithStreaming(storeMessages, currentMessage, isStreaming);
+  const activeCurrentMessage = activeThread?.id === currentMessage?.threadId ? currentMessage : null;
+  const allMessages = mergeMessagesWithStreaming(storeMessages, activeCurrentMessage, isStreaming);
 
   const exportTitle = activeThread?.title || book?.meta?.title || t("chat.aiAssistant");
 

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -44,15 +44,13 @@ export function ChatPanel({ book, onNavigateToCitation }: ChatPanelProps) {
   const { t } = useTranslation();
   const bookId = book?.id;
 
-  const {
-    threads,
-    loadThreads,
-    createThread,
-    removeThread,
-    setBookActiveThread,
-    getActiveThreadId,
-    getThreadsForContext,
-  } = useChatStore();
+  const threads = useChatStore((s) => s.threads);
+  const loadThreads = useChatStore((s) => s.loadThreads);
+  const createThread = useChatStore((s) => s.createThread);
+  const removeThread = useChatStore((s) => s.removeThread);
+  const setBookActiveThread = useChatStore((s) => s.setBookActiveThread);
+  const getActiveThreadId = useChatStore((s) => s.getActiveThreadId);
+  const getThreadsForContext = useChatStore((s) => s.getThreadsForContext);
 
   // Use streaming chat hook with book context
   const { isStreaming, currentMessage, currentStep, sendMessage, stopStream } = useStreamingChat({

--- a/packages/core/src/hooks/use-streaming-chat.ts
+++ b/packages/core/src/hooks/use-streaming-chat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { maybeCompressThreadMemory } from "../ai/chat-memory";
 import { getBuiltinSkills } from "../ai/skills/builtin-skills";
 import { StreamingChat, createMessageId } from "../ai/streaming";
@@ -10,7 +10,7 @@ import {
 import { getAvailableTools } from "../ai/tools";
 import { getSkills as getDbSkills } from "../db/database";
 import i18n from "../i18n";
-import { useChatStore } from "../stores/chat-store";
+import { getChatStreamingKey, useChatStore } from "../stores/chat-store";
 import { useSettingsStore } from "../stores/settings-store";
 import type {
   AIConfig,
@@ -92,16 +92,31 @@ export interface StreamingState {
   currentStep: "thinking" | "tool_calling" | "responding" | "idle";
 }
 
-export function useStreamingChat(options?: StreamingChatOptions) {
-  const [state, setState] = useState<StreamingState>({
-    isStreaming: false,
-    currentMessage: null,
-    currentStep: "idle",
-  });
-  const [error, setError] = useState<Error | null>(null);
-  const streamingRef = useRef<StreamingChat | null>(null);
+const activeStreams = new Map<string, StreamingChat>();
 
-  const { createThread, addMessage, updateThreadTitle, setStreaming } = useChatStore();
+export function useStreamingChat(options?: StreamingChatOptions) {
+  const streamingKey = getChatStreamingKey(options?.bookId);
+  const streamingSession = useChatStore(
+    useCallback((store) => store.streamingSessions[streamingKey] ?? null, [streamingKey]),
+  );
+  const state: StreamingState = {
+    isStreaming: streamingSession?.isStreaming ?? false,
+    currentMessage: streamingSession?.currentMessage ?? null,
+    currentStep: streamingSession?.currentStep ?? "idle",
+  };
+  const error = useMemo(
+    () => (streamingSession?.errorMessage ? new Error(streamingSession.errorMessage) : null),
+    [streamingSession?.errorMessage],
+  );
+
+  const {
+    createThread,
+    addMessage,
+    updateThreadTitle,
+    startStreamingSession,
+    updateStreamingSession,
+    finishStreamingSession,
+  } = useChatStore();
 
   const aiConfig = useSettingsStore((s) => s.aiConfig);
 
@@ -160,10 +175,18 @@ export function useStreamingChat(options?: StreamingChatOptions) {
       quotes?: AttachedQuote[],
       aiConfigOverride?: AIConfig,
     ) => {
-      if ((!content.trim() && (!quotes || quotes.length === 0)) || state.isStreaming) return;
+      const bookId = overrideBookId ?? options?.bookId;
+      const sessionKey = getChatStreamingKey(bookId);
+      const activeSession = useChatStore.getState().streamingSessions[sessionKey];
+      if (
+        (!content.trim() && (!quotes || quotes.length === 0)) ||
+        activeSession?.isStreaming
+      ) {
+        return;
+      }
 
       const messageId = createMessageId();
-      const initialMessage = {
+      const initialMessage: MessageV2 = {
         id: messageId,
         threadId: "",
         role: "assistant" as const,
@@ -171,11 +194,9 @@ export function useStreamingChat(options?: StreamingChatOptions) {
         createdAt: Date.now(),
       };
 
-      setError(null);
-
       try {
-        const bookId = overrideBookId ?? options?.bookId;
         const thread = await getOrCreateThread(bookId);
+        initialMessage.threadId = thread.id;
 
         if (thread.messages.length === 0 && !thread.title) {
           await updateThreadTitle(thread.id, content.slice(0, 50));
@@ -219,14 +240,20 @@ export function useStreamingChat(options?: StreamingChatOptions) {
         await addMessage(thread.id, userMessage as any);
 
         // Then set streaming state — user message is already visible
-        setState({
+        startStreamingSession({
+          key: sessionKey,
+          threadId: thread.id,
+          bookId: bookId || undefined,
           isStreaming: true,
           currentMessage: initialMessage,
           currentStep: "thinking",
+          errorMessage: null,
+          startedAt: Date.now(),
+          updatedAt: Date.now(),
         });
-        setStreaming(true);
 
-        streamingRef.current = new StreamingChat();
+        const stream = new StreamingChat();
+        activeStreams.set(sessionKey, stream);
 
         const enabledSkills = await loadEnabledSkills();
 
@@ -258,7 +285,20 @@ export function useStreamingChat(options?: StreamingChatOptions) {
         let currentReasoningPart: ReasoningPart | null = null;
         let currentToolCallPart: ToolCallPart | null = null;
         void currentToolCallPart;
-        await streamingRef.current.stream({
+        const publishCurrentMessage = (currentStep?: StreamingState["currentStep"]) => {
+          updateStreamingSession(sessionKey, {
+            isStreaming: true,
+            currentMessage: { ...initialMessage, parts: [...currentParts] },
+            ...(currentStep ? { currentStep } : {}),
+            updatedAt: Date.now(),
+          });
+        };
+        const finishCurrentSession = () => {
+          activeStreams.delete(sessionKey);
+          finishStreamingSession(sessionKey);
+        };
+
+        await stream.stream({
           thread: threadForStream,
           book: options?.book || null,
           bookId,
@@ -277,13 +317,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             currentTextPart.text += token;
             currentTextPart.status = "running";
             currentTextPart.updatedAt = Date.now();
-            setState((prev) => ({
-              ...prev,
-              currentMessage: prev.currentMessage
-                ? { ...prev.currentMessage, parts: [...currentParts] }
-                : null,
-              currentStep: "responding",
-            }));
+            publishCurrentMessage("responding");
           },
           onComplete: async () => {
             if (currentTextPart) {
@@ -328,18 +362,21 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             // This prevents the gap where message disappears
             // Set currentStep to "idle" before addMessage to prevent
             // the "thinking" indicator from briefly flashing during persist
-            setState((prev) => ({ ...prev, currentStep: "idle" }));
-            await addMessage(thread.id, assistantMessage as any);
-
-            setState({
-              isStreaming: false,
-              currentMessage: null,
+            updateStreamingSession(sessionKey, {
+              isStreaming: true,
+              currentMessage: { ...initialMessage, parts: [...currentParts] },
               currentStep: "idle",
+              updatedAt: Date.now(),
             });
-            setStreaming(false);
+            await addMessage(thread.id, assistantMessage as any);
+            finishCurrentSession();
           },
           onError: async (err) => {
-            setError(err);
+            updateStreamingSession(sessionKey, {
+              isStreaming: true,
+              errorMessage: err.message,
+              updatedAt: Date.now(),
+            });
             markRunningToolCallPartsAsError(currentParts, err.message || "Unknown error");
 
             const errorPart = createTextPart(`⚠️ ${err.message || "Unknown error"}`);
@@ -375,15 +412,14 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             };
 
             // Persist error message FIRST, then clear streaming state
-            setState((prev) => ({ ...prev, currentStep: "idle" }));
-            await addMessage(thread.id, errorMessage as any);
-
-            setState({
-              isStreaming: false,
-              currentMessage: null,
+            updateStreamingSession(sessionKey, {
+              isStreaming: true,
+              currentMessage: { ...initialMessage, parts: [...currentParts] },
               currentStep: "idle",
+              updatedAt: Date.now(),
             });
-            setStreaming(false);
+            await addMessage(thread.id, errorMessage as any);
+            finishCurrentSession();
           },
           onAbort: async () => {
             for (const part of currentParts) {
@@ -431,15 +467,14 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               createdAt: Date.now(),
             };
 
-            setState((prev) => ({ ...prev, currentStep: "idle" }));
-            await addMessage(thread.id, abortedMessage as any);
-
-            setState({
-              isStreaming: false,
-              currentMessage: null,
+            updateStreamingSession(sessionKey, {
+              isStreaming: true,
+              currentMessage: { ...initialMessage, parts: [...currentParts] },
               currentStep: "idle",
+              updatedAt: Date.now(),
             });
-            setStreaming(false);
+            await addMessage(thread.id, abortedMessage as any);
+            finishCurrentSession();
           },
           onToolCall: (name, args) => {
             if (currentTextPart) {
@@ -454,13 +489,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             currentReasoningPart = null;
             currentToolCallPart = createToolCallPart(name, args);
             currentParts.push(currentToolCallPart);
-            setState((prev) => ({
-              ...prev,
-              currentMessage: prev.currentMessage
-                ? { ...prev.currentMessage, parts: [...currentParts] }
-                : null,
-              currentStep: "tool_calling",
-            }));
+            publishCurrentMessage("tool_calling");
           },
           onToolResult: (name, result) => {
             const part = applyToolResultToParts(currentParts, name, result);
@@ -471,12 +500,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               }
 
               currentTextPart = null;
-              setState((prev) => ({
-                ...prev,
-                currentMessage: prev.currentMessage
-                  ? { ...prev.currentMessage, parts: [...currentParts] }
-                  : null,
-              }));
+              publishCurrentMessage();
             }
           },
           onReasoning: (content, type) => {
@@ -487,13 +511,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             currentReasoningPart.text += content;
             currentReasoningPart.status = "running";
             currentReasoningPart.updatedAt = Date.now();
-            setState((prev) => ({
-              ...prev,
-              currentMessage: prev.currentMessage
-                ? { ...prev.currentMessage, parts: [...currentParts] }
-                : null,
-              currentStep: "thinking",
-            }));
+            publishCurrentMessage("thinking");
           },
           onCitation: (citation) => {
             const citationPart = createCitationPart(
@@ -505,30 +523,28 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               citation.citationIndex,
             );
             currentParts.push(citationPart);
-            setState((prev) => ({
-              ...prev,
-              currentMessage: prev.currentMessage
-                ? { ...prev.currentMessage, parts: [...currentParts] }
-                : null,
-            }));
+            publishCurrentMessage();
           },
         });
       } catch (err) {
-        setError(err instanceof Error ? err : new Error("Unknown error"));
-        setState({
+        const errorMessage = err instanceof Error ? err.message : "Unknown error";
+        updateStreamingSession(sessionKey, {
           isStreaming: false,
           currentMessage: null,
           currentStep: "idle",
+          errorMessage,
+          updatedAt: Date.now(),
         });
-        setStreaming(false);
+        activeStreams.delete(sessionKey);
       }
     },
     [
-      state.isStreaming,
       getOrCreateThread,
       addMessage,
       updateThreadTitle,
-      setStreaming,
+      startStreamingSession,
+      updateStreamingSession,
+      finishStreamingSession,
       aiConfig,
       loadEnabledSkills,
       options?.book,
@@ -538,11 +554,8 @@ export function useStreamingChat(options?: StreamingChatOptions) {
   );
 
   const stopStream = useCallback(() => {
-    streamingRef.current?.abort();
-    // Immediately update UI state
-    setState((prev) => ({ ...prev, isStreaming: false }));
-    setStreaming(false);
-  }, [setStreaming]);
+    activeStreams.get(streamingKey)?.abort();
+  }, [streamingKey]);
 
   return {
     ...state,

--- a/packages/core/src/hooks/use-streaming-chat.ts
+++ b/packages/core/src/hooks/use-streaming-chat.ts
@@ -93,6 +93,7 @@ export interface StreamingState {
 }
 
 const activeStreams = new Map<string, StreamingChat>();
+const STREAMING_PUBLISH_INTERVAL_MS = 160;
 
 export function useStreamingChat(options?: StreamingChatOptions) {
   const streamingKey = getChatStreamingKey(options?.bookId);
@@ -109,14 +110,12 @@ export function useStreamingChat(options?: StreamingChatOptions) {
     [streamingSession?.errorMessage],
   );
 
-  const {
-    createThread,
-    addMessage,
-    updateThreadTitle,
-    startStreamingSession,
-    updateStreamingSession,
-    finishStreamingSession,
-  } = useChatStore();
+  const createThread = useChatStore((s) => s.createThread);
+  const addMessage = useChatStore((s) => s.addMessage);
+  const updateThreadTitle = useChatStore((s) => s.updateThreadTitle);
+  const startStreamingSession = useChatStore((s) => s.startStreamingSession);
+  const updateStreamingSession = useChatStore((s) => s.updateStreamingSession);
+  const finishStreamingSession = useChatStore((s) => s.finishStreamingSession);
 
   const aiConfig = useSettingsStore((s) => s.aiConfig);
 
@@ -193,6 +192,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
         parts: [],
         createdAt: Date.now(),
       };
+      let clearPendingPublish: (() => void) | null = null;
 
       try {
         const thread = await getOrCreateThread(bookId);
@@ -284,16 +284,52 @@ export function useStreamingChat(options?: StreamingChatOptions) {
         let currentTextPart: TextPart | null = null;
         let currentReasoningPart: ReasoningPart | null = null;
         let currentToolCallPart: ToolCallPart | null = null;
+        let pendingPublishTimer: ReturnType<typeof setTimeout> | null = null;
+        let pendingCurrentStep: StreamingState["currentStep"] | undefined;
+        let lastPublishedAt = 0;
         void currentToolCallPart;
+
+        clearPendingPublish = () => {
+          if (pendingPublishTimer) {
+            clearTimeout(pendingPublishTimer);
+            pendingPublishTimer = null;
+          }
+        };
+
         const publishCurrentMessage = (currentStep?: StreamingState["currentStep"]) => {
+          lastPublishedAt = Date.now();
+          pendingCurrentStep = undefined;
           updateStreamingSession(sessionKey, {
             isStreaming: true,
             currentMessage: { ...initialMessage, parts: [...currentParts] },
             ...(currentStep ? { currentStep } : {}),
-            updatedAt: Date.now(),
+            updatedAt: lastPublishedAt,
           });
         };
+
+        const flushCurrentMessage = (currentStep?: StreamingState["currentStep"]) => {
+          clearPendingPublish?.();
+          publishCurrentMessage(currentStep ?? pendingCurrentStep);
+        };
+
+        const scheduleCurrentMessage = (currentStep?: StreamingState["currentStep"]) => {
+          if (currentStep) {
+            pendingCurrentStep = currentStep;
+          }
+
+          const now = Date.now();
+          const elapsed = now - lastPublishedAt;
+
+          if (!pendingPublishTimer) {
+            pendingPublishTimer = setTimeout(() => {
+              pendingPublishTimer = null;
+              publishCurrentMessage(pendingCurrentStep);
+            }, lastPublishedAt === 0 ? 0 : Math.max(STREAMING_PUBLISH_INTERVAL_MS - elapsed, 0));
+          }
+        };
+
         const finishCurrentSession = () => {
+          clearPendingPublish?.();
           activeStreams.delete(sessionKey);
           finishStreamingSession(sessionKey);
         };
@@ -317,7 +353,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             currentTextPart.text += token;
             currentTextPart.status = "running";
             currentTextPart.updatedAt = Date.now();
-            publishCurrentMessage("responding");
+            scheduleCurrentMessage("responding");
           },
           onComplete: async () => {
             if (currentTextPart) {
@@ -362,16 +398,12 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             // This prevents the gap where message disappears
             // Set currentStep to "idle" before addMessage to prevent
             // the "thinking" indicator from briefly flashing during persist
-            updateStreamingSession(sessionKey, {
-              isStreaming: true,
-              currentMessage: { ...initialMessage, parts: [...currentParts] },
-              currentStep: "idle",
-              updatedAt: Date.now(),
-            });
+            flushCurrentMessage("idle");
             await addMessage(thread.id, assistantMessage as any);
             finishCurrentSession();
           },
           onError: async (err) => {
+            flushCurrentMessage();
             updateStreamingSession(sessionKey, {
               isStreaming: true,
               errorMessage: err.message,
@@ -412,12 +444,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             };
 
             // Persist error message FIRST, then clear streaming state
-            updateStreamingSession(sessionKey, {
-              isStreaming: true,
-              currentMessage: { ...initialMessage, parts: [...currentParts] },
-              currentStep: "idle",
-              updatedAt: Date.now(),
-            });
+            flushCurrentMessage("idle");
             await addMessage(thread.id, errorMessage as any);
             finishCurrentSession();
           },
@@ -467,12 +494,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               createdAt: Date.now(),
             };
 
-            updateStreamingSession(sessionKey, {
-              isStreaming: true,
-              currentMessage: { ...initialMessage, parts: [...currentParts] },
-              currentStep: "idle",
-              updatedAt: Date.now(),
-            });
+            flushCurrentMessage("idle");
             await addMessage(thread.id, abortedMessage as any);
             finishCurrentSession();
           },
@@ -489,7 +511,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             currentReasoningPart = null;
             currentToolCallPart = createToolCallPart(name, args);
             currentParts.push(currentToolCallPart);
-            publishCurrentMessage("tool_calling");
+            flushCurrentMessage("tool_calling");
           },
           onToolResult: (name, result) => {
             const part = applyToolResultToParts(currentParts, name, result);
@@ -500,7 +522,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               }
 
               currentTextPart = null;
-              publishCurrentMessage();
+              flushCurrentMessage();
             }
           },
           onReasoning: (content, type) => {
@@ -511,7 +533,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
             currentReasoningPart.text += content;
             currentReasoningPart.status = "running";
             currentReasoningPart.updatedAt = Date.now();
-            publishCurrentMessage("thinking");
+            scheduleCurrentMessage("thinking");
           },
           onCitation: (citation) => {
             const citationPart = createCitationPart(
@@ -523,10 +545,11 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               citation.citationIndex,
             );
             currentParts.push(citationPart);
-            publishCurrentMessage();
+            flushCurrentMessage();
           },
         });
       } catch (err) {
+        clearPendingPublish?.();
         const errorMessage = err instanceof Error ? err.message : "Unknown error";
         updateStreamingSession(sessionKey, {
           isStreaming: false,

--- a/packages/core/src/stores/chat-store.test.ts
+++ b/packages/core/src/stores/chat-store.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  deleteThread: vi.fn(),
+  getThreads: vi.fn(),
+  insertMessage: vi.fn(),
+  insertThread: vi.fn(),
+  updateThreadTitle: vi.fn(),
+}));
+
+vi.mock("../db/database", () => dbMocks);
+
+const { getChatStreamingKey, useChatStore } = await import("./chat-store");
+
+function resetChatStore() {
+  useChatStore.setState({
+    threads: [],
+    generalActiveThreadId: null,
+    bookActiveThreadIds: {},
+    isStreaming: false,
+    streamingContent: "",
+    streamingSessions: {},
+    toolCalls: [],
+    reasoning: [],
+    currentStep: "idle",
+    semanticContext: null,
+    initialized: false,
+  });
+}
+
+describe("useChatStore streaming sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChatStore();
+  });
+
+  it("stores and updates a book-scoped streaming message", () => {
+    const key = getChatStreamingKey("book-1");
+    const message = {
+      id: "msg-1",
+      threadId: "thread-1",
+      role: "assistant" as const,
+      parts: [],
+      createdAt: 100,
+    };
+
+    useChatStore.getState().startStreamingSession({
+      key,
+      threadId: "thread-1",
+      bookId: "book-1",
+      isStreaming: true,
+      currentMessage: message,
+      currentStep: "thinking",
+      errorMessage: null,
+      startedAt: 100,
+      updatedAt: 100,
+    });
+
+    expect(useChatStore.getState().streamingSessions[key]?.currentMessage).toBe(message);
+    expect(useChatStore.getState().isStreaming).toBe(true);
+
+    const updatedMessage = {
+      ...message,
+      parts: [
+        {
+          id: "text-1",
+          type: "text" as const,
+          text: "hello",
+          status: "running" as const,
+          createdAt: 101,
+        },
+      ],
+    };
+    useChatStore.getState().updateStreamingSession(key, {
+      currentMessage: updatedMessage,
+      currentStep: "responding",
+    });
+
+    expect(useChatStore.getState().streamingSessions[key]?.currentMessage).toBe(updatedMessage);
+    expect(useChatStore.getState().streamingSessions[key]?.currentStep).toBe("responding");
+
+    useChatStore.getState().finishStreamingSession(key);
+
+    expect(useChatStore.getState().streamingSessions[key]).toBeUndefined();
+    expect(useChatStore.getState().isStreaming).toBe(false);
+    expect(useChatStore.getState().currentStep).toBe("idle");
+  });
+
+  it("keeps global streaming true while another session is active", () => {
+    const generalKey = getChatStreamingKey();
+    const bookKey = getChatStreamingKey("book-1");
+    const baseSession = {
+      threadId: "thread-1",
+      isStreaming: true,
+      currentMessage: null,
+      currentStep: "thinking" as const,
+      startedAt: 100,
+      updatedAt: 100,
+    };
+
+    useChatStore.getState().startStreamingSession({ ...baseSession, key: generalKey });
+    useChatStore
+      .getState()
+      .startStreamingSession({ ...baseSession, key: bookKey, bookId: "book-1" });
+
+    useChatStore.getState().finishStreamingSession(generalKey);
+
+    expect(useChatStore.getState().isStreaming).toBe(true);
+    expect(useChatStore.getState().streamingSessions[bookKey]).toBeDefined();
+  });
+});

--- a/packages/core/src/stores/chat-store.ts
+++ b/packages/core/src/stores/chat-store.ts
@@ -15,7 +15,25 @@ import {
  * - Each book has its own active thread; general chat has its own.
  * - All threads are persisted to SQLite via core db module
  */
-import type { Message, ReasoningStep, SemanticContext, Thread, ToolCall } from "../types";
+import type { Message, MessageV2, ReasoningStep, SemanticContext, Thread, ToolCall } from "../types";
+
+export type ChatStreamingStep = "thinking" | "tool_calling" | "responding" | "idle";
+
+export interface ChatStreamingSession {
+  key: string;
+  threadId: string;
+  bookId?: string;
+  isStreaming: boolean;
+  currentMessage: MessageV2 | null;
+  currentStep: ChatStreamingStep;
+  errorMessage?: string | null;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export function getChatStreamingKey(bookId?: string | null): string {
+  return bookId ? `book:${bookId}` : "general";
+}
 
 export interface ChatState {
   threads: Thread[];
@@ -23,9 +41,10 @@ export interface ChatState {
   bookActiveThreadIds: Record<string, string>;
   isStreaming: boolean;
   streamingContent: string;
+  streamingSessions: Record<string, ChatStreamingSession>;
   toolCalls: ToolCall[];
   reasoning: ReasoningStep[];
-  currentStep: "thinking" | "tool_calling" | "responding" | "idle";
+  currentStep: ChatStreamingStep;
   semanticContext: SemanticContext | null;
   initialized: boolean;
 
@@ -41,6 +60,17 @@ export interface ChatState {
   updateMessage: (threadId: string, messageId: string, content: string) => void;
   updateThreadTitle: (threadId: string, title: string) => Promise<void>;
   setStreaming: (streaming: boolean) => void;
+  startStreamingSession: (session: ChatStreamingSession) => void;
+  updateStreamingSession: (
+    key: string,
+    update: Partial<
+      Pick<
+        ChatStreamingSession,
+        "isStreaming" | "currentMessage" | "currentStep" | "errorMessage" | "updatedAt"
+      >
+    >,
+  ) => void;
+  finishStreamingSession: (key: string) => void;
   setStreamingContent: (content: string) => void;
   appendStreamingContent: (chunk: string) => void;
   setToolCalls: (toolCalls: ToolCall[]) => void;
@@ -48,7 +78,7 @@ export interface ChatState {
   updateToolCall: (id: string, update: Partial<ToolCall>) => void;
   setReasoning: (reasoning: ReasoningStep[]) => void;
   addReasoningStep: (step: ReasoningStep) => void;
-  setCurrentStep: (step: "thinking" | "tool_calling" | "responding" | "idle") => void;
+  setCurrentStep: (step: ChatStreamingStep) => void;
   setSemanticContext: (ctx: SemanticContext | null) => void;
   resetStreamingState: () => void;
 }
@@ -59,6 +89,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   bookActiveThreadIds: {},
   isStreaming: false,
   streamingContent: "",
+  streamingSessions: {},
   toolCalls: [],
   reasoning: [],
   currentStep: "idle",
@@ -224,6 +255,47 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   setStreaming: (streaming) => set({ isStreaming: streaming }),
+  startStreamingSession: (session) =>
+    set((state) => ({
+      isStreaming: true,
+      currentStep: session.currentStep,
+      streamingSessions: {
+        ...state.streamingSessions,
+        [session.key]: session,
+      },
+    })),
+  updateStreamingSession: (key, update) =>
+    set((state) => {
+      const existing = state.streamingSessions[key];
+      if (!existing) return {};
+
+      const nextSession = {
+        ...existing,
+        ...update,
+        updatedAt: update.updatedAt ?? Date.now(),
+      };
+      const sessions = {
+        ...state.streamingSessions,
+        [key]: nextSession,
+      };
+      const anyStreaming = Object.values(sessions).some((session) => session.isStreaming);
+
+      return {
+        isStreaming: anyStreaming,
+        currentStep: nextSession.currentStep,
+        streamingSessions: sessions,
+      };
+    }),
+  finishStreamingSession: (key) =>
+    set((state) => {
+      const { [key]: _finished, ...sessions } = state.streamingSessions;
+      const activeSessions = Object.values(sessions).filter((session) => session.isStreaming);
+      return {
+        isStreaming: activeSessions.length > 0,
+        currentStep: activeSessions[0]?.currentStep ?? "idle",
+        streamingSessions: sessions,
+      };
+    }),
   setStreamingContent: (content) => set({ streamingContent: content }),
   appendStreamingContent: (chunk) =>
     set((state) => ({ streamingContent: state.streamingContent + chunk })),
@@ -246,6 +318,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({
       isStreaming: false,
       streamingContent: "",
+      streamingSessions: {},
       toolCalls: [],
       reasoning: [],
       currentStep: "idle",


### PR DESCRIPTION
## Summary
- Persist in-progress streaming chat sessions in the shared chat store so answers survive chat screen unmount/remount
- Reconnect mobile and desktop chat surfaces to the active streaming session and only render streaming messages in their owning thread
- Restore the latest book chat thread when book-scoped chat opens without an active thread
- Add chat store tests for streaming session lifecycle

## Validation
- git diff --check
- PATH="/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.codex/tmp/arg0/codex-arg0szTZEi:/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/bealqiu/.antigravity/antigravity/bin:/Users/bealqiu/.codebuddy/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/Library/pnpm:/Users/bealqiu/.rd/bin:/Users/bealqiu/.codeium/windsurf/bin:/Users/bealqiu/.nvm/versions/node/v14.21.3/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/opt/podman/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.cargo/bin:/Applications/Codex.app/Contents/Resources" pnpm --filter @readany/core exec vitest run src/stores/chat-store.test.ts src/utils/chat-utils.test.ts

## Notes
- Full tsc still fails on existing missing dependencies/types unrelated to this change: @smithy/*, @zip.js/zip.js, base64-js, and the existing app auto-metadata ArrayBuffer type issue.