### PR TITLE
feat(ai): add Atlas Cloud provider

### DIFF
--- a/packages/app-expo/src/components/onboarding/steps/AIPage.tsx
+++ b/packages/app-expo/src/components/onboarding/steps/AIPage.tsx
@@ -29,6 +29,7 @@ const ONBOARDING_ENDPOINT_ID = "onboarding-ai-endpoint";
 
 const PROVIDER_OPTIONS: { id: AIProviderType; name: string }[] = [
   { id: "openai", name: "OpenAI" },
+  { id: "atlascloud", name: "Atlas Cloud" },
   { id: "anthropic", name: "Anthropic" },
   { id: "google", name: "Google Gemini" },
   { id: "deepseek", name: "DeepSeek" },

--- a/packages/app-expo/src/screens/settings/ai/EndpointEditor.tsx
+++ b/packages/app-expo/src/screens/settings/ai/EndpointEditor.tsx
@@ -25,6 +25,7 @@ import { makeStyles } from "./ai-settings-styles";
 
 const PROVIDERS: { id: AIProviderType; label: string }[] = [
   { id: "openai", label: "OpenAI" },
+  { id: "atlascloud", label: "Atlas Cloud" },
   { id: "anthropic", label: "Anthropic" },
   { id: "google", label: "Google Gemini" },
   { id: "deepseek", label: "DeepSeek" },

--- a/packages/app/src/components/onboarding/steps/AIPage.tsx
+++ b/packages/app/src/components/onboarding/steps/AIPage.tsx
@@ -21,6 +21,7 @@ const ONBOARDING_ENDPOINT_ID = "onboarding-ai-endpoint";
 
 const PROVIDER_OPTIONS: { id: AIProviderType; name: string }[] = [
   { id: "openai", name: "OpenAI" },
+  { id: "atlascloud", name: "Atlas Cloud" },
   { id: "anthropic", name: "Anthropic" },
   { id: "google", name: "Google Gemini" },
   { id: "deepseek", name: "DeepSeek" },

--- a/packages/app/src/components/settings/AISettings.tsx
+++ b/packages/app/src/components/settings/AISettings.tsx
@@ -34,6 +34,7 @@ function useProviderOptions(): { value: AIProviderType; label: string }[] {
   const { t } = useTranslation();
   return useMemo(() => [
     { value: "openai", label: "OpenAI" },
+    { value: "atlascloud", label: "Atlas Cloud" },
     { value: "anthropic", label: "Anthropic" },
     { value: "google", label: "Google Gemini" },
     { value: "deepseek", label: "DeepSeek" },

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -124,6 +124,7 @@ export interface SemanticContext {
 
 export type AIProviderType =
   | "openai"
+  | "atlascloud"
   | "anthropic"
   | "google"
   | "deepseek"

--- a/packages/core/src/utils/api.test.ts
+++ b/packages/core/src/utils/api.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildOpenAICompatibleUrl,
   buildProviderModelsUrl,
+  detectProviderFromUrl,
   ensureUrlProtocol,
   formatApiHost,
+  getDefaultBaseUrl,
   isOllamaEmbeddingEndpointUrl,
   normalizeEmbeddingEndpointUrl,
   providerSupportsExactRequestUrl,
@@ -61,6 +63,8 @@ describe("AI API URL helpers", () => {
   });
 
   it("respects providers that should not auto-append /v1", () => {
+    expect(getDefaultBaseUrl("atlascloud")).toBe("https://api.atlascloud.ai/v1");
+    expect(resolveProviderBaseUrl("atlascloud")).toBe("https://api.atlascloud.ai/v1");
     expect(resolveProviderBaseUrl("anthropic", "https://api.anthropic.com")).toBe(
       "https://api.anthropic.com",
     );
@@ -73,12 +77,17 @@ describe("AI API URL helpers", () => {
     expect(buildProviderModelsUrl("openai", "https://api.openai.com")).toBe(
       "https://api.openai.com/v1/models",
     );
+    expect(buildProviderModelsUrl("atlascloud")).toBe("https://api.atlascloud.ai/v1/models");
     expect(buildProviderModelsUrl("ollama", "http://localhost:11434")).toBe(
       "http://localhost:11434/api/tags",
     );
     expect(
       buildProviderModelsUrl("google", "https://generativelanguage.googleapis.com", "AIza-test"),
     ).toBe("https://generativelanguage.googleapis.com/v1beta/models?key=AIza-test");
+  });
+
+  it("detects Atlas Cloud endpoints", () => {
+    expect(detectProviderFromUrl("https://api.atlascloud.ai/v1")).toBe("atlascloud");
   });
 
   describe("ensureUrlProtocol / scheme-less inputs", () => {

--- a/packages/core/src/utils/api.ts
+++ b/packages/core/src/utils/api.ts
@@ -33,6 +33,14 @@ export const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
     placeholder: "https://api.openai.com",
     keyPlaceholder: "sk-...",
   },
+  atlascloud: {
+    id: "atlascloud",
+    name: "Atlas Cloud",
+    defaultBaseUrl: "https://api.atlascloud.ai/v1",
+    needsV1Suffix: false,
+    placeholder: "https://api.atlascloud.ai/v1",
+    keyPlaceholder: "sk-...",
+  },
   deepseek: {
     id: "deepseek",
     name: "DeepSeek",
@@ -536,6 +544,7 @@ export function detectProviderFromUrl(url: string): string {
   if (!url) return "custom";
   const urlLower = url.toLowerCase();
 
+  if (urlLower.includes("api.atlascloud.ai")) return "atlascloud";
   if (urlLower.includes("openai.com")) return "openai";
   if (urlLower.includes("deepseek.com")) return "deepseek";
   if (urlLower.includes("anthropic.com")) return "anthropic";


### PR DESCRIPTION
## Summary

- add Atlas Cloud to the desktop and mobile AI provider selectors
- configure the managed OpenAI-compatible endpoint at `https://api.atlascloud.ai/v1`
- reuse the existing model discovery, connection test, and chat runtime paths
- detect Atlas Cloud endpoints when importing provider settings

## Validation

- focused URL/provider tests: 18 passed
- core test run: 556 passed; one existing PDF timeout and one dependency-layout import failure remained outside this diff
- `git diff --check`
- Atlas Cloud model catalog: 123 models, default model present
- Atlas Cloud live chat: successful non-empty response

No README, public docs, logo, dependency, or lockfile changes.