### PR TITLE
fix: stabilize mobile import auto vectorization

### DIFF
--- a/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
+++ b/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
@@ -39,7 +39,10 @@ export async function getMobileBookFileSize(filePath: string): Promise<number | 
   return typeof info.size === "number" ? info.size : null;
 }
 
-export async function inspectMobileBookForVectorize(book: Book): Promise<{
+export async function inspectMobileBookForVectorize(
+  book: Book,
+  options?: { maxBytes?: number },
+): Promise<{
   absPath: string;
   mimeType: string | null;
   size: number | null;
@@ -56,7 +59,7 @@ export async function inspectMobileBookForVectorize(book: Book): Promise<{
   if (size == null) {
     return { absPath, mimeType, size, canVectorize: false, reason: "missing-file" };
   }
-  if (size > MOBILE_AUTO_VECTORIZE_MAX_BYTES) {
+  if (options?.maxBytes != null && size > options.maxBytes) {
     return { absPath, mimeType, size, canVectorize: false, reason: "file-too-large" };
   }
 
@@ -64,7 +67,9 @@ export async function inspectMobileBookForVectorize(book: Book): Promise<{
 }
 
 export async function queueBookForAutoVectorize(book: Book): Promise<boolean> {
-  const info = await inspectMobileBookForVectorize(book);
+  const info = await inspectMobileBookForVectorize(book, {
+    maxBytes: MOBILE_AUTO_VECTORIZE_MAX_BYTES,
+  });
   if (!info.canVectorize || !info.mimeType) {
     console.warn(
       `[AutoVectorize] Skip mobile book: ${book.meta.title} (${info.reason}, size=${info.size ?? "unknown"}, format=${book.format})`,

--- a/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
+++ b/packages/app-expo/src/lib/rag/auto-vectorize-book.ts
@@ -3,6 +3,8 @@ import type { Book } from "@readany/core/types";
 import * as FileSystem from "expo-file-system/legacy";
 import { queueBook as queueAutoVectorize } from "./auto-vectorize-service";
 
+export const MOBILE_AUTO_VECTORIZE_MAX_BYTES = 32 * 1024 * 1024;
+
 const MIME_TYPES: Record<string, string> = {
   epub: "application/epub+zip",
   pdf: "application/pdf",
@@ -14,18 +16,6 @@ const MIME_TYPES: Record<string, string> = {
 export function getMobileVectorizeMimeType(format: string | undefined): string | null {
   const normalized = String(format || "").toLowerCase();
   return MIME_TYPES[normalized] ?? null;
-}
-
-function bytesToBase64(bytes: Uint8Array): string {
-  const chunkSize = 0x8000;
-  let binary = "";
-
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-
-  return btoa(binary);
 }
 
 export async function resolveMobileBookPath(filePath: string): Promise<string> {
@@ -54,7 +44,7 @@ export async function inspectMobileBookForVectorize(book: Book): Promise<{
   mimeType: string | null;
   size: number | null;
   canVectorize: boolean;
-  reason?: "unsupported-format" | "missing-file";
+  reason?: "unsupported-format" | "missing-file" | "file-too-large";
 }> {
   const absPath = await resolveMobileBookPath(book.filePath);
   const mimeType = getMobileVectorizeMimeType(book.format);
@@ -66,12 +56,14 @@ export async function inspectMobileBookForVectorize(book: Book): Promise<{
   if (size == null) {
     return { absPath, mimeType, size, canVectorize: false, reason: "missing-file" };
   }
+  if (size > MOBILE_AUTO_VECTORIZE_MAX_BYTES) {
+    return { absPath, mimeType, size, canVectorize: false, reason: "file-too-large" };
+  }
 
   return { absPath, mimeType, size, canVectorize: true };
 }
 
 export async function queueBookForAutoVectorize(book: Book): Promise<boolean> {
-  const platform = getPlatformService();
   const info = await inspectMobileBookForVectorize(book);
   if (!info.canVectorize || !info.mimeType) {
     console.warn(
@@ -80,7 +72,13 @@ export async function queueBookForAutoVectorize(book: Book): Promise<boolean> {
     return false;
   }
 
-  const bytes = await platform.readFile(info.absPath);
-  queueAutoVectorize(book, bytesToBase64(bytes), info.mimeType);
+  queueAutoVectorize(
+    book,
+    () =>
+      FileSystem.readAsStringAsync(info.absPath, {
+        encoding: FileSystem.EncodingType.Base64,
+      }),
+    info.mimeType,
+  );
   return true;
 }

--- a/packages/app-expo/src/lib/rag/auto-vectorize-service.ts
+++ b/packages/app-expo/src/lib/rag/auto-vectorize-service.ts
@@ -1,21 +1,26 @@
 import type { ChapterData } from "@readany/core/rag";
 import type { Book } from "@readany/core/types";
 
-export type AutoVectorizeCallback = (bookId: string, progress: { status: string; progress: number }) => void;
+export type AutoVectorizeCallback = (
+  bookId: string,
+  progress: { status: string; progress: number },
+) => void;
 
 interface ExtractorRef {
   extractChapters: (base64BookData: string, mimeType?: string) => Promise<ChapterData[]>;
 }
 
+export type AutoVectorizeDataLoader = () => Promise<string>;
+
 interface QueueItem {
   book: Book;
-  base64Data: string;
+  loadBase64Data: AutoVectorizeDataLoader;
   mimeType: string;
 }
 
 let extractorRef: ExtractorRef | null = null;
 let callback: AutoVectorizeCallback | null = null;
-let queue: QueueItem[] = [];
+const queue: QueueItem[] = [];
 let processing = false;
 
 export function setExtractorRef(ref: ExtractorRef | null) {
@@ -34,8 +39,12 @@ export function getQueueLength() {
   return queue.length;
 }
 
-export async function queueBook(book: Book, base64Data: string, mimeType: string) {
-  queue.push({ book, base64Data, mimeType });
+export async function queueBook(
+  book: Book,
+  loadBase64Data: AutoVectorizeDataLoader,
+  mimeType: string,
+) {
+  queue.push({ book, loadBase64Data, mimeType });
   if (!processing) {
     processQueue();
   }
@@ -51,7 +60,7 @@ async function processQueue() {
     const item = queue.shift();
     if (!item) break;
 
-    const { book, base64Data, mimeType } = item;
+    const { book, loadBase64Data, mimeType } = item;
 
     try {
       callback?.(book.id, { status: "extracting", progress: 0 });
@@ -61,6 +70,7 @@ async function processQueue() {
         continue;
       }
 
+      const base64Data = await loadBase64Data();
       const chapters = await extractorRef.extractChapters(base64Data, mimeType);
       if (!chapters || chapters.length === 0) {
         console.warn(`[AutoVectorize] No chapters for ${book.meta.title}`);

--- a/packages/app-expo/src/screens/library/useVectorizationQueue.ts
+++ b/packages/app-expo/src/screens/library/useVectorizationQueue.ts
@@ -109,7 +109,9 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
   const handleVectorize = useCallback(
     (book: Book) => {
       const prepareAndQueue = async () => {
-        const info = await inspectMobileBookForVectorize(book);
+        const info = await inspectMobileBookForVectorize(book, {
+          maxBytes: MOBILE_AUTO_VECTORIZE_MAX_BYTES,
+        });
         if (info.reason === "unsupported-format") {
           Alert.alert(
             t("vectorize.unsupportedFormatTitle", "Unsupported format"),
@@ -132,12 +134,34 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
         }
         if (info.reason === "file-too-large") {
           const maxMb = Math.round(MOBILE_AUTO_VECTORIZE_MAX_BYTES / 1024 / 1024);
+          const shouldContinue = await new Promise<boolean>((resolve) => {
+            Alert.alert(
+              t("vectorize.largeBookTitle", "文件较大"),
+              t("vectorize.largeBookDesc", {
+                maxMb,
+                defaultValue: `这本书超过 ${maxMb}MB，移动端向量化可能较慢并占用较多内存。仍要继续吗？`,
+              }),
+              [
+                {
+                  text: t("common.cancel", "取消"),
+                  style: "cancel",
+                  onPress: () => resolve(false),
+                },
+                {
+                  text: t("common.continue", "继续"),
+                  onPress: () => resolve(true),
+                },
+              ],
+              { cancelable: true, onDismiss: () => resolve(false) },
+            );
+          });
+          if (!shouldContinue) {
+            return;
+          }
+        } else if (!info.canVectorize) {
           Alert.alert(
-            t("vectorize.tooLargeTitle", "文件过大"),
-            t("vectorize.tooLargeDesc", {
-              maxMb,
-              defaultValue: `移动端暂不处理超过 ${maxMb}MB 的书籍向量化，请在桌面端处理或换用更小的文件。`,
-            }),
+            t("common.error", "Error"),
+            t("vectorize.prepareFailed", "Failed to prepare vectorization."),
           );
           return;
         }

--- a/packages/app-expo/src/screens/library/useVectorizationQueue.ts
+++ b/packages/app-expo/src/screens/library/useVectorizationQueue.ts
@@ -1,5 +1,8 @@
 import type { ExtractorRef } from "@/components/rag/ExtractorWebView";
-import { inspectMobileBookForVectorize } from "@/lib/rag/auto-vectorize-book";
+import {
+  MOBILE_AUTO_VECTORIZE_MAX_BYTES,
+  inspectMobileBookForVectorize,
+} from "@/lib/rag/auto-vectorize-book";
 import { triggerVectorizeBook } from "@/lib/rag/vectorize-trigger";
 import type { RootStackParamList } from "@/navigation/RootNavigator";
 import { useVectorModelStore } from "@/stores/vector-model-store";
@@ -124,6 +127,17 @@ export function useVectorizationQueue({ extractorRef, nav }: UseVectorizationQue
               "vectorize.missingFileDesc",
               "The local book file is missing. Please download or re-import it.",
             ),
+          );
+          return;
+        }
+        if (info.reason === "file-too-large") {
+          const maxMb = Math.round(MOBILE_AUTO_VECTORIZE_MAX_BYTES / 1024 / 1024);
+          Alert.alert(
+            t("vectorize.tooLargeTitle", "文件过大"),
+            t("vectorize.tooLargeDesc", {
+              maxMb,
+              defaultValue: `移动端暂不处理超过 ${maxMb}MB 的书籍向量化，请在桌面端处理或换用更小的文件。`,
+            }),
           );
           return;
         }

--- a/packages/app-expo/src/stores/library-store.ts
+++ b/packages/app-expo/src/stores/library-store.ts
@@ -3,7 +3,7 @@ import {
   extractBookMetadata,
   extractBookMetadataFromFile,
 } from "@/lib/book/metadata-extractor";
-import { queueBook as queueAutoVectorize } from "@/lib/rag/auto-vectorize-service";
+import { queueBookForAutoVectorize } from "@/lib/rag/auto-vectorize-book";
 import {
   type ImportBooksResult,
   createEmptyImportBooksResult,
@@ -143,18 +143,6 @@ async function saveCoverToAppData(bookId: string, coverBlob: Blob): Promise<stri
   return relativePath;
 }
 
-function bytesToBase64(bytes: Uint8Array): string {
-  const chunkSize = 0x8000;
-  let binary = "";
-
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-
-  return btoa(binary);
-}
-
 const MOBILE_IMPORT_METADATA_MAX_BYTES = 32 * 1024 * 1024;
 
 async function getMobileFileStat(path: string): Promise<{ size: number; md5?: string }> {
@@ -202,6 +190,30 @@ async function extractMobileImportMetadata(params: {
 
 function shouldAutoVectorizeMobile(format: Book["format"]): boolean {
   return format === "epub" || format === "txt" || format === "umd";
+}
+
+async function maybeQueueImportedBookForAutoVectorize(book: Book, fileName: string): Promise<void> {
+  try {
+    const vmState = useVectorModelStore.getState();
+    if (
+      !vmState.autoVectorizeOnImport ||
+      !vmState.vectorModelEnabled ||
+      !vmState.hasVectorCapability()
+    ) {
+      return;
+    }
+
+    if (!shouldAutoVectorizeMobile(book.format)) {
+      console.warn(
+        `[importBooks] Skip auto-vectorize for unsupported mobile import: ${fileName} (format=${book.format})`,
+      );
+      return;
+    }
+
+    await queueBookForAutoVectorize(book);
+  } catch (autoVectorizeErr) {
+    console.warn(`[importBooks] Auto-vectorize enqueue failed for ${fileName}:`, autoVectorizeErr);
+  }
 }
 
 /**
@@ -991,25 +1003,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
               }
               console.log(`[importBooks] TXT imported as EPUB: ${title}`);
 
-              // Auto-vectorize if enabled. Keep failures isolated so a
-              // successful import doesn't get reported as a failed import.
-              try {
-                const vmState = useVectorModelStore.getState();
-                if (
-                  vmState.autoVectorizeOnImport &&
-                  vmState.vectorModelEnabled &&
-                  vmState.hasVectorCapability() &&
-                  shouldAutoVectorizeMobile("txt")
-                ) {
-                  const base64 = bytesToBase64(conversion.epubBytes);
-                  queueAutoVectorize(book, base64, "application/epub+zip");
-                }
-              } catch (autoVectorizeErr) {
-                console.warn(
-                  `[importBooks] Auto-vectorize enqueue failed for ${fileName}:`,
-                  autoVectorizeErr,
-                );
-              }
+              await maybeQueueImportedBookForAutoVectorize(book, fileName);
               continue;
             } catch (convErr) {
               console.error("[importBooks] TXT conversion failed:", convErr);
@@ -1114,23 +1108,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
               }
               console.log(`[importBooks] UMD imported as EPUB: ${title}`);
 
-              try {
-                const vmState = useVectorModelStore.getState();
-                if (
-                  vmState.autoVectorizeOnImport &&
-                  vmState.vectorModelEnabled &&
-                  vmState.hasVectorCapability() &&
-                  shouldAutoVectorizeMobile("umd")
-                ) {
-                  const base64 = bytesToBase64(conversion.epubBytes);
-                  queueAutoVectorize(book, base64, "application/epub+zip");
-                }
-              } catch (autoVectorizeErr) {
-                console.warn(
-                  `[importBooks] Auto-vectorize enqueue failed for ${fileName}:`,
-                  autoVectorizeErr,
-                );
-              }
+              await maybeQueueImportedBookForAutoVectorize(book, fileName);
               continue;
             } catch (convErr) {
               console.error("[importBooks] UMD conversion failed:", convErr);
@@ -1231,43 +1209,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
             duplicateIndex.byHash.set(fileHash, book);
           }
 
-          // Auto-vectorize if enabled. Keep failures isolated so a
-          // successful import doesn't get reported as a failed import.
-          try {
-            const vmState = useVectorModelStore.getState();
-            if (
-              vmState.autoVectorizeOnImport &&
-              vmState.vectorModelEnabled &&
-              vmState.hasVectorCapability() &&
-              shouldAutoVectorizeMobile(format)
-            ) {
-              const sourceBytes = await platform.readFile(filePath);
-              const base64 = bytesToBase64(sourceBytes);
-              const mimeTypes: Record<string, string> = {
-                epub: "application/epub+zip",
-                pdf: "application/pdf",
-                mobi: "application/x-mobipocket-ebook",
-                azw: "application/vnd.amazon.ebook",
-                azw3: "application/vnd.amazon.ebook",
-                cbz: "application/vnd.comicbook+zip",
-                cbr: "application/vnd.comicbook+zip",
-                fb2: "application/x-fictionbook+xml",
-                fbz: "application/x-zip-compressed-fb2",
-                txt: "text/plain",
-              };
-              const mimeType = mimeTypes[format] || "application/epub+zip";
-              queueAutoVectorize(book, base64, mimeType);
-            } else if (vmState.autoVectorizeOnImport && vmState.vectorModelEnabled) {
-              console.warn(
-                `[importBooks] Skip auto-vectorize for unsupported mobile import: ${fileName} (${fileSize} bytes, format=${format})`,
-              );
-            }
-          } catch (autoVectorizeErr) {
-            console.warn(
-              `[importBooks] Auto-vectorize enqueue failed for ${fileName}:`,
-              autoVectorizeErr,
-            );
-          }
+          await maybeQueueImportedBookForAutoVectorize(book, fileName);
         } catch (err) {
           console.error(`Failed to import ${fileInfo.uri}:`, err);
           result.failures.push({


### PR DESCRIPTION
## Summary
- Defer mobile auto-vectorize file reads until the queue is actually processing the current book
- Stop importBooks from converting imported book bytes to base64 inline after TXT/UMD/generic imports
- Skip >32MB books only for automatic mobile vectorization after import/download; manual vectorization now warns and still allows the user to continue

## Scope
- Helps reduce Android memory pressure during local import, LAN/QR sync import, and post-download auto-vectorization flows
- Partially addresses the crash/stuck symptoms in #483, #553, #558, #560, and #580
- Does not claim to fix pairing-code failures (#569/#570) or S3 LIST pagination (#546), which are separate sync backend paths

## Verification
- PASS: git diff --check
- PASS: Biome check on touched files, with one existing warning in library-store.ts (unused saveCoverToAppData)
- BLOCKED: packages/app-expo/node_modules/.bin/tsc -p packages/app-expo/tsconfig.json --noEmit, existing missing packages: base64-js, @smithy/protocol-http, @smithy/querystring-builder