### PR TITLE
fix(pdf): improve text selection on macOS (#600)

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -120,6 +120,9 @@ function getRangeTextWithoutRuby(range: Range, fallback = ""): string {
     for (const node of fragment.querySelectorAll("rt, rp")) {
       node.remove();
     }
+    for (const node of fragment.querySelectorAll("br")) {
+      node.replaceWith(fragment.ownerDocument.createTextNode("\n"));
+    }
     const text = fragment.textContent?.trim();
     if (text) return text;
   } catch {

--- a/packages/foliate-js/pdf.js
+++ b/packages/foliate-js/pdf.js
@@ -34,6 +34,8 @@ const TEXT_LAYER_CSS = `
   transform-origin: 0 0;
   caret-color: CanvasText;
   z-index: 0;
+  letter-spacing: normal;
+  word-spacing: normal;
 }
 .textLayer.highlighting { touch-action: none; }
 .textLayer :is(span, br) {
@@ -43,7 +45,6 @@ const TEXT_LAYER_CSS = `
   cursor: text;
   transform-origin: 0% 0%;
 }
-.textLayer --min-font-size: 1;
 .textLayer {
   --min-font-size: 1;
   --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
@@ -104,7 +105,109 @@ const ANNOTATION_LAYER_CSS = `
 .annotationLayer .linkAnnotation.hasBorder:hover {
   background-color: rgb(255 255 0 / 0.2);
 }
+.textLayer.selecting ~ .annotationLayer section {
+  pointer-events: none;
+}
 `;
+
+const NULL_CHAR = String.fromCharCode(0);
+const removeNullCharacters = (str) => str.replaceAll(NULL_CHAR, "");
+const normalizeSelectedText = (str) => removeNullCharacters(pdfjsLib.normalizeUnicode(str)).trim();
+
+const getRangeTextWithLineBreaks = (range) => {
+  try {
+    const fragment = range.cloneContents();
+    for (const node of fragment.querySelectorAll(".endOfContent")) {
+      node.remove();
+    }
+    for (const node of fragment.querySelectorAll("br")) {
+      node.replaceWith(fragment.ownerDocument.createTextNode("\n"));
+    }
+    return fragment.textContent || "";
+  } catch {
+    return "";
+  }
+};
+
+const getSelectedText = (selection, container) => {
+  const doc = container.ownerDocument;
+  const view = doc.defaultView;
+  const segments = [];
+  let textWithExplicitLineBreaks = "";
+
+  const walker = doc.createTreeWalker(container, view.NodeFilter.SHOW_TEXT);
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const range = selection.getRangeAt(i);
+    if (!range.intersectsNode(container)) continue;
+
+    const rangeText = getRangeTextWithLineBreaks(range);
+    if (rangeText.trim()) {
+      textWithExplicitLineBreaks += `${textWithExplicitLineBreaks ? "\n" : ""}${rangeText}`;
+    }
+
+    walker.currentNode = container;
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const parent = node.parentElement;
+      if (!parent || parent.closest(".endOfContent")) continue;
+      if (!range.intersectsNode(node)) continue;
+
+      let start = 0;
+      let end = node.nodeValue.length;
+      if (range.startContainer === node) start = range.startOffset;
+      if (range.endContainer === node) end = range.endOffset;
+      const text = node.nodeValue.slice(start, end);
+      if (!text) continue;
+
+      const rect = parent.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) continue;
+      segments.push({
+        text,
+        left: rect.left,
+        centerY: rect.top + rect.height / 2,
+        height: rect.height || 1,
+      });
+    }
+  }
+
+  if (textWithExplicitLineBreaks.trim()) {
+    return normalizeSelectedText(textWithExplicitLineBreaks);
+  }
+
+  if (segments.length === 0) {
+    return normalizeSelectedText(selection.toString());
+  }
+
+  segments.sort((a, b) => {
+    const tolerance = Math.max(2, Math.min(a.height, b.height) * 0.6);
+    if (Math.abs(a.centerY - b.centerY) > tolerance) return a.centerY - b.centerY;
+    return a.left - b.left;
+  });
+
+  const lines = [];
+  for (const segment of segments) {
+    const line = lines.at(-1);
+    const tolerance = Math.max(2, segment.height * 0.6);
+    if (!line || Math.abs(line.centerY - segment.centerY) > tolerance) {
+      lines.push({ centerY: segment.centerY, height: segment.height, parts: [segment] });
+      continue;
+    }
+    line.parts.push(segment);
+    line.centerY = (line.centerY * (line.parts.length - 1) + segment.centerY) / line.parts.length;
+    line.height = Math.max(line.height, segment.height);
+  }
+
+  const text = lines
+    .map((line) =>
+      line.parts
+        .sort((a, b) => a.left - b.left)
+        .map((segment) => segment.text)
+        .join(""),
+    )
+    .join("\n");
+
+  return normalizeSelectedText(text);
+};
 
 /**
  * Render canvas + text layer + annotation layer for a PDF page inside an iframe document.
@@ -112,10 +215,11 @@ const ANNOTATION_LAYER_CSS = `
  */
 const render = async (page, doc, zoom) => {
   if (!doc) return;
-  const scale = zoom * devicePixelRatio;
+  const scale = zoom;
+  const outputScale = globalThis.devicePixelRatio || 1;
 
-  doc.documentElement.style.transform = `scale(${1 / devicePixelRatio})`;
-  doc.documentElement.style.transformOrigin = "top left";
+  doc.documentElement.style.removeProperty("transform");
+  doc.documentElement.style.removeProperty("transform-origin");
   doc.documentElement.style.setProperty("--total-scale-factor", scale);
   doc.documentElement.style.setProperty("--user-unit", "1");
   doc.documentElement.style.setProperty("--scale-round-x", "1px");
@@ -125,10 +229,13 @@ const render = async (page, doc, zoom) => {
 
   // Render canvas (in main document for font loading, then adopt into iframe)
   const canvas = document.createElement("canvas");
-  canvas.height = viewport.height;
-  canvas.width = viewport.width;
+  canvas.height = Math.floor(viewport.height * outputScale);
+  canvas.width = Math.floor(viewport.width * outputScale);
+  canvas.style.width = `${Math.floor(viewport.width)}px`;
+  canvas.style.height = `${Math.floor(viewport.height)}px`;
   const canvasContext = canvas.getContext("2d");
-  await page.render({ canvasContext, viewport }).promise;
+  const transform = outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null;
+  await page.render({ canvasContext, transform, viewport }).promise;
 
   const canvasContainer = doc.querySelector("#canvas");
   if (!canvasContainer) return;
@@ -138,12 +245,19 @@ const render = async (page, doc, zoom) => {
   const textContainer = doc.querySelector(".textLayer");
   if (textContainer) {
     textContainer.replaceChildren();
-    const textLayer = new pdfjsLib.TextLayer({
-      textContentSource: await page.streamTextContent(),
-      container: textContainer,
-      viewport,
-    });
-    await textLayer.render();
+    try {
+      const textLayer = new pdfjsLib.TextLayer({
+        textContentSource: await page.streamTextContent({
+          includeMarkedContent: true,
+          disableNormalization: true,
+        }),
+        container: textContainer,
+        viewport,
+      });
+      await textLayer.render();
+    } catch (error) {
+      console.error(`Failed to render PDF text layer for page ${page.pageNumber}.`, error);
+    }
 
     // Hide offscreen canvases created by TextLayer
     for (const c of document.querySelectorAll(".hiddenCanvasElement")) {
@@ -157,10 +271,87 @@ const render = async (page, doc, zoom) => {
       });
     }
 
-    // Fix text selection end-of-content marker
-    const endOfContent = document.createElement("div");
+    doc.__readanyPdfTextSelectionAbortController?.abort();
+    const selectionAbortController = new AbortController();
+    doc.__readanyPdfTextSelectionAbortController = selectionAbortController;
+    const { signal } = selectionAbortController;
+    const SelectionRange = doc.defaultView.Range;
+    const endOfContent = doc.createElement("div");
     endOfContent.className = "endOfContent";
     textContainer.append(endOfContent);
+    let previousSelectionRange = null;
+
+    const resetEndOfContent = () => {
+      textContainer.append(endOfContent);
+      endOfContent.style.width = "";
+      endOfContent.style.height = "";
+      endOfContent.style.userSelect = "";
+      textContainer.classList.remove("selecting");
+      previousSelectionRange = null;
+    };
+
+    const moveEndOfContent = (selection) => {
+      if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+        resetEndOfContent();
+        return;
+      }
+
+      let range = null;
+      for (let i = 0; i < selection.rangeCount; i++) {
+        const candidate = selection.getRangeAt(i);
+        if (candidate.intersectsNode(textContainer)) {
+          range = candidate;
+          break;
+        }
+      }
+
+      if (!range) {
+        resetEndOfContent();
+        return;
+      }
+
+      textContainer.classList.add("selecting");
+
+      const isModifyingStart =
+        previousSelectionRange &&
+        (range.compareBoundaryPoints(SelectionRange.END_TO_END, previousSelectionRange) === 0 ||
+          range.compareBoundaryPoints(SelectionRange.START_TO_END, previousSelectionRange) === 0);
+
+      let anchor = isModifyingStart ? range.startContainer : range.endContainer;
+      if (anchor.nodeType === Node.TEXT_NODE) anchor = anchor.parentNode;
+      if (anchor.classList?.contains("highlight")) anchor = anchor.parentNode;
+
+      if (!isModifyingStart && range.endOffset === 0) {
+        while (anchor && anchor !== textContainer && !anchor.previousSibling) {
+          anchor = anchor.parentNode;
+        }
+        if (anchor?.previousSibling) anchor = anchor.previousSibling;
+      }
+
+      const parentTextLayer = anchor?.parentElement?.closest(".textLayer");
+      if (parentTextLayer === textContainer && anchor.parentElement) {
+        endOfContent.style.width = `${Math.ceil(viewport.width)}px`;
+        endOfContent.style.height = `${Math.ceil(viewport.height)}px`;
+        endOfContent.style.userSelect = "text";
+        anchor.parentElement.insertBefore(
+          endOfContent,
+          isModifyingStart ? anchor : anchor.nextSibling,
+        );
+      }
+
+      previousSelectionRange = range.cloneRange();
+    };
+
+    const handleCopy = (event) => {
+      const selection = doc.getSelection();
+      const text = selection ? getSelectedText(selection, textContainer) : "";
+      if (!text || !event.clipboardData) return;
+      event.clipboardData.setData("text/plain", text);
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    textContainer.oncopy = handleCopy;
+    doc.addEventListener("copy", handleCopy, { signal });
 
     // Panning + text selection cursor logic
     let isPanning = false;
@@ -240,7 +431,7 @@ const render = async (page, doc, zoom) => {
         isPanning = false;
         scrollParent = null;
         textContainer.style.cursor = "grab";
-      } else textContainer.classList.remove("selecting");
+      } else resetEndOfContent();
     };
 
     textContainer.onpointerleave = () => {
@@ -251,11 +442,19 @@ const render = async (page, doc, zoom) => {
       }
     };
 
-    doc.addEventListener("selectionchange", () => {
-      const selection = doc.getSelection();
-      if (selection && selection.toString().length > 0) textContainer.style.cursor = "text";
-      else if (!isPanning) textContainer.style.cursor = "grab";
-    });
+    doc.addEventListener(
+      "selectionchange",
+      () => {
+        const selection = doc.getSelection();
+        moveEndOfContent(selection);
+        if (selection && selection.toString().length > 0) textContainer.style.cursor = "text";
+        else if (!isPanning) textContainer.style.cursor = "grab";
+      },
+      { signal },
+    );
+    doc.addEventListener("pointerup", resetEndOfContent, { signal });
+    doc.addEventListener("keyup", resetEndOfContent, { signal });
+    doc.defaultView.addEventListener("blur", resetEndOfContent, { signal });
 
     textContainer.style.cursor = "grab";
   }
@@ -274,7 +473,7 @@ const render = async (page, doc, zoom) => {
     try {
       await new pdfjsLib.AnnotationLayer({
         page,
-        viewport,
+        viewport: viewport.clone({ dontFlip: true }),
         div: annotationDiv,
         linkService,
       }).render({ annotations: await page.getAnnotations() });


### PR DESCRIPTION
## Summary

Fix PDF text selection not working correctly on macOS (issue #600).

## Changes

- **Canvas DPI scaling**: Use `outputScale` transform for Retina displays so the text layer aligns with the rendered canvas
- **Geometric text extraction**: Rewrite `getSelectedText` using TreeWalker + `getBoundingClientRect` sorting for reliable text selection across complex PDF layouts
- **Dynamic endOfContent marker**: Move the selection boundary marker to follow the actual selection range, fixing incomplete selections
- **Custom copy handler**: Override copy to use DOM-based text extraction instead of `selection.toString()`
- **Text layer CSS**: Normalize `letter-spacing` and `word-spacing`; disable annotation layer pointer events during selection
- **Annotation layer**: Add `dontFlip: true` to prevent viewport flipping
- **Text range extraction**: Replace `<br>` with newlines in `getRangeTextWithoutRuby` to preserve line breaks

## Testing

Verified on macOS (Apple Silicon). PDF text selection, copy, and highlight all work correctly.