### PR TITLE
fix: force full sync database snapshots

### DIFF
--- a/packages/core/src/stores/sync-store.test.ts
+++ b/packages/core/src/stores/sync-store.test.ts
@@ -457,6 +457,33 @@ describe("useSyncStore", () => {
     const result = await useSyncStore.getState().syncNow("upload");
 
     expect(syncMocks.runSimpleSync).toHaveBeenCalledWith(mockBackend, expect.any(Function), {
+      forceUploadSnapshot: true,
+      fileSyncOptions: {
+        forceUploadAll: true,
+      },
+    });
+    expect(result).toMatchObject({
+      success: true,
+      direction: "upload",
+    });
+  });
+
+  it("forceFullSync upload forces both database snapshot and file upload", async () => {
+    useSyncStore.setState({
+      config: baseConfig,
+      isConfigured: true,
+      backendType: "webdav",
+    });
+    mockPlatformService.kvGetItem.mockImplementation(async (key: string) =>
+      key === "sync_webdav_password" ? "secret" : null,
+    );
+
+    const result = await useSyncStore.getState().forceFullSync("upload");
+
+    expect(syncMocks.runSimpleSync).toHaveBeenCalledWith(mockBackend, expect.any(Function), {
+      receiveOnly: false,
+      forceApply: false,
+      forceUploadSnapshot: true,
       fileSyncOptions: {
         forceUploadAll: true,
       },

--- a/packages/core/src/stores/sync-store.ts
+++ b/packages/core/src/stores/sync-store.ts
@@ -611,6 +611,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
             }
           : uploadOnly
             ? {
+                forceUploadSnapshot: true,
                 fileSyncOptions: {
                   forceUploadAll: true,
                 },
@@ -825,6 +826,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
                     disableUploads: true,
                     disableRemoteDeletes: true,
                   },
+            ...(direction === "upload" ? { forceUploadSnapshot: true } : {}),
           },
         );
 

--- a/packages/core/src/sync/__tests__/simple-sync.integration.test.ts
+++ b/packages/core/src/sync/__tests__/simple-sync.integration.test.ts
@@ -682,6 +682,38 @@ describe("simple sync convergence", () => {
     ).toHaveProperty("books");
   });
 
+  it("force-uploads a fresh full snapshot even when incremental changes are empty", async () => {
+    const backend = new MemoryBackend();
+    const deviceA = new FakeSyncDb();
+    deviceA.syncMetadata.set("last_sync_at", "5000");
+    deviceA.insert("books", bookRow({ title: "Latest PC title", updated_at: 1000 }));
+
+    backend.jsonFiles.set("/readany/sync/device-device-a.json", {
+      deviceId: "device-a",
+      timestamp: 5900,
+      since: 0,
+      tables: {
+        books: {
+          records: [bookRow({ title: "Old remote snapshot", updated_at: 1000 })],
+          deletedIds: [],
+        },
+      },
+    });
+
+    now = 6000;
+    dbMocks.currentDeviceId = "device-a";
+    dbMocks.currentDb = deviceA;
+    const result = await runSimpleSync(backend, undefined, { forceUploadSnapshot: true });
+
+    expect(result.success).toBe(true);
+    const snapshot = backend.jsonFiles.get("/readany/sync/device-device-a.json") as {
+      timestamp: number;
+      tables: { books?: { records: Row[] } };
+    };
+    expect(snapshot.timestamp).toBe(6000);
+    expect(snapshot.tables.books?.records[0]?.title).toBe("Latest PC title");
+  });
+
   it("downloads remote snapshots using the listed path", async () => {
     class AliasPathBackend extends MemoryBackend {
       async listDir(path: string): Promise<RemoteFile[]> {

--- a/packages/core/src/sync/simple-sync.ts
+++ b/packages/core/src/sync/simple-sync.ts
@@ -39,6 +39,8 @@ export interface SimpleSyncOptions {
   receiveOnly?: boolean;
   /** When true, bypass timestamp comparisons and force-apply all remote records */
   forceApply?: boolean;
+  /** When true, always upload a fresh full local device snapshot. */
+  forceUploadSnapshot?: boolean;
   fileSyncOptions?: SyncFilesOptions;
 }
 
@@ -828,7 +830,7 @@ export async function runSimpleSync(
       );
 
       try {
-        if (changeCount > 0 || totalApplied > 0) {
+        if (options.forceUploadSnapshot || changeCount > 0 || totalApplied > 0) {
           onProgress?.({
             phase: "database",
             operation: "upload",


### PR DESCRIPTION
## Summary
- Add a `forceUploadSnapshot` option to the simple sync database layer
- Make upload-direction syncs force-upload a fresh full device snapshot, not just all book/cover files
- Keep force-download receive-only semantics unchanged

## Analysis
Issues #586 and #587 report the same cross-device flow: PC performs full upload, then Android performs full download, but the mobile data is not the latest. The file layer already had force-upload/force-download options, but the database snapshot layer could skip rewriting this device's remote snapshot when `last_sync_at` made incremental changes look empty and the existing remote snapshot was recent. In that case, a full upload could refresh files while leaving metadata/progress/library snapshot stale.

## Verification
- PASS `git diff --check`
- PASS `biome check packages/core/src/stores/sync-store.ts packages/core/src/stores/sync-store.test.ts packages/core/src/sync/simple-sync.ts packages/core/src/sync/__tests__/simple-sync.integration.test.ts`
- PASS `PATH=/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH packages/core/node_modules/.bin/vitest run packages/core/src/stores/sync-store.test.ts`
- PASS `PATH=/Users/bealqiu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH packages/core/node_modules/.bin/vitest run packages/core/src/sync/__tests__/simple-sync.integration.test.ts`

Fixes #586
Fixes #587