### PR TITLE
fix(tts): prevent Android voice picker crash

### DIFF
--- a/packages/app-expo/modules/system-tts-synthesis/android/src/main/java/expo/modules/systemttssynthesis/SystemTtsSynthesisModule.kt
+++ b/packages/app-expo/modules/system-tts-synthesis/android/src/main/java/expo/modules/systemttssynthesis/SystemTtsSynthesisModule.kt
@@ -3,6 +3,7 @@ package expo.modules.systemttssynthesis
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import android.speech.tts.Voice
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.modules.Module
@@ -27,6 +28,7 @@ class SystemTtsSynthesisModule : Module() {
 
   private val pendingRequests = ArrayDeque<PendingRequest>()
   private val pendingPromises = mutableMapOf<String, Promise>()
+  private val pendingVoicePromises = ArrayDeque<Promise>()
   private var tts: TextToSpeech? = null
   private var ready = false
   private var failedInit = false
@@ -41,9 +43,23 @@ class SystemTtsSynthesisModule : Module() {
     OnDestroy {
       pendingRequests.clear()
       pendingPromises.clear()
+      pendingVoicePromises.clear()
       tts?.shutdown()
       tts = null
       ready = false
+    }
+
+    AsyncFunction("getVoices") { promise: Promise ->
+      if (failedInit) {
+        promise.resolve(emptyList<Map<String, Any?>>())
+        return@AsyncFunction
+      }
+      ensureTts()
+      if (ready) {
+        promise.resolve(getVoiceRecords())
+      } else {
+        pendingVoicePromises.add(promise)
+      }
     }
 
     AsyncFunction("synthesizeToFile") { text: String, options: SynthesisOptions, promise: Promise ->
@@ -104,7 +120,26 @@ class SystemTtsSynthesisModule : Module() {
         }
       })
 
+      while (pendingVoicePromises.isNotEmpty()) {
+        pendingVoicePromises.removeFirst().resolve(getVoiceRecords())
+      }
+
       flushPendingRequests()
+    }
+  }
+
+  private fun getVoiceRecords(): List<Map<String, Any?>> {
+    return try {
+      tts?.voices?.map { voice ->
+        mapOf(
+          "identifier" to voice.name,
+          "name" to voice.name,
+          "language" to voice.locale.toLanguageTag(),
+          "quality" to if (voice.quality > Voice.QUALITY_NORMAL) "Enhanced" else "Default",
+        )
+      } ?: emptyList()
+    } catch (_: Exception) {
+      emptyList()
     }
   }
 

