### PR TITLE
fix: stabilize reader AI tool calls

### DIFF
--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -616,6 +616,9 @@ describe("streamReadingAgent tool registration", () => {
     expect(first.totalResults).toBe(1);
     expect(second.totalResults).toBe(1);
     expect(third.totalResults).toBe(1);
+    expect(third.repeatedToolCall).toBe(true);
+    expect(third.stopToolCalls).toBe(true);
+    expect(third.instruction).toContain("Stop calling tools now");
     expect(searchCalls).toEqual(["主角是谁"]);
   });
 });

--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -455,7 +455,7 @@ describe("streamReadingAgent tool registration", () => {
     expect(fourth.attemptedQueries).toEqual(["张三疯那一章讲了什么", "张三疯", "张三疯"]);
   });
 
-  it("routes current-page questions to current-context tools only", async () => {
+  it("keeps RAG fallback available for current-page questions on indexed books", async () => {
     let capturedTools: any[] = [];
     createReactAgentMock.mockImplementation((config) => {
       capturedTools = config.tools;
@@ -487,8 +487,10 @@ describe("streamReadingAgent tool registration", () => {
     expect(toolNames).toContain("getCurrentChapter");
     expect(toolNames).toContain("getSurroundingContext");
     expect(toolNames).toContain("getReadingProgress");
-    expect(toolNames).not.toContain("ragSearch");
+    expect(toolNames).toContain("ragSearch");
+    expect(toolNames).toContain("ragContext");
     expect(toolNames).not.toContain("resolveChapterReference");
+    expect(toolNames.indexOf("getSurroundingContext")).toBeLessThan(toolNames.indexOf("ragSearch"));
   });
 
   it("does not misroute generic analysis requests into current-page-only tools", async () => {
@@ -524,6 +526,45 @@ describe("streamReadingAgent tool registration", () => {
     expect(toolNames).toContain("ragContext");
     expect(toolNames).toContain("summarize");
     expect(toolNames).toContain("getCurrentChapter");
+    expect(toolNames.indexOf("ragSearch")).toBeLessThan(toolNames.indexOf("getCurrentChapter"));
+  });
+
+  it("keeps indexed search and toc fallbacks for specific chapter requests", async () => {
+    let capturedTools: any[] = [];
+    createReactAgentMock.mockImplementation((config) => {
+      capturedTools = config.tools;
+      return {
+        streamEvents: vi.fn(() => ({
+          [Symbol.asyncIterator]: async function* () {
+            // no-op stream
+          },
+        })),
+      };
+    });
+
+    for await (const event of streamReadingAgent(
+      {
+        aiConfig: makeAIConfig(),
+        book: null,
+        bookId: "book-1",
+        semanticContext: null,
+        enabledSkills: [],
+        isVectorized: true,
+        getAvailableTools,
+      },
+      "第十二章里主角为什么离开",
+    )) {
+      void event;
+    }
+
+    const toolNames = capturedTools.map((tool) => tool.name);
+    expect(toolNames).toContain("resolveChapterReference");
+    expect(toolNames).toContain("ragSearch");
+    expect(toolNames).toContain("ragToc");
+    expect(toolNames).toContain("ragContext");
+    expect(toolNames.indexOf("resolveChapterReference")).toBeLessThan(
+      toolNames.indexOf("ragSearch"),
+    );
   });
 
   it("routes library requests away from book-content tools", async () => {

--- a/packages/core/src/ai/__tests__/system-prompt.test.ts
+++ b/packages/core/src/ai/__tests__/system-prompt.test.ts
@@ -92,4 +92,22 @@ describe("buildSystemPrompt citations", () => {
     expect(prompt).toContain("- getSurroundingContext");
     expect(prompt).toContain("- addCitation");
   });
+
+  it("does not describe tools that are unavailable in the current turn", () => {
+    const prompt = buildSystemPrompt({
+      book: makeBook(),
+      semanticContext: null,
+      enabledSkills: [],
+      isVectorized: true,
+      userLanguage: "en",
+      allowedToolNames: ["getCurrentChapter", "addCitation"],
+    });
+
+    expect(prompt).toContain("- getCurrentChapter");
+    expect(prompt).toContain("- addCitation");
+    expect(prompt).not.toContain("- getReadingProgress");
+    expect(prompt).not.toContain("Get overall reading progress");
+    expect(prompt).not.toContain("- ragSearch");
+    expect(prompt).not.toContain("Semantic/keyword search across book content");
+  });
 });

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -76,6 +76,89 @@ const GENERAL_TOOL_NAMES = new Set([
   "manageBookGroups",
 ]);
 
+const CATEGORY_TOOL_ORDER: Record<ReadingQuestionCategory, string[]> = {
+  general_chat: [],
+  library_request: [
+    "listBooks",
+    "searchAllHighlights",
+    "searchAllNotes",
+    "getReadingStats",
+    "getSkills",
+    "mindmap",
+    "classifyBooks",
+    "tagBooks",
+    "manageBookTags",
+    "updateBookMetadata",
+    "manageBookGroups",
+  ],
+  current_selection: [
+    "getSelection",
+    "getSurroundingContext",
+    "getCurrentChapter",
+    "ragSearch",
+    "ragContext",
+    "fallbackSearch",
+    "fallbackChapterContext",
+    "addCitation",
+  ],
+  current_page_context: [
+    "getSurroundingContext",
+    "getCurrentChapter",
+    "getReadingProgress",
+    "ragSearch",
+    "ragContext",
+    "fallbackSearch",
+    "fallbackChapterContext",
+    "addCitation",
+  ],
+  current_chapter_context: [
+    "getCurrentChapter",
+    "getSurroundingContext",
+    "resolveChapterReference",
+    "ragSearch",
+    "ragContext",
+    "summarize",
+    "findQuotes",
+    "fallbackChapterContext",
+    "fallbackSearch",
+    "addCitation",
+  ],
+  specific_chapter_request: [
+    "resolveChapterReference",
+    "ragSearch",
+    "ragToc",
+    "ragContext",
+    "summarize",
+    "findQuotes",
+    "extractEntities",
+    "analyzeArguments",
+    "fallbackToc",
+    "fallbackSearch",
+    "fallbackChapterContext",
+    "addCitation",
+  ],
+  book_wide_search: [
+    "ragSearch",
+    "resolveChapterReference",
+    "ragToc",
+    "ragContext",
+    "summarize",
+    "findQuotes",
+    "extractEntities",
+    "analyzeArguments",
+    "compareSections",
+    "fallbackSearch",
+    "fallbackToc",
+    "fallbackChapterContext",
+    "getCurrentChapter",
+    "getSurroundingContext",
+    "getReadingProgress",
+    "getRecentHighlights",
+    "getAnnotations",
+    "addCitation",
+  ],
+};
+
 type ReadingQuestionCategory =
   | "general_chat"
   | "library_request"
@@ -156,18 +239,58 @@ function getFocusedToolNames(
     case "library_request":
       return GENERAL_TOOL_NAMES;
     case "current_selection":
-      return new Set(["getSelection", "getSurroundingContext", "getCurrentChapter", "addCitation"]);
+      return new Set(
+        isVectorized
+          ? [
+              "getSelection",
+              "getSurroundingContext",
+              "getCurrentChapter",
+              "ragSearch",
+              "ragContext",
+              "addCitation",
+            ]
+          : [
+              "getSelection",
+              "getSurroundingContext",
+              "getCurrentChapter",
+              "fallbackSearch",
+              "fallbackChapterContext",
+              "addCitation",
+            ],
+      );
     case "current_page_context":
-      return new Set([
-        "getCurrentChapter",
-        "getSurroundingContext",
-        "getReadingProgress",
-        "addCitation",
-      ]);
+      return new Set(
+        isVectorized
+          ? [
+              "getCurrentChapter",
+              "getSurroundingContext",
+              "getReadingProgress",
+              "ragSearch",
+              "ragContext",
+              "addCitation",
+            ]
+          : [
+              "getCurrentChapter",
+              "getSurroundingContext",
+              "getReadingProgress",
+              "fallbackSearch",
+              "fallbackChapterContext",
+              "addCitation",
+            ],
+      );
     case "current_chapter_context":
       return new Set(
         isVectorized
-          ? ["getCurrentChapter", "getSurroundingContext", "ragContext", "summarize", "addCitation"]
+          ? [
+              "getCurrentChapter",
+              "getSurroundingContext",
+              "resolveChapterReference",
+              "ragSearch",
+              "ragContext",
+              "summarize",
+              "findQuotes",
+              "addCitation",
+            ]
           : ["getCurrentChapter", "getSurroundingContext", "fallbackChapterContext", "addCitation"],
       );
     case "specific_chapter_request":
@@ -175,6 +298,8 @@ function getFocusedToolNames(
         isVectorized
           ? [
               "resolveChapterReference",
+              "ragSearch",
+              "ragToc",
               "ragContext",
               "summarize",
               "findQuotes",
@@ -189,6 +314,22 @@ function getFocusedToolNames(
   }
 }
 
+function sortToolsForCategory(
+  tools: ToolDefinition[],
+  category: ReadingQuestionCategory,
+): ToolDefinition[] {
+  const order = CATEGORY_TOOL_ORDER[category];
+  if (order.length === 0) return tools;
+
+  const priority = new Map(order.map((name, index) => [name, index]));
+  return [...tools].sort((a, b) => {
+    const aPriority = priority.get(a.name) ?? Number.MAX_SAFE_INTEGER;
+    const bPriority = priority.get(b.name) ?? Number.MAX_SAFE_INTEGER;
+    if (aPriority !== bPriority) return aPriority - bPriority;
+    return 0;
+  });
+}
+
 function filterToolsForQuestion(options: {
   tools: ToolDefinition[];
   category: ReadingQuestionCategory;
@@ -196,30 +337,42 @@ function filterToolsForQuestion(options: {
 }): ToolDefinition[] {
   const focusedNames = getFocusedToolNames(options.category, options.isVectorized);
   if (focusedNames === null) {
-    return options.tools.filter((tool) => !GENERAL_TOOL_NAMES.has(tool.name));
+    return sortToolsForCategory(
+      options.tools.filter((tool) => !GENERAL_TOOL_NAMES.has(tool.name)),
+      options.category,
+    );
   }
 
   const filtered = options.tools.filter((tool) => focusedNames.has(tool.name));
-  return filtered;
+  return sortToolsForCategory(filtered, options.category);
 }
 
 function buildRouteHint(
   category: ReadingQuestionCategory,
   selectionActive: boolean,
+  isVectorized: boolean,
 ): string | undefined {
   switch (category) {
     case "current_selection":
       return selectionActive
-        ? "The user already has an active selection. Prefer the selected text and surrounding context before any chapter-wide or book-wide retrieval."
+        ? "The user already has an active selection. Start with the selected text and surrounding context; if that is not enough, use content retrieval instead of guessing."
         : undefined;
     case "current_page_context":
-      return "This question is about the user's current page or current reading location. Prefer current-context tools before any wider retrieval.";
+      return isVectorized
+        ? "This question is about the user's current page or current reading location. Start with current-context tools; use ragSearch/ragContext when visible text is insufficient."
+        : "This question is about the user's current page or current reading location. Start with current-context tools; use fallback content tools when visible text is insufficient.";
     case "current_chapter_context":
-      return "This question is about the chapter the user is currently reading. Get the current chapter first, then use chapter context tools.";
+      return isVectorized
+        ? "This question is about the chapter the user is currently reading. Get the current chapter first, then prefer indexed chapter/content retrieval."
+        : "This question is about the chapter the user is currently reading. Get the current chapter first, then use fallback chapter content.";
     case "specific_chapter_request":
-      return "This question targets a specific chapter reference. Resolve the chapter reference first, then read that chapter. Do not start with full-book search.";
+      return isVectorized
+        ? "This question targets a specific chapter reference. Resolve the chapter reference first; if resolution is weak or the user asks for content, use ragSearch/ragToc/ragContext instead of guessing."
+        : "This question targets a specific chapter reference. Resolve the chapter reference first; if resolution is weak, use fallbackToc/fallbackSearch or ask for clarification.";
     case "book_wide_search":
-      return "This question may require broader retrieval. Use book-wide search only when current-context tools are insufficient.";
+      return isVectorized
+        ? "This is a book-content question and the book is indexed. Prefer ragSearch first for retrieval; use current-context tools only when the question is explicitly about the current page."
+        : "This is a book-content question and the book is not indexed. Prefer fallbackSearch/fallbackToc for retrieval.";
     case "library_request":
       return "This is a library-management or cross-book request. Stay within library tools.";
     default:
@@ -596,7 +749,7 @@ export async function* streamReadingAgent(
       memorySummary,
       questionCategory,
       selectionActive,
-      routeHint: buildRouteHint(questionCategory, selectionActive),
+      routeHint: buildRouteHint(questionCategory, selectionActive, isVectorized),
       allowedToolNames: tools.map((tool) => tool.name),
     });
 

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -27,6 +27,8 @@ const CHAPTER_TOOL_EXECUTION_LIMIT = 8;
 const DEFAULT_RECURSION_LIMIT = 24;
 const CHAPTER_TASK_RECURSION_LIMIT = 24;
 const DEFAULT_TOOL_TIMEOUT_MS = 45_000;
+const TOOL_EXECUTION_LIMIT = 12;
+const REPEATED_TOOL_CALL_LIMIT = 2;
 
 const CHAPTER_LOOKUP_STOP_TOOL_NAMES = new Set([
   "resolveChapterReference",
@@ -305,6 +307,32 @@ function buildChapterReferenceLimitResult(
   };
 }
 
+function buildRepeatedToolCallResult(
+  lastResult: unknown,
+  toolName: string,
+  reason: "duplicate" | "limit",
+): Record<string, unknown> {
+  const base =
+    lastResult && typeof lastResult === "object" && !Array.isArray(lastResult)
+      ? (lastResult as Record<string, unknown>)
+      : lastResult === undefined
+        ? {}
+        : { previousResult: lastResult };
+  return {
+    ...base,
+    ...(toolName === "addCitation" ? { type: "notice" } : {}),
+    repeatedToolCall: true,
+    toolName,
+    stopToolCalls: true,
+    reason:
+      reason === "duplicate"
+        ? "This tool call repeats information already returned in this turn."
+        : "Tool execution limit reached for this turn.",
+    instruction:
+      "Stop calling tools now. Use the tool results already available in the conversation to answer the user directly. If the available results are insufficient, ask one concise clarification question.",
+  };
+}
+
 // --- Stream Event Types ---
 
 export type AgentStreamEvent =
@@ -515,6 +543,9 @@ export async function* streamReadingAgent(
   };
   const toolResultCache = new Map<string, unknown>();
   const searchResultCache = new Map<string, unknown>();
+  const toolExecutionCounts = new Map<string, number>();
+  const lastToolResults = new Map<string, unknown>();
+  let totalToolExecutions = 0;
   const pendingToolCallNames: string[] = [];
   const isChapterTask =
     questionCategory === "specific_chapter_request" || CHAPTER_REFERENCE_RE.test(userInput);
@@ -715,13 +746,34 @@ export async function* streamReadingAgent(
             chapterReferenceState.attemptedQueries.push(effectiveQuery);
           }
 
+          const progressKey =
+            tool.name === "ragSearch" || tool.name === "fallbackSearch"
+              ? buildSearchToolCacheKey(tool.name, toolInput) ||
+                buildToolCacheKey(tool.name, toolInput)
+              : buildToolCacheKey(tool.name, toolInput);
+          const previousExecutions = toolExecutionCounts.get(progressKey) ?? 0;
+          if (previousExecutions >= REPEATED_TOOL_CALL_LIMIT) {
+            return JSON.stringify(
+              buildRepeatedToolCallResult(lastToolResults.get(progressKey), tool.name, "duplicate"),
+            );
+          }
+          if (totalToolExecutions >= TOOL_EXECUTION_LIMIT) {
+            return JSON.stringify(
+              buildRepeatedToolCallResult(lastToolResults.get(progressKey), tool.name, "limit"),
+            );
+          }
+          toolExecutionCounts.set(progressKey, previousExecutions + 1);
+          totalToolExecutions += 1;
+
           const skipExactCache =
             tool.name === "addCitation" || tool.name === "resolveChapterReference";
           const exactCacheKey = skipExactCache
             ? undefined
             : buildToolCacheKey(tool.name, toolInput);
           if (exactCacheKey && toolResultCache.has(exactCacheKey)) {
-            return JSON.stringify(toolResultCache.get(exactCacheKey));
+            const cachedResult = toolResultCache.get(exactCacheKey);
+            lastToolResults.set(progressKey, cachedResult);
+            return JSON.stringify(cachedResult);
           }
 
           const searchCacheKey =
@@ -729,7 +781,9 @@ export async function* streamReadingAgent(
               ? buildSearchToolCacheKey(tool.name, toolInput)
               : undefined;
           if (searchCacheKey && searchResultCache.has(searchCacheKey)) {
-            return JSON.stringify(searchResultCache.get(searchCacheKey));
+            const cachedResult = searchResultCache.get(searchCacheKey);
+            lastToolResults.set(progressKey, cachedResult);
+            return JSON.stringify(cachedResult);
           }
 
           const result = await executeTool(tool, toolInput, toolTimeoutMs);
@@ -750,6 +804,7 @@ export async function* streamReadingAgent(
               chapterReferenceState.limitReached = true;
             }
           }
+          lastToolResults.set(progressKey, result);
           return JSON.stringify(result);
         },
       });

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -114,6 +114,7 @@ const CATEGORY_TOOL_ORDER: Record<ReadingQuestionCategory, string[]> = {
   current_chapter_context: [
     "getCurrentChapter",
     "getSurroundingContext",
+    "getReadingProgress",
     "resolveChapterReference",
     "ragSearch",
     "ragContext",
@@ -284,6 +285,7 @@ function getFocusedToolNames(
           ? [
               "getCurrentChapter",
               "getSurroundingContext",
+              "getReadingProgress",
               "resolveChapterReference",
               "ragSearch",
               "ragContext",
@@ -291,7 +293,13 @@ function getFocusedToolNames(
               "findQuotes",
               "addCitation",
             ]
-          : ["getCurrentChapter", "getSurroundingContext", "fallbackChapterContext", "addCitation"],
+          : [
+              "getCurrentChapter",
+              "getSurroundingContext",
+              "getReadingProgress",
+              "fallbackChapterContext",
+              "addCitation",
+            ],
       );
     case "specific_chapter_request":
       return new Set(

--- a/packages/core/src/ai/system-prompt.ts
+++ b/packages/core/src/ai/system-prompt.ts
@@ -274,7 +274,9 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     steps.push(
       "   - **resolveChapterReference**: first step for user-mentioned chapter numbers/titles; do not convert human chapter numbers to chapterIndex yourself",
     );
-    steps.push("   - **ragSearch**: for finding specific content by topic/keyword");
+    steps.push(
+      "   - **ragSearch**: primary path for indexed book-content questions by topic/keyword",
+    );
     steps.push("   - **ragToc**: for compact/paginated structure browsing");
     steps.push(
       "   - **summarize/extractEntities/analyzeArguments/findQuotes**: for indexed content analysis",
@@ -393,7 +395,9 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     "- If a tool returns no results or an error, tell the user honestly. Do NOT retry with rephrased queries.",
   );
   steps.push(
-    "- Prefer current selection, current page, and current chapter context before wider retrieval whenever the user is asking about what they are reading right now.",
+    isVectorized
+      ? "- For indexed books, prefer ragSearch/ragContext for broad content questions. Use current selection/page/chapter context first only when the user explicitly asks about what they are reading right now, then fall back to indexed retrieval if needed."
+      : "- For non-indexed books, prefer fallbackSearch/fallbackChapterContext for broad content questions. Use current selection/page/chapter context first only when the user explicitly asks about what they are reading right now, then fall back to original-file retrieval if needed.",
   );
   steps.push(
     "- For a specific chapter request, call resolveChapterReference first. If matched=false, present the candidates or ask for clarification instead of guessing chapterIndex.",

--- a/packages/core/src/ai/system-prompt.ts
+++ b/packages/core/src/ai/system-prompt.ts
@@ -43,7 +43,12 @@ export function buildSystemPrompt(ctx: PromptContext): string {
     buildSemanticSection(ctx.semanticContext),
     buildRouteSection(ctx.questionCategory, ctx.selectionActive, ctx.routeHint),
     buildTurnAvailableToolsSection(ctx.allowedToolNames),
-    buildToolsSection(ctx.enabledSkills, ctx.isVectorized, !!(ctx.book?.id || ctx.bookId)),
+    buildToolsSection(
+      ctx.enabledSkills,
+      ctx.isVectorized,
+      !!(ctx.book?.id || ctx.bookId),
+      ctx.allowedToolNames,
+    ),
     buildWorkflowSection(ctx.isVectorized, !!(ctx.book?.id || ctx.bookId)),
     buildConstraintsSection(
       ctx.userLanguage,
@@ -139,105 +144,160 @@ function buildToolsSection(
   skills: Skill[],
   isVectorized: boolean,
   hasBookContext: boolean,
+  allowedToolNames?: string[],
 ): string {
   const tools: string[] = [];
+  const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
+  const canUse = (name: string) => !allowed || allowed.has(name);
+  const pushTool = (name: string, description: string) => {
+    if (canUse(name)) tools.push(description);
+  };
 
   // General tools (always available)
-  tools.push("### General Tools (always available)");
-  tools.push(
+  const generalStartIndex = tools.length;
+  pushTool(
+    "listBooks",
     "- **listBooks**: List books in the library with search/status filters (params: reasoning, search, status, limit)",
   );
-  tools.push(
+  pushTool(
+    "searchAllHighlights",
     "- **searchAllHighlights**: Get highlights across all books (params: reasoning, days, limit)",
   );
-  tools.push(
+  pushTool(
+    "searchAllNotes",
     "- **searchAllNotes**: Get notes across all books (params: reasoning, days, bookTitle, limit)",
   );
-  tools.push("- **getReadingStats**: Get reading statistics (params: reasoning, days)");
-  tools.push("- **getSkills**: Query available skills/SOPs for guidance (params: reasoning, task)");
-  tools.push(
+  pushTool(
+    "getReadingStats",
+    "- **getReadingStats**: Get reading statistics (params: reasoning, days)",
+  );
+  pushTool(
+    "getSkills",
+    "- **getSkills**: Query available skills/SOPs for guidance (params: reasoning, task)",
+  );
+  pushTool(
+    "mindmap",
     "- **mindmap**: Generate an interactive mindmap visualization (params: reasoning, title, markdown)",
   );
-  tools.push(
+  pushTool(
+    "updateBookMetadata",
     "- **updateBookMetadata**: Edit a book's library metadata when the user explicitly asks to modify it (params: reasoning, bookId, updates JSON)",
   );
-  tools.push(
+  pushTool(
+    "manageBookGroups",
     "- **manageBookGroups**: List/create/rename/delete groups or move books between groups (params: reasoning, action, groupId, name, bookIds)",
   );
+  if (tools.length > generalStartIndex) {
+    tools.splice(generalStartIndex, 0, "### General Tools");
+  }
 
   if (hasBookContext) {
-    tools.push("");
-    tools.push("### Reading Context Tools");
-    tools.push("- **getCurrentChapter**: Get current chapter title, index, and reading position");
-    tools.push("- **getSelection**: Get the text the user has currently selected");
-    tools.push("- **getReadingProgress**: Get overall reading progress, current page and chapter");
-    tools.push(
+    const contextStartIndex = tools.length;
+    pushTool(
+      "getCurrentChapter",
+      "- **getCurrentChapter**: Get current chapter title, index, and reading position",
+    );
+    pushTool("getSelection", "- **getSelection**: Get the text the user has currently selected");
+    pushTool(
+      "getReadingProgress",
+      "- **getReadingProgress**: Get overall reading progress, current page and chapter",
+    );
+    pushTool(
+      "getRecentHighlights",
       "- **getRecentHighlights**: Get user's recent highlights and annotations (params: limit)",
     );
-    tools.push(
+    pushTool(
+      "getSurroundingContext",
       "- **getSurroundingContext**: Get the text visible on the current page (params: includeSelection)",
     );
+    if (tools.length > contextStartIndex) {
+      tools.splice(contextStartIndex, 0, "", "### Reading Context Tools");
+    }
   }
 
   // RAG tools (require vectorization)
   if (hasBookContext && isVectorized) {
-    tools.push("");
-    tools.push("### Content Retrieval Tools (RAG)");
-    tools.push(
+    const retrievalStartIndex = tools.length;
+    pushTool(
+      "resolveChapterReference",
       "- **resolveChapterReference**: Resolve user-mentioned chapter numbers or fuzzy chapter titles to internal chapterIndex (params: query, maxCandidates)",
     );
-    tools.push(
+    pushTool(
+      "ragSearch",
       "- **ragSearch**: Semantic/keyword search across book content (params: query, mode, topK)",
     );
-    tools.push(
+    pushTool(
+      "ragToc",
       "- **ragToc**: Get a compact, paginated chapter list (params: query, aroundChapter, offset, limit)",
     );
-    tools.push(
+    pushTool(
+      "ragContext",
       "- **ragContext**: Get content around a specific chapter position (params: chapterIndex, range)",
     );
+    if (tools.length > retrievalStartIndex) {
+      tools.splice(retrievalStartIndex, 0, "", "### Content Retrieval Tools (RAG)");
+    }
 
-    tools.push("");
-    tools.push("### Content Analysis Tools");
-    tools.push(
+    const analysisStartIndex = tools.length;
+    pushTool(
+      "summarize",
       "- **summarize**: Generate summary of a chapter or entire book (params: scope, chapterIndex, style)",
     );
-    tools.push(
+    pushTool(
+      "extractEntities",
       "- **extractEntities**: Extract characters, places, concepts from text (params: entityType, chapterIndex)",
     );
-    tools.push(
+    pushTool(
+      "analyzeArguments",
       "- **analyzeArguments**: Analyze author's arguments and reasoning (params: chapterIndex, focusType)",
     );
-    tools.push(
+    pushTool(
+      "findQuotes",
       "- **findQuotes**: Find notable quotes and passages (params: quoteType, chapterIndex, maxQuotes)",
     );
-    tools.push(
+    pushTool(
+      "compareSections",
       "- **compareSections**: Compare two chapters (params: chapterIndex1, chapterIndex2, compareType)",
     );
+    if (tools.length > analysisStartIndex) {
+      tools.splice(analysisStartIndex, 0, "", "### Content Analysis Tools");
+    }
   } else if (hasBookContext) {
-    tools.push("");
-    tools.push("### Fallback Content Tools (no vector index)");
-    tools.push(
+    const fallbackStartIndex = tools.length;
+    pushTool(
+      "resolveChapterReference",
       "- **resolveChapterReference**: Resolve user-mentioned chapter numbers or fuzzy chapter titles to internal chapterIndex (params: query, maxCandidates)",
     );
-    tools.push(
+    pushTool(
+      "fallbackToc",
       "- **fallbackToc**: Read a compact, paginated chapter list from the original file (params: query, aroundChapter, offset, limit, includePreview)",
     );
-    tools.push(
+    pushTool(
+      "fallbackSearch",
       "- **fallbackSearch**: Keyword-scan the original file when the book is not vectorized (params: query, topK)",
     );
-    tools.push(
+    pushTool(
+      "fallbackChapterContext",
       "- **fallbackChapterContext**: Read a specific chapter from the original file (params: chapterIndex)",
     );
+    if (tools.length > fallbackStartIndex) {
+      tools.splice(fallbackStartIndex, 0, "", "### Fallback Content Tools (no vector index)");
+    }
   }
 
   if (hasBookContext) {
-    tools.push("- **getAnnotations**: Get user's highlights and notes (params: type)");
-    if (isVectorized) {
-      tools.push(
+    pushTool(
+      "getAnnotations",
+      "- **getAnnotations**: Get user's highlights and notes (params: type)",
+    );
+    if (isVectorized && canUse("addCitation")) {
+      pushTool(
+        "addCitation",
         "- **addCitation**: CRITICAL - Register a citation with CFI for precise navigation. You MUST extract the 'cfi' field from ragSearch/tool results and pass it here. The citationIndex param determines which [N] marker it maps to (params: citationIndex [REQUIRED - the number N for [N]], chapterTitle, chapterIndex, cfi [REQUIRED from tool results], quotedText, reasoning)",
       );
-    } else {
-      tools.push(
+    } else if (canUse("addCitation")) {
+      pushTool(
+        "addCitation",
         "- **addCitation**: Register a citation only when fallbackSearch/fallbackChapterContext returns a non-empty segment-level cfi for the exact text you cite. If no cfi is present, cite chapter titles/indices in plain text instead.",
       );
     }
@@ -245,10 +305,12 @@ function buildToolsSection(
 
   // Custom skills
   if (skills.length > 0) {
-    tools.push("");
-    tools.push("### Custom Skills");
+    const skillStartIndex = tools.length;
     for (const skill of skills) {
-      tools.push(`- **${skill.name}**: ${skill.description}`);
+      pushTool(skill.name, `- **${skill.name}**: ${skill.description}`);
+    }
+    if (tools.length > skillStartIndex) {
+      tools.splice(skillStartIndex, 0, "", "### Custom Skills");
     }
   }
 

--- a/packages/core/src/hooks/use-streaming-chat.ts
+++ b/packages/core/src/hooks/use-streaming-chat.ts
@@ -380,6 +380,10 @@ export function useStreamingChat(options?: StreamingChatOptions) {
               currentReasoningPart.status = "completed";
               currentReasoningPart.updatedAt = Date.now();
             }
+            markRunningToolCallPartsAsError(
+              currentParts,
+              i18n.t("streaming.toolNoResult", "工具没有返回结果"),
+            );
 
             const textContent = currentParts
               .filter((p) => p.type === "text")

--- a/packages/core/src/hooks/use-streaming-chat.ts
+++ b/packages/core/src/hooks/use-streaming-chat.ts
@@ -8,7 +8,7 @@ import {
   toolCallPartToMessageToolCall,
 } from "../ai/tool-call-state";
 import { getAvailableTools } from "../ai/tools";
-import { getSkills as getDbSkills } from "../db/database";
+import { getBook, getSkills as getDbSkills } from "../db/database";
 import i18n from "../i18n";
 import { getChatStreamingKey, useChatStore } from "../stores/chat-store";
 import { useSettingsStore } from "../stores/settings-store";
@@ -95,6 +95,19 @@ export interface StreamingState {
 const activeStreams = new Map<string, StreamingChat>();
 const STREAMING_PUBLISH_INTERVAL_MS = 160;
 
+async function resolveFreshBook(
+  bookId: string | undefined,
+  fallback?: Book | null,
+): Promise<Book | null> {
+  if (!bookId) return fallback ?? null;
+  try {
+    return (await getBook(bookId)) ?? fallback ?? null;
+  } catch (err) {
+    console.warn("[AI] Failed to refresh book state before streaming:", err);
+    return fallback ?? null;
+  }
+}
+
 export function useStreamingChat(options?: StreamingChatOptions) {
   const streamingKey = getChatStreamingKey(options?.bookId);
   const streamingSession = useChatStore(
@@ -177,10 +190,7 @@ export function useStreamingChat(options?: StreamingChatOptions) {
       const bookId = overrideBookId ?? options?.bookId;
       const sessionKey = getChatStreamingKey(bookId);
       const activeSession = useChatStore.getState().streamingSessions[sessionKey];
-      if (
-        (!content.trim() && (!quotes || quotes.length === 0)) ||
-        activeSession?.isStreaming
-      ) {
+      if ((!content.trim() && (!quotes || quotes.length === 0)) || activeSession?.isStreaming) {
         return;
       }
 
@@ -321,10 +331,13 @@ export function useStreamingChat(options?: StreamingChatOptions) {
           const elapsed = now - lastPublishedAt;
 
           if (!pendingPublishTimer) {
-            pendingPublishTimer = setTimeout(() => {
-              pendingPublishTimer = null;
-              publishCurrentMessage(pendingCurrentStep);
-            }, lastPublishedAt === 0 ? 0 : Math.max(STREAMING_PUBLISH_INTERVAL_MS - elapsed, 0));
+            pendingPublishTimer = setTimeout(
+              () => {
+                pendingPublishTimer = null;
+                publishCurrentMessage(pendingCurrentStep);
+              },
+              lastPublishedAt === 0 ? 0 : Math.max(STREAMING_PUBLISH_INTERVAL_MS - elapsed, 0),
+            );
           }
         };
 
@@ -334,13 +347,16 @@ export function useStreamingChat(options?: StreamingChatOptions) {
           finishStreamingSession(sessionKey);
         };
 
+        const streamBook = await resolveFreshBook(bookId, options?.book);
+        const streamIsVectorized = streamBook?.isVectorized ?? false;
+
         await stream.stream({
           thread: threadForStream,
-          book: options?.book || null,
+          book: streamBook,
           bookId,
           semanticContext: options?.semanticContext || null,
           enabledSkills,
-          isVectorized: options?.book?.isVectorized || false,
+          isVectorized: streamIsVectorized,
           aiConfig: aiConfigOverride || aiConfig,
           deepThinking,
           spoilerFree,


### PR DESCRIPTION
## Summary
- refresh the latest book record before streaming AI responses so vectorized books register RAG tools even when screen state is stale
- add repeated-tool/no-progress guards so the reader agent asks the model to answer instead of looping through the same tools
- cover repeated search calls with an assertion for stopToolCalls guidance

Fixes #541

## Verification
- PATH="/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.codex/tmp/arg0/codex-arg0EBmBfL:/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/bealqiu/.antigravity/antigravity/bin:/Users/bealqiu/.codebuddy/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/Library/pnpm:/Users/bealqiu/.rd/bin:/Users/bealqiu/.codeium/windsurf/bin:/Users/bealqiu/.nvm/versions/node/v14.21.3/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/opt/podman/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.cargo/bin:/Applications/Codex.app/Contents/Resources" pnpm --filter @readany/core exec vitest run src/ai/__tests__/reading-agent-tools.test.ts
- PATH="/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.codex/tmp/arg0/codex-arg0EBmBfL:/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/bealqiu/.antigravity/antigravity/bin:/Users/bealqiu/.codebuddy/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/Library/pnpm:/Users/bealqiu/.rd/bin:/Users/bealqiu/.codeium/windsurf/bin:/Users/bealqiu/.nvm/versions/node/v14.21.3/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/opt/podman/bin:/Users/bealqiu/.local/bin:/Users/bealqiu/.cargo/bin:/Applications/Codex.app/Contents/Resources" ./node_modules/.bin/biome check packages/core/src/ai/agents/reading-agent.ts packages/core/src/hooks/use-streaming-chat.ts packages/core/src/ai/__tests__/reading-agent-tools.test.ts
- git diff --check

## Notes
- Full core typecheck is still blocked by existing missing packages: @smithy/protocol-http and @smithy/querystring-builder.