--- a/packages/app-expo/modules/system-tts-synthesis/index.ts
+++ b/packages/app-expo/modules/system-tts-synthesis/index.ts
@@ -2,6 +2,14 @@ import { NativeModule, requireNativeModule } from "expo";
 import { Platform } from "react-native";
 
 declare class SystemTtsSynthesisModule extends NativeModule {
+  getVoices(): Promise<
+    Array<{
+      identifier: string;
+      name: string;
+      language: string;
+      quality: "Default" | "Enhanced";
+    }>
+  >;
   synthesizeToFile(
     text: string,
     options: {
@@ -14,6 +22,7 @@ declare class SystemTtsSynthesisModule extends NativeModule {
 }
 
 const noop = {
+  getVoices: async () => [],
   synthesizeToFile: async () => {
     throw new Error("SystemTtsSynthesis module is unavailable");
   },

--- a/packages/app-expo/package.json
+++ b/packages/app-expo/package.json
@@ -32,6 +32,7 @@
     "build:reader": "node scripts/build-reader.js",
     "sync:native-variant": "node scripts/configure-native-variant.js",
     "lint": "biome check .",
+    "test": "vitest run",
     "eas-build-pre-install": "bash scripts/eas-install-ios-build-tools.sh",
     "eas-build-post-install": "pnpm run build:reader && node scripts/configure-native-variant.js",
     "eas:device:create": "pnpm exec eas device:create",
@@ -117,6 +118,7 @@
     "eas-cli": "^18.11.0",
     "esbuild": "^0.27.3",
     "react-native-svg-transformer": "^1.5.3",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/app-expo/src/lib/platform/system-voices.ts
+++ b/packages/app-expo/src/lib/platform/system-voices.ts
@@ -1,5 +1,7 @@
 import * as Speech from "expo-speech";
+import { Platform } from "react-native";
 import { compareVoiceLanguage } from "@readany/core/tts";
+import SystemTtsSynthesis from "../../../modules/system-tts-synthesis";
 
 export const DEFAULT_SYSTEM_VOICE_VALUE = "__default__";
 
@@ -12,7 +14,14 @@ export interface NativeSystemVoiceOption {
 
 export async function getSystemVoiceOptionsAsync(): Promise<NativeSystemVoiceOption[]> {
   try {
-    const voices = await Speech.getAvailableVoicesAsync();
+    // On Android, expo-speech creates a separate TextToSpeech instance for
+    // getAvailableVoicesAsync(). Some vendor engines (notably ColorOS) crash
+    // in that second instance's onInit callback while another TTS is active.
+    // Reuse the app's synthesis module instead.
+    const voices =
+      Platform.OS === "android"
+        ? await SystemTtsSynthesis.getVoices()
+        : await Speech.getAvailableVoicesAsync();
     const deduped = new Map<string, NativeSystemVoiceOption>();
     for (const voice of voices) {
       const option = {

--- a/packages/app-expo/src/lib/platform/track-player-cloud-tts-player.test.ts
+++ b/packages/app-expo/src/lib/platform/track-player-cloud-tts-player.test.ts
@@ -1,0 +1,55 @@
+import { DEFAULT_TTS_CONFIG } from "@readany/core/tts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchXiaomiTTSWav, stop, reset } = vi.hoisted(() => ({
+  fetchXiaomiTTSWav: vi.fn(),
+  stop: vi.fn(() => Promise.resolve()),
+  reset: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@readany/core/tts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@readany/core/tts")>()),
+  fetchXiaomiTTSWav,
+}));
+vi.mock("expo-file-system", () => ({
+  File: class {},
+  Paths: { cache: "/cache" },
+}));
+vi.mock("react-native", () => ({
+  Image: { resolveAssetSource: () => ({ uri: "icon" }) },
+}));
+vi.mock("react-native-track-player", () => ({
+  default: {
+    stop,
+    reset,
+    addEventListener: vi.fn(() => ({ remove: vi.fn() })),
+  },
+  Event: {},
+  State: {},
+}));
+
+const { TrackPlayerCloudTTSPlayer } = await import("./track-player-cloud-tts-player");
+
+describe("TrackPlayerCloudTTSPlayer provider failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchXiaomiTTSWav.mockRejectedValue(new Error("invalid API key"));
+  });
+
+  it("reports the first synthesis failure without treating it as natural completion", async () => {
+    const player = new TrackPlayerCloudTTSPlayer();
+    const onError = vi.fn();
+    const onEnd = vi.fn();
+    player.onError = onError;
+    player.onEnd = onEnd;
+
+    await player.speak("first segment", {
+      ...DEFAULT_TTS_CONFIG,
+      engine: "xiaomi",
+      xiaomiApiKey: "bad-key",
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onEnd).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-expo/src/lib/platform/track-player-cloud-tts-player.ts
+++ b/packages/app-expo/src/lib/platform/track-player-cloud-tts-player.ts
@@ -34,6 +34,7 @@ function extensionForConfig(config: TTSConfig): string {
 export class TrackPlayerCloudTTSPlayer implements ITTSPlayer {
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
   onChunkChange?: (index: number, total: number) => void;
+  onError?: (error: Error) => void;
   onEnd?: () => void;
 
   private _stopped = true;
@@ -174,7 +175,7 @@ export class TrackPlayerCloudTTSPlayer implements ITTSPlayer {
     } catch (error) {
       if ((error as Error)?.message === "aborted" || isTTSAbortError(error)) return;
       console.warn("[TrackPlayerCloudTTSPlayer] chunk error:", error);
-      await this._skipFailedChunk(index, gen);
+      this._failPlayback(error);
     }
   }
 
@@ -223,16 +224,6 @@ export class TrackPlayerCloudTTSPlayer implements ITTSPlayer {
     if (!this._endWatchdog) return;
     clearInterval(this._endWatchdog);
     this._endWatchdog = null;
-  }
-
-  private async _skipFailedChunk(index: number, gen: number): Promise<void> {
-    if (gen !== this._speakGen || this._stopped || this._paused) return;
-    const next = index + 1;
-    if (next >= this._chunks.length) {
-      this._finishPlayback();
-      return;
-    }
-    await this._playChunk(next, gen);
   }
 
   private _prefetchUpcomingChunks(index: number, gen: number): void {
@@ -326,6 +317,18 @@ export class TrackPlayerCloudTTSPlayer implements ITTSPlayer {
     this._cleanupEvents();
     this.onStateChange?.("stopped");
     this.onEnd?.();
+  }
+
+  private _failPlayback(error: unknown): void {
+    if (this._stopped) return;
+    this._stopped = true;
+    this._paused = false;
+    this._clearEndWatchdog();
+    this._cleanupEvents();
+    TrackPlayer.stop().catch(() => {});
+    TrackPlayer.reset().catch(() => {});
+    this.onStateChange?.("stopped");
+    this.onError?.(error instanceof Error ? error : new Error(String(error)));
   }
 
   private async _cleanup(): Promise<void> {

--- a/packages/app-expo/src/lib/platform/track-player-dashscope-player.ts
+++ b/packages/app-expo/src/lib/platform/track-player-dashscope-player.ts
@@ -27,6 +27,7 @@ export class TrackPlayerDashScopeTTSPlayer implements ITTSPlayer {
 
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
   onChunkChange?: (index: number, total: number) => void;
+  onError?: (error: Error) => void;
   onEnd?: () => void;
 
   private _stopped = false;
@@ -66,15 +67,13 @@ export class TrackPlayerDashScopeTTSPlayer implements ITTSPlayer {
     await this._cleanup();
     if (gen !== this._speakGen) return;
 
+    this._stopped = false;
+    this._paused = false;
     if (!config.dashscopeApiKey) {
-      console.warn("[TrackPlayerDashScopeTTSPlayer] No API key provided");
-      this.onStateChange?.("stopped");
-      this.onEnd?.();
+      this._failPlayback(new Error("DashScope API key is required"));
       return;
     }
 
-    this._stopped = false;
-    this._paused = false;
     this._config = config;
     this._downloadComplete = false;
     this._retryCount = 0;
@@ -182,8 +181,7 @@ export class TrackPlayerDashScopeTTSPlayer implements ITTSPlayer {
           TrackPlayer.retry().catch(() => {});
         } else {
           console.error("[TrackPlayerDashScopeTTSPlayer] playback error, max retries reached");
-          this._stopped = true;
-          this.onStateChange?.("stopped");
+          this._failPlayback(new Error("DashScope playback failed after retries"));
         }
       } else if (event.state === State.Ended || event.state === State.Stopped) {
         this._handlePlaybackEnded(gen);
@@ -274,8 +272,7 @@ export class TrackPlayerDashScopeTTSPlayer implements ITTSPlayer {
     } catch (err) {
       if (!this._stopped && (err as Error)?.message !== "aborted") {
         console.error("[TrackPlayerDashScopeTTSPlayer] download error:", err);
-        this._stopped = true;
-        this.onStateChange?.("stopped");
+        this._failPlayback(err);
       }
     }
   }
@@ -629,6 +626,16 @@ export class TrackPlayerDashScopeTTSPlayer implements ITTSPlayer {
     this._stopProgressPolling();
     this.onStateChange?.("stopped");
     this.onEnd?.();
+  }
+
+  private _failPlayback(error: unknown): void {
+    if (this._stopped) return;
+    this._stopped = true;
+    this._paused = false;
+    this._queueStarved = false;
+    this._stopProgressPolling();
+    this.onStateChange?.("stopped");
+    this.onError?.(error instanceof Error ? error : new Error(String(error)));
   }
 
   private async _fetchChunkFile(index: number, gen: number): Promise<string> {

--- a/packages/app-expo/src/stores/tts-store.test.ts
+++ b/packages/app-expo/src/stores/tts-store.test.ts
@@ -1,0 +1,94 @@
+import { DEFAULT_TTS_CONFIG, type ITTSPlayer } from "@readany/core/tts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-native", () => ({ Platform: { OS: "ios" } }));
+vi.mock("react-native-track-player", () => ({
+  default: {
+    getActiveTrackIndex: vi.fn(() => Promise.resolve(undefined)),
+    updateMetadataForTrack: vi.fn(() => Promise.resolve()),
+  },
+}));
+vi.mock("./persist", () => ({
+  withPersist: (_key: string, creator: unknown) => creator,
+}));
+vi.mock("../lib/platform/system-tts-synthesis", () => ({
+  canUseSystemTtsSynthesis: () => true,
+}));
+vi.mock("../lib/platform/expo-speech-player", () => ({ ExpoSpeechTTSPlayer: class {} }));
+vi.mock("../lib/platform/track-player-system-player", () => ({
+  TrackPlayerSystemTTSPlayer: class {},
+}));
+vi.mock("../lib/platform/track-player-edge-player", () => ({
+  TrackPlayerEdgeTTSPlayer: class {},
+}));
+vi.mock("../lib/platform/track-player-dashscope-player", () => ({
+  TrackPlayerDashScopeTTSPlayer: class {},
+}));
+vi.mock("../lib/platform/track-player-cloud-tts-player", () => ({
+  TrackPlayerCloudTTSPlayer: class {},
+}));
+
+const { setTTSPlayerFactories, useTTSStore } = await import("./tts-store");
+
+type MockPlayer = ITTSPlayer & {
+  speak: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  onError?: (error: Error) => void;
+};
+
+function createPlayer(): MockPlayer {
+  const player = {
+    speak: vi.fn(() => player.onStateChange?.("playing")),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(() => {
+      player.onStateChange?.("stopped");
+      player.onEnd?.();
+    }),
+  } as MockPlayer;
+  return player;
+}
+
+describe("Expo TTS provider failures", () => {
+  let systemPlayer: MockPlayer;
+  let dashscopePlayer: MockPlayer;
+
+  beforeEach(() => {
+    systemPlayer = createPlayer();
+    dashscopePlayer = createPlayer();
+    setTTSPlayerFactories({
+      createSystemTTS: () => systemPlayer,
+      createDashScopeTTS: () => dashscopePlayer,
+    });
+    useTTSStore.setState({
+      config: DEFAULT_TTS_CONFIG,
+      playState: "stopped",
+      currentText: "",
+      currentSegmentText: "",
+      onEnd: null,
+    });
+    useTTSStore.getState().stop();
+    vi.clearAllMocks();
+  });
+
+  it("uses the DashScope player even when its API key is missing", () => {
+    useTTSStore.getState().updateConfig({ engine: "dashscope", dashscopeApiKey: "" });
+
+    useTTSStore.getState().play("test sentence");
+
+    expect(dashscopePlayer.speak).toHaveBeenCalledOnce();
+    expect(systemPlayer.speak).not.toHaveBeenCalled();
+  });
+
+  it("stops on a provider error without firing the reader onEnd", () => {
+    const onEnd = vi.fn();
+    useTTSStore.getState().updateConfig({ engine: "dashscope", dashscopeApiKey: "key" });
+    useTTSStore.getState().setOnEnd(onEnd);
+    useTTSStore.getState().play(["first", "second"]);
+
+    dashscopePlayer.onError?.(new Error("request failed"));
+
+    expect(onEnd).not.toHaveBeenCalled();
+    expect(useTTSStore.getState().playState).toBe("stopped");
+  });
+});

--- a/packages/app-expo/src/stores/tts-store.ts
+++ b/packages/app-expo/src/stores/tts-store.ts
@@ -117,6 +117,7 @@ function detachAndStopPlayer(player: ITTSPlayer | null): void {
   if (!player) return;
   player.onStateChange = undefined;
   player.onChunkChange = undefined;
+  player.onError = undefined;
   player.onEnd = undefined;
   try {
     player.stop();
@@ -204,7 +205,7 @@ function syncProfileUpdatesFromLegacyFields(
 }
 
 function getPlayerForConfig(config: TTSConfig): ITTSPlayer {
-  if (config.engine === "dashscope" && config.dashscopeApiKey) {
+  if (config.engine === "dashscope") {
     return getDashScopeTTS();
   }
   if (config.engine === "edge") {
@@ -288,6 +289,13 @@ function startPlayback(
       totalChunks: _sessionSegments.length,
       currentSegmentText: _sessionSegments[absoluteIndex] || "",
     });
+  };
+
+  player.onError = (error) => {
+    if (gen !== _sessionGeneration) return;
+    console.error("[TTSStore][player] error", error);
+    _activeTTS = null;
+    set({ playState: "stopped" });
   };
 
   player.onEnd = () => {

--- a/packages/core/src/tts/types.ts
+++ b/packages/core/src/tts/types.ts
@@ -406,6 +406,8 @@ export interface ITTSPlayer {
 
   onStateChange?: (state: "playing" | "paused" | "stopped") => void;
   onChunkChange?: (index: number, total: number) => void;
+  /** Called when playback cannot continue. Must not be followed by onEnd. */
+  onError?: (error: Error) => void;
   /** Called when all chunks finish playing naturally (not by stop()) */
   onEnd?: () => void;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.2)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.8.2))
 
   packages/cli:
     dependencies:


### PR DESCRIPTION
## Summary
- Reuse the existing Android system TTS instance when loading voice options, avoiding a ColorOS `TextToSpeech.onInit` crash caused by a second instance.
- Report cloud TTS synthesis failures without treating them as natural completion, preventing rapid paragraph/page advancement.
- Add provider failure regression tests and the Expo Vitest test setup.

## Root cause
On the affected ColorOS device, opening the TTS engine/voice picker called `expo-speech.getAvailableVoicesAsync()`, which initialized a second Android `TextToSpeech` instance and crashed with a main-thread `NullPointerException` inside the vendor TTS engine.

## Verification
- Expo Vitest: 3/3 tests passed
- Core TTS Vitest: 47/47 tests passed
- Expo TypeScript check passed
- Android Release APK built and tested on a physical ColorOS device