### PR TITLE
fix: keep mobile inputs visible above keyboard

### DIFF
--- a/packages/app-expo/package.json
+++ b/packages/app-expo/package.json
@@ -94,6 +94,7 @@
     "react-native": "~0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-markdown-display": "^7.0.2",
     "react-native-qrcode-svg": "^6.3.21",
     "react-native-reanimated": "4.1.1",

--- a/packages/app-expo/src/App.tsx
+++ b/packages/app-expo/src/App.tsx
@@ -28,6 +28,7 @@ import { StatusBar } from "expo-status-bar";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { LogBox, Platform, Text, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import { AnimatedSplash } from "@/components/splash/AnimatedSplash";
@@ -274,14 +275,16 @@ function AppInner() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: colors.background }}>
-      <SafeAreaProvider>
-        <NavigationContainer theme={navTheme} ref={navigationRef}>
-          <StatusBar style={mode === "dark" ? "light" : "dark"} />
-          <RootNavigator />
-        </NavigationContainer>
-        <UpdateDialog />
-        <FloatingTTSBubble />
-      </SafeAreaProvider>
+      <KeyboardProvider>
+        <SafeAreaProvider>
+          <NavigationContainer theme={navTheme} ref={navigationRef}>
+            <StatusBar style={mode === "dark" ? "light" : "dark"} />
+            <RootNavigator />
+          </NavigationContainer>
+          <UpdateDialog />
+          <FloatingTTSBubble />
+        </SafeAreaProvider>
+      </KeyboardProvider>
     </GestureHandlerRootView>
   );
 }

--- a/packages/app-expo/src/components/library/GroupPickerSheet.tsx
+++ b/packages/app-expo/src/components/library/GroupPickerSheet.tsx
@@ -4,16 +4,16 @@ import type { BookGroup } from "@readany/core/types";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  KeyboardAvoidingView,
   Modal,
-  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface GroupPickerSheetProps {
@@ -56,19 +56,18 @@ export function GroupPickerSheet({
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <Pressable style={styles.overlay} onPress={onClose}>
-        <KeyboardAvoidingView
-          style={styles.keyboardWrap}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-        >
+      <KeyboardAvoidingView style={styles.keyboardRoot} behavior="height">
+        <Pressable style={styles.overlay} onPress={onClose}>
           <Pressable style={styles.sheet} onPress={(event) => event.stopPropagation()}>
             <View style={styles.handle} />
-            <Text style={styles.title}>
-              {t("library.moveToGroup", "移入分组")}
-            </Text>
+            <Text style={styles.title}>{t("library.moveToGroup", "移入分组")}</Text>
 
             {groups.length > 0 && (
-              <View style={styles.groupList}>
+              <ScrollView
+                style={styles.groupList}
+                keyboardShouldPersistTaps="handled"
+                nestedScrollEnabled
+              >
                 {groups.map((group) => (
                   <TouchableOpacity
                     key={group.id}
@@ -79,7 +78,7 @@ export function GroupPickerSheet({
                     <Text style={styles.groupName}>{group.name}</Text>
                   </TouchableOpacity>
                 ))}
-              </View>
+              </ScrollView>
             )}
 
             {isCreating ? (
@@ -109,9 +108,7 @@ export function GroupPickerSheet({
                 onPress={() => setIsCreating(true)}
               >
                 <FolderPlusIcon size={20} color={colors.primary} />
-                <Text style={styles.newGroupText}>
-                  {t("library.createGroup", "新建分组")}
-                </Text>
+                <Text style={styles.newGroupText}>{t("library.createGroup", "新建分组")}</Text>
               </TouchableOpacity>
             )}
 
@@ -121,14 +118,12 @@ export function GroupPickerSheet({
                 activeOpacity={0.7}
                 onPress={() => handleSelect(undefined)}
               >
-                <Text style={styles.ungroupedText}>
-                  {t("library.removeFromGroup", "移出分组")}
-                </Text>
+                <Text style={styles.ungroupedText}>{t("library.removeFromGroup", "移出分组")}</Text>
               </TouchableOpacity>
             )}
           </Pressable>
-        </KeyboardAvoidingView>
-      </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
@@ -148,15 +143,12 @@ const makeStyles = (colors: ThemeColors, bottomInset: number) =>
       paddingBottom: Math.max(34, bottomInset + 18),
       paddingHorizontal: spacing.lg,
     },
-    keyboardWrap: {
-      width: "100%",
-      justifyContent: "flex-end",
-    },
+    keyboardRoot: { flex: 1 },
     handle: {
       width: 36,
       height: 4,
       borderRadius: 2,
-      backgroundColor: colors.mutedForeground + "40",
+      backgroundColor: `${colors.mutedForeground}40`,
       alignSelf: "center",
       marginBottom: spacing.md,
     },
@@ -168,6 +160,7 @@ const makeStyles = (colors: ThemeColors, bottomInset: number) =>
       paddingHorizontal: 4,
     },
     groupList: {
+      maxHeight: 280,
       borderRadius: radius.lg,
       borderWidth: 1,
       borderColor: colors.border,

--- a/packages/app-expo/src/components/tts/TTSSleepTimerSheet.tsx
+++ b/packages/app-expo/src/components/tts/TTSSleepTimerSheet.tsx
@@ -5,8 +5,11 @@ import { fontSize, fontWeight, radius, useColors, withOpacity } from "@/styles/t
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -70,6 +73,7 @@ export function TTSSleepTimerSheet({ visible, onClose }: TTSSleepTimerSheetProps
           backgroundColor: "rgba(0,0,0,0.36)",
           justifyContent: "flex-end",
         },
+        keyboardRoot: { flex: 1 },
         sheet: {
           backgroundColor: colors.background,
           borderTopLeftRadius: 24,
@@ -77,8 +81,9 @@ export function TTSSleepTimerSheet({ visible, onClose }: TTSSleepTimerSheetProps
           paddingHorizontal: 20,
           paddingTop: 12,
           paddingBottom: Math.max(insets.bottom, 16) + 12,
-          gap: 16,
+          maxHeight: "90%",
         },
+        sheetContent: { gap: 16 },
         handle: {
           alignSelf: "center",
           width: 36,
@@ -206,90 +211,102 @@ export function TTSSleepTimerSheet({ visible, onClose }: TTSSleepTimerSheetProps
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <Pressable style={s.overlay} onPress={onClose}>
-        <Pressable
-          style={[
-            s.sheet,
-            layout.isTablet && {
-              width: "100%",
-            },
-          ]}
-          onPress={(event) => event.stopPropagation()}
-        >
-          <View style={s.handle} />
-          <View style={s.header}>
-            <ClockIcon size={18} color={colors.primary} />
-            <View>
-              <Text style={s.title}>{t("tts.sleepTimer", "定时停止")}</Text>
-              <Text style={s.subtitle}>
-                {t("tts.sleepTimerSubtitle", "让朗读在你设定的时间后自动停止")}
-              </Text>
-            </View>
-          </View>
+      <KeyboardAvoidingView
+        style={s.keyboardRoot}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <Pressable style={s.overlay} onPress={onClose}>
+          <Pressable
+            style={[
+              s.sheet,
+              layout.isTablet && {
+                width: "100%",
+              },
+            ]}
+            onPress={(event) => event.stopPropagation()}
+          >
+            <ScrollView
+              contentContainerStyle={s.sheetContent}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={s.handle} />
+              <View style={s.header}>
+                <ClockIcon size={18} color={colors.primary} />
+                <View>
+                  <Text style={s.title}>{t("tts.sleepTimer", "定时停止")}</Text>
+                  <Text style={s.subtitle}>
+                    {t("tts.sleepTimerSubtitle", "让朗读在你设定的时间后自动停止")}
+                  </Text>
+                </View>
+              </View>
 
-          {sleepTimerEndsAt ? (
-            <View style={s.current}>
-              <Text style={s.currentLabel}>{t("tts.sleepTimerActive", "已开启睡眠定时")}</Text>
-              <Text style={s.currentValue}>
-                {remainingLabel
-                  ? t("tts.sleepTimerRemaining", {
-                      time: remainingLabel,
-                      defaultValue: `Remaining ${remainingLabel}`,
-                    })
-                  : t("tts.sleepTimerSoon", "即将停止")}
-              </Text>
-            </View>
-          ) : null}
+              {sleepTimerEndsAt ? (
+                <View style={s.current}>
+                  <Text style={s.currentLabel}>{t("tts.sleepTimerActive", "已开启睡眠定时")}</Text>
+                  <Text style={s.currentValue}>
+                    {remainingLabel
+                      ? t("tts.sleepTimerRemaining", {
+                          time: remainingLabel,
+                          defaultValue: `Remaining ${remainingLabel}`,
+                        })
+                      : t("tts.sleepTimerSoon", "即将停止")}
+                  </Text>
+                </View>
+              ) : null}
 
-          <View style={s.presets}>
-            {PRESET_MINUTES.map((minutes) => (
-              <TouchableOpacity
-                key={minutes}
-                style={s.presetBtn}
-                onPress={() => {
-                  setSleepTimer(minutes);
-                  onClose();
-                }}
-              >
-                <Text style={s.presetBtnText}>
-                  {t("tts.sleepTimerPresetShort", { minutes, defaultValue: `${minutes} 分钟` })}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
+              <View style={s.presets}>
+                {PRESET_MINUTES.map((minutes) => (
+                  <TouchableOpacity
+                    key={minutes}
+                    style={s.presetBtn}
+                    onPress={() => {
+                      setSleepTimer(minutes);
+                      onClose();
+                    }}
+                  >
+                    <Text style={s.presetBtnText}>
+                      {t("tts.sleepTimerPresetShort", { minutes, defaultValue: `${minutes} 分钟` })}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
 
-          <View style={s.inputRow}>
-            <TextInput
-              style={s.input}
-              keyboardType="number-pad"
-              value={customMinutes}
-              onChangeText={setCustomMinutes}
-              placeholder={t("tts.sleepTimerCustomPlaceholder", "自定义分钟数")}
-              placeholderTextColor={colors.mutedForeground}
-            />
-            <TouchableOpacity style={s.applyBtn} onPress={applyCustomMinutes}>
-              <Text style={s.applyBtnText}>{t("tts.sleepTimerApply", "开始计时")}</Text>
-            </TouchableOpacity>
-          </View>
+              <View style={s.inputRow}>
+                <TextInput
+                  style={s.input}
+                  keyboardType="number-pad"
+                  value={customMinutes}
+                  onChangeText={setCustomMinutes}
+                  placeholder={t("tts.sleepTimerCustomPlaceholder", "自定义分钟数")}
+                  placeholderTextColor={colors.mutedForeground}
+                />
+                <TouchableOpacity style={s.applyBtn} onPress={applyCustomMinutes}>
+                  <Text style={s.applyBtnText}>{t("tts.sleepTimerApply", "开始计时")}</Text>
+                </TouchableOpacity>
+              </View>
 
-          <View style={s.footer}>
-            {sleepTimerEndsAt ? (
-              <TouchableOpacity
-                style={s.ghostBtn}
-                onPress={() => {
-                  clearSleepTimer();
-                  onClose();
-                }}
-              >
-                <Text style={s.ghostBtnText}>{t("tts.sleepTimerCancel", "关闭定时")}</Text>
-              </TouchableOpacity>
-            ) : null}
-            <TouchableOpacity style={s.ghostBtn} onPress={onClose}>
-              <Text style={s.ghostBtnText}>{t("common.cancel", "取消")}</Text>
-            </TouchableOpacity>
-          </View>
+              <View style={s.footer}>
+                {sleepTimerEndsAt ? (
+                  <TouchableOpacity
+                    style={s.ghostBtn}
+                    onPress={() => {
+                      clearSleepTimer();
+                      onClose();
+                    }}
+                  >
+                    <Text style={s.ghostBtnText}>{t("tts.sleepTimerCancel", "关闭定时")}</Text>
+                  </TouchableOpacity>
+                ) : null}
+                <TouchableOpacity style={s.ghostBtn} onPress={onClose}>
+                  <Text style={s.ghostBtnText}>{t("common.cancel", "取消")}</Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/packages/app-expo/src/components/ui/KeyboardAwareScrollView.tsx
+++ b/packages/app-expo/src/components/ui/KeyboardAwareScrollView.tsx
@@ -1,60 +1,43 @@
-import { useKeyboardInsets } from "@/hooks/use-keyboard-insets";
+import { StyleSheet, type ViewStyle } from "react-native";
 import {
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  type ScrollViewProps,
-  type StyleProp,
-  StyleSheet,
-  type ViewStyle,
-} from "react-native";
+  KeyboardAwareScrollView as ControllerKeyboardAwareScrollView,
+  type KeyboardAwareScrollViewProps as ControllerKeyboardAwareScrollViewProps,
+} from "react-native-keyboard-controller";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { spacing } from "../../styles/theme";
 
-interface KeyboardAwareScrollViewProps extends ScrollViewProps {
-  keyboardViewStyle?: StyleProp<ViewStyle>;
+interface KeyboardAwareScrollViewProps extends ControllerKeyboardAwareScrollViewProps {
   contentBottomInset?: number;
-  keyboardVerticalOffset?: number;
 }
 
 export function KeyboardAwareScrollView({
   children,
-  keyboardViewStyle,
   contentContainerStyle,
   contentBottomInset = spacing.xl,
-  keyboardVerticalOffset = 0,
+  bottomOffset = spacing.md,
   keyboardShouldPersistTaps = "handled",
   keyboardDismissMode = "on-drag",
   ...props
 }: KeyboardAwareScrollViewProps) {
-  const keyboardInsets = useKeyboardInsets();
+  const safeAreaInsets = useSafeAreaInsets();
   const flattenedContent = StyleSheet.flatten(contentContainerStyle) as ViewStyle | undefined;
   const existingPaddingBottom =
     typeof flattenedContent?.paddingBottom === "number" ? flattenedContent.paddingBottom : 0;
-  const bottomInset =
-    keyboardInsets.safeAreaBottom + (keyboardInsets.isVisible ? keyboardInsets.bottomInset : 0);
 
   return (
-    <KeyboardAvoidingView
-      style={[styles.keyboardView, keyboardViewStyle]}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-      keyboardVerticalOffset={keyboardVerticalOffset}
+    <ControllerKeyboardAwareScrollView
+      {...props}
+      bottomOffset={bottomOffset}
+      contentContainerStyle={[
+        contentContainerStyle,
+        {
+          paddingBottom: existingPaddingBottom + contentBottomInset + safeAreaInsets.bottom,
+        },
+      ]}
+      keyboardDismissMode={keyboardDismissMode}
+      keyboardShouldPersistTaps={keyboardShouldPersistTaps}
     >
-      <ScrollView
-        {...props}
-        automaticallyAdjustKeyboardInsets={false}
-        contentContainerStyle={[
-          contentContainerStyle,
-          { paddingBottom: existingPaddingBottom + contentBottomInset + bottomInset },
-        ]}
-        keyboardDismissMode={keyboardDismissMode}
-        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-      >
-        {children}
-      </ScrollView>
-    </KeyboardAvoidingView>
+      {children}
+    </ControllerKeyboardAwareScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  keyboardView: { flex: 1 },
-});

--- a/packages/app-expo/src/components/ui/RichTextEditor.tsx
+++ b/packages/app-expo/src/components/ui/RichTextEditor.tsx
@@ -19,7 +19,9 @@ import { radius, useColors } from "@/styles/theme";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -265,44 +267,49 @@ export function RichTextEditor({
         animationType="fade"
         onRequestClose={() => setShowLinkModal(false)}
       >
-        <View style={styles.modalOverlay}>
-          <View style={styles.linkModal}>
-            <View style={styles.linkModalHeader}>
-              <Text style={styles.linkModalTitle}>{t("common.insertLink", "插入链接")}</Text>
-              <TouchableOpacity onPress={() => setShowLinkModal(false)}>
-                <XIcon size={20} color={colors.mutedForeground} />
-              </TouchableOpacity>
-            </View>
-            <TextInput
-              style={styles.linkInput}
-              value={linkText}
-              onChangeText={setLinkText}
-              placeholder={t("common.linkText", "链接文字")}
-              placeholderTextColor={colors.mutedForeground}
-            />
-            <TextInput
-              style={styles.linkInput}
-              value={linkUrl}
-              onChangeText={setLinkUrl}
-              placeholder={t("common.enterLinkUrl", "输入链接地址")}
-              placeholderTextColor={colors.mutedForeground}
-              autoCapitalize="none"
-              autoCorrect={false}
-              keyboardType="url"
-            />
-            <View style={styles.linkModalActions}>
-              <TouchableOpacity
-                style={styles.linkCancelBtn}
-                onPress={() => setShowLinkModal(false)}
-              >
-                <Text style={styles.linkCancelText}>{t("common.cancel", "取消")}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.linkConfirmBtn} onPress={handleInsertLink}>
-                <Text style={styles.linkConfirmText}>{t("common.confirm", "确定")}</Text>
-              </TouchableOpacity>
+        <KeyboardAvoidingView
+          style={styles.modalKeyboardRoot}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
+          <View style={styles.modalOverlay}>
+            <View style={styles.linkModal}>
+              <View style={styles.linkModalHeader}>
+                <Text style={styles.linkModalTitle}>{t("common.insertLink", "插入链接")}</Text>
+                <TouchableOpacity onPress={() => setShowLinkModal(false)}>
+                  <XIcon size={20} color={colors.mutedForeground} />
+                </TouchableOpacity>
+              </View>
+              <TextInput
+                style={styles.linkInput}
+                value={linkText}
+                onChangeText={setLinkText}
+                placeholder={t("common.linkText", "链接文字")}
+                placeholderTextColor={colors.mutedForeground}
+              />
+              <TextInput
+                style={styles.linkInput}
+                value={linkUrl}
+                onChangeText={setLinkUrl}
+                placeholder={t("common.enterLinkUrl", "输入链接地址")}
+                placeholderTextColor={colors.mutedForeground}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="url"
+              />
+              <View style={styles.linkModalActions}>
+                <TouchableOpacity
+                  style={styles.linkCancelBtn}
+                  onPress={() => setShowLinkModal(false)}
+                >
+                  <Text style={styles.linkCancelText}>{t("common.cancel", "取消")}</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.linkConfirmBtn} onPress={handleInsertLink}>
+                  <Text style={styles.linkConfirmText}>{t("common.confirm", "确定")}</Text>
+                </TouchableOpacity>
+              </View>
             </View>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       </Modal>
     </View>
   );
@@ -409,6 +416,7 @@ const makeStyles = (colors: ReturnType<typeof useColors>) =>
       fontSize: 15,
       lineHeight: 24,
     },
+    modalKeyboardRoot: { flex: 1 },
     modalOverlay: {
       flex: 1,
       backgroundColor: "rgba(0,0,0,0.5)",

--- a/packages/app-expo/src/screens/BookDetailsScreen.tsx
+++ b/packages/app-expo/src/screens/BookDetailsScreen.tsx
@@ -6,7 +6,7 @@ import {
   PlusIcon,
   Trash2Icon,
 } from "@/components/ui/Icon";
-import { useKeyboardInsets } from "@/hooks/use-keyboard-insets";
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
 import { extractLocalBookMetadata } from "@/lib/book/auto-metadata";
 import type { RootStackParamList } from "@/navigation/RootNavigator";
@@ -47,7 +47,6 @@ import {
   Modal,
   Platform,
   Pressable,
-  ScrollView,
   type StyleProp,
   StyleSheet,
   Text,
@@ -56,6 +55,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 type Props = NativeStackScreenProps<RootStackParamList, "BookDetails">;
@@ -279,7 +279,6 @@ export function BookDetailsScreen({ route }: Props) {
   const layout = useResponsiveLayout();
   const { t, i18n } = useTranslation();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const keyboardInsets = useKeyboardInsets();
   const books = useLibraryStore((state) => state.books);
   const groups = useLibraryStore((state) => state.groups);
   const allTags = useLibraryStore((state) => state.allTags);
@@ -512,15 +511,12 @@ export function BookDetailsScreen({ route }: Props) {
     >
       <SettingsHeader title={t("library.detailsTitle", "书籍详情")} />
       <View style={styles.flex}>
-        <ScrollView
+        <KeyboardAwareScrollView
           style={styles.flex}
-          automaticallyAdjustKeyboardInsets={false}
           contentContainerStyle={[
             styles.scrollContent,
             { maxWidth: layout.centeredContentWidth, alignSelf: "center" },
-            keyboardInsets.isVisible ? { paddingBottom: 64 + keyboardInsets.bottomInset } : null,
           ]}
-          keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
         >
           <View style={styles.heroStage}>
@@ -782,7 +778,7 @@ export function BookDetailsScreen({ route }: Props) {
               colors={colors}
             />
           )}
-        </ScrollView>
+        </KeyboardAwareScrollView>
       </View>
       <TextEditSheet
         target={textEditorTarget}
@@ -1301,7 +1297,6 @@ function TextEditSheet({
 }) {
   const [draft, setDraft] = useState("");
   const inputRef = useRef<TextInput>(null);
-  const keyboardInsets = useKeyboardInsets();
   const multiline = Boolean(target && (target.kind !== "field" || target.multiline));
 
   useEffect(() => {
@@ -1321,7 +1316,7 @@ function TextEditSheet({
 
   return (
     <Modal visible={Boolean(target)} transparent animationType="slide" onRequestClose={onClose}>
-      <View style={[styles.sheetRoot, { paddingBottom: keyboardInsets.bottomInset }]}>
+      <KeyboardAvoidingView behavior="padding" style={styles.sheetRoot}>
         <Pressable style={styles.sheetOverlay} onPress={onClose} />
         <View style={[styles.textSheet, multiline && styles.textSheetTall]}>
           <View style={styles.sheetHandle} />
@@ -1358,7 +1353,7 @@ function TextEditSheet({
             }}
           />
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/packages/app-expo/src/screens/LibraryScreen.tsx
+++ b/packages/app-expo/src/screens/LibraryScreen.tsx
@@ -74,6 +74,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { TagManagementSheet } from "./library/TagManagementSheet";
 import { useBookDownload } from "./library/useBookDownload";
@@ -1103,36 +1104,41 @@ export function LibraryScreen() {
         animationType="fade"
         onRequestClose={() => setGroupNameModal(null)}
       >
-        <Pressable style={s.groupModalOverlay} onPress={() => setGroupNameModal(null)}>
-          <Pressable style={s.groupModalCard} onPress={() => {}}>
-            <Text style={s.groupModalTitle}>
-              {groupNameModal?.mode === "rename"
-                ? t("common.rename", "重命名")
-                : t("library.createGroup", "新建分组")}
-            </Text>
-            <TextInput
-              style={s.groupModalInput}
-              value={groupNameInput}
-              onChangeText={setGroupNameInput}
-              placeholder={t("library.groupNamePrompt", "分组名称")}
-              placeholderTextColor={colors.mutedForeground}
-              autoFocus
-              returnKeyType="done"
-              onSubmitEditing={() => void submitGroupName()}
-            />
-            <View style={s.groupModalActions}>
-              <TouchableOpacity
-                style={s.groupModalSecondary}
-                onPress={() => setGroupNameModal(null)}
-              >
-                <Text style={s.groupModalSecondaryText}>{t("common.cancel", "取消")}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity style={s.groupModalPrimary} onPress={() => void submitGroupName()}>
-                <Text style={s.groupModalPrimaryText}>{t("common.confirm", "确定")}</Text>
-              </TouchableOpacity>
-            </View>
+        <KeyboardAvoidingView style={s.groupModalKeyboardRoot} behavior="height">
+          <Pressable style={s.groupModalOverlay} onPress={() => setGroupNameModal(null)}>
+            <Pressable style={s.groupModalCard} onPress={() => {}}>
+              <Text style={s.groupModalTitle}>
+                {groupNameModal?.mode === "rename"
+                  ? t("common.rename", "重命名")
+                  : t("library.createGroup", "新建分组")}
+              </Text>
+              <TextInput
+                style={s.groupModalInput}
+                value={groupNameInput}
+                onChangeText={setGroupNameInput}
+                placeholder={t("library.groupNamePrompt", "分组名称")}
+                placeholderTextColor={colors.mutedForeground}
+                autoFocus
+                returnKeyType="done"
+                onSubmitEditing={() => void submitGroupName()}
+              />
+              <View style={s.groupModalActions}>
+                <TouchableOpacity
+                  style={s.groupModalSecondary}
+                  onPress={() => setGroupNameModal(null)}
+                >
+                  <Text style={s.groupModalSecondaryText}>{t("common.cancel", "取消")}</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={s.groupModalPrimary}
+                  onPress={() => void submitGroupName()}
+                >
+                  <Text style={s.groupModalPrimaryText}>{t("common.confirm", "确定")}</Text>
+                </TouchableOpacity>
+              </View>
+            </Pressable>
           </Pressable>
-        </Pressable>
+        </KeyboardAvoidingView>
       </Modal>
 
       <TagManagementSheet
@@ -1377,6 +1383,7 @@ const makeStyles = (
     gridRow: { gap: layout.gridGap, justifyContent: "flex-start" },
     gridContent: { paddingBottom: 24, paddingTop: 4, width: "100%" },
     gridItem: { width: layout.gridItemWidth, marginBottom: layout.gridGap },
+    groupModalKeyboardRoot: { flex: 1 },
     groupModalOverlay: {
       flex: 1,
       backgroundColor: "rgba(0,0,0,0.24)",

--- a/packages/app-expo/src/screens/NotesView.tsx
+++ b/packages/app-expo/src/screens/NotesView.tsx
@@ -7,6 +7,7 @@ import {
   ShareIcon,
   XIcon,
 } from "@/components/ui/Icon";
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { SyncButton } from "@/components/ui/SyncButton";
 import { openMobileBook } from "@/lib/library/open-mobile-book";
 import type { RootStackParamList } from "@/navigation/RootNavigator";
@@ -440,7 +441,7 @@ export function NotesView({
             </Text>
           </View>
         ) : (
-          <ScrollView style={s.detailList} showsVerticalScrollIndicator={false}>
+          <KeyboardAwareScrollView style={s.detailList} showsVerticalScrollIndicator={false}>
             {itemsByChapter.map(({ chapter, items }) => (
               <View key={chapter} style={s.chapterGroup}>
                 {/* Chapter divider */}
@@ -477,7 +478,7 @@ export function NotesView({
               </View>
             ))}
             <View style={{ height: 24 }} />
-          </ScrollView>
+          </KeyboardAwareScrollView>
         )}
 
         {/* Export menu */}

--- a/packages/app-expo/src/screens/SkillsScreen.tsx
+++ b/packages/app-expo/src/screens/SkillsScreen.tsx
@@ -14,7 +14,9 @@ import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -312,58 +314,69 @@ export default function SkillsScreen() {
         animationType="slide"
         onRequestClose={() => setEditorOpen(false)}
       >
-        <Pressable style={s.editorOverlay} onPress={() => setEditorOpen(false)} />
-        <View style={[s.editorSheet, layout.isTablet && s.editorSheetTablet]}>
-          <View style={s.editorHandle} />
-          <Text style={s.editorTitle}>
-            {editingSkill ? t("skills.editSkill", "编辑技能") : t("skills.createSkill", "创建技能")}
-          </Text>
+        <KeyboardAvoidingView
+          style={s.editorModalRoot}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
+          <Pressable style={s.editorOverlay} onPress={() => setEditorOpen(false)} />
+          <View style={[s.editorSheet, layout.isTablet && s.editorSheetTablet]}>
+            <View style={s.editorHandle} />
+            <Text style={s.editorTitle}>
+              {editingSkill
+                ? t("skills.editSkill", "编辑技能")
+                : t("skills.createSkill", "创建技能")}
+            </Text>
 
-          <ScrollView style={s.editorContent}>
-            <Text style={s.fieldLabel}>{t("skills.name", "名称")} *</Text>
-            <TextInput
-              style={[s.fieldInput, editingSkill?.builtIn && s.fieldInputDisabled]}
-              value={formName}
-              onChangeText={setFormName}
-              placeholder={t("skills.namePlaceholder", "技能名称")}
-              placeholderTextColor={colors.mutedForeground}
-              editable={!editingSkill?.builtIn}
-            />
-
-            <Text style={s.fieldLabel}>{t("skills.description", "描述")}</Text>
-            <TextInput
-              style={s.fieldInput}
-              value={formDescription}
-              onChangeText={setFormDescription}
-              placeholder={t("skills.descriptionPlaceholder", "简要描述...")}
-              placeholderTextColor={colors.mutedForeground}
-            />
-
-            <Text style={s.fieldLabel}>{t("skills.prompt", "提示词")}</Text>
-            <TextInput
-              style={[s.fieldInput, s.fieldTextarea]}
-              value={formPrompt}
-              onChangeText={setFormPrompt}
-              placeholder={t("skills.promptPlaceholder", "输入提示词...")}
-              placeholderTextColor={colors.mutedForeground}
-              multiline
-              textAlignVertical="top"
-            />
-          </ScrollView>
-
-          <View style={s.editorActions}>
-            <TouchableOpacity style={s.editorCancelBtn} onPress={() => setEditorOpen(false)}>
-              <Text style={s.editorCancelText}>{t("common.cancel", "取消")}</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[s.editorSaveBtn, !formName.trim() && s.editorSaveBtnDisabled]}
-              onPress={handleSaveSkill}
-              disabled={!formName.trim()}
+            <ScrollView
+              style={s.editorContent}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
             >
-              <Text style={s.editorSaveText}>{t("common.save", "保存")}</Text>
-            </TouchableOpacity>
+              <Text style={s.fieldLabel}>{t("skills.name", "名称")} *</Text>
+              <TextInput
+                style={[s.fieldInput, editingSkill?.builtIn && s.fieldInputDisabled]}
+                value={formName}
+                onChangeText={setFormName}
+                placeholder={t("skills.namePlaceholder", "技能名称")}
+                placeholderTextColor={colors.mutedForeground}
+                editable={!editingSkill?.builtIn}
+              />
+
+              <Text style={s.fieldLabel}>{t("skills.description", "描述")}</Text>
+              <TextInput
+                style={s.fieldInput}
+                value={formDescription}
+                onChangeText={setFormDescription}
+                placeholder={t("skills.descriptionPlaceholder", "简要描述...")}
+                placeholderTextColor={colors.mutedForeground}
+              />
+
+              <Text style={s.fieldLabel}>{t("skills.prompt", "提示词")}</Text>
+              <TextInput
+                style={[s.fieldInput, s.fieldTextarea]}
+                value={formPrompt}
+                onChangeText={setFormPrompt}
+                placeholder={t("skills.promptPlaceholder", "输入提示词...")}
+                placeholderTextColor={colors.mutedForeground}
+                multiline
+                textAlignVertical="top"
+              />
+            </ScrollView>
+
+            <View style={s.editorActions}>
+              <TouchableOpacity style={s.editorCancelBtn} onPress={() => setEditorOpen(false)}>
+                <Text style={s.editorCancelText}>{t("common.cancel", "取消")}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[s.editorSaveBtn, !formName.trim() && s.editorSaveBtnDisabled]}
+                onPress={handleSaveSkill}
+                disabled={!formName.trim()}
+              >
+                <Text style={s.editorSaveText}>{t("common.save", "保存")}</Text>
+              </TouchableOpacity>
+            </View>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
   );
@@ -456,6 +469,7 @@ const makeStyles = (colors: ThemeColors) =>
     },
     customEmptyBtnText: { fontSize: fontSize.sm, color: colors.primaryForeground },
     // Editor
+    editorModalRoot: { flex: 1 },
     editorOverlay: { flex: 1, backgroundColor: "rgba(0,0,0,0.4)" },
     editorSheet: {
       backgroundColor: colors.background,

--- a/packages/app-expo/src/screens/notes/NoteCard.tsx
+++ b/packages/app-expo/src/screens/notes/NoteCard.tsx
@@ -5,7 +5,7 @@ import { useColors } from "@/styles/theme";
 import type { HighlightWithBook } from "@readany/core/db/database";
 import { HIGHLIGHT_COLOR_HEX } from "@readany/core/types";
 import type { TFunction } from "i18next";
-import { KeyboardAvoidingView, Platform, Text, TouchableOpacity, View } from "react-native";
+import { Text, TouchableOpacity, View } from "react-native";
 import { makeStyles } from "./notes-styles";
 
 export function NoteCard({
@@ -37,12 +37,19 @@ export function NoteCard({
   return (
     <View style={s.noteCard}>
       <TouchableOpacity style={s.noteCardTop} onPress={onNavigate}>
-        <View style={[s.colorDot, { backgroundColor: HIGHLIGHT_COLOR_HEX[highlight.color] || colors.amber }]} />
-        <Text style={s.noteQuote} numberOfLines={2}>"{highlight.text}"</Text>
+        <View
+          style={[
+            s.colorDot,
+            { backgroundColor: HIGHLIGHT_COLOR_HEX[highlight.color] || colors.amber },
+          ]}
+        />
+        <Text style={s.noteQuote} numberOfLines={2}>
+          "{highlight.text}"
+        </Text>
       </TouchableOpacity>
 
       {isEditing ? (
-        <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={s.editArea}>
+        <View style={s.editArea}>
           <View style={s.editorContainer}>
             <RichTextEditor
               initialContent={editNote}
@@ -61,7 +68,7 @@ export function NoteCard({
               <Text style={s.editSaveText}>{t("common.save", "保存")}</Text>
             </TouchableOpacity>
           </View>
-        </KeyboardAvoidingView>
+        </View>
       ) : (
         <>
           {highlight.note && (

--- a/packages/app-expo/src/screens/settings/AISettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/AISettingsScreen.tsx
@@ -1,24 +1,22 @@
-import { useSettingsStore } from "@/stores";
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
+import { useSettingsStore } from "@/stores";
 import type { AIConfig, AIEndpoint } from "@readany/core/types";
-import { getDefaultBaseUrl, PROVIDER_CONFIGS } from "@readany/core/utils";
+import { PROVIDER_CONFIGS, getDefaultBaseUrl } from "@readany/core/utils";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Alert,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
   Text,
   TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { ConfigTransfer } from "../../components/settings/ConfigTransfer";
 import { MinusIcon, PlusIcon } from "../../components/ui/Icon";
 import { useColors } from "../../styles/theme";
 import { fontSize, fontWeight, spacing } from "../../styles/theme";
-import { ConfigTransfer } from "../../components/settings/ConfigTransfer";
 import { SettingsHeader } from "./SettingsHeader";
 import { EndpointEditor } from "./ai/EndpointEditor";
 import { makeStyles } from "./ai/ai-settings-styles";
@@ -104,21 +102,15 @@ export default function AISettingsScreen() {
         subtitle={t("settings.realtimeHint")}
         right={addButton}
       />
-      <KeyboardAvoidingView
-        style={styles.keyboardView}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      <KeyboardAwareScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
+        showsVerticalScrollIndicator={true}
+        alwaysBounceVertical={false}
+        scrollEventThrottle={16}
+        overScrollMode="never"
+        bounces={true}
       >
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="on-drag"
-          showsVerticalScrollIndicator={true}
-          alwaysBounceVertical={false}
-          scrollEventThrottle={16}
-          overScrollMode="never"
-          bounces={true}
-        >
           <View style={[styles.contentColumn, { width: "100%", maxWidth: layout.centeredContentWidth }]}>
             {/* Endpoints */}
             <View style={styles.endpointList}>
@@ -254,8 +246,7 @@ export default function AISettingsScreen() {
               />
             </View>
           </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
     </SafeAreaView>
   );
 }

--- a/packages/app-expo/src/screens/settings/FeedbackScreen.tsx
+++ b/packages/app-expo/src/screens/settings/FeedbackScreen.tsx
@@ -1,10 +1,10 @@
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import type { RootStackParamList } from "@/navigation/RootNavigator";
 /**
  * FeedbackScreen — Submit bug reports / feature requests and track history.
  * Submissions are sent to a Cloudflare Worker that creates GitHub Issues.
  */
-import { useColors } from "@/styles/theme";
-import type { ThemeColors } from "@/styles/theme";
+import { type ThemeColors, spacing, useColors } from "@/styles/theme";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {
@@ -18,19 +18,17 @@ import {
   submitFeedback,
 } from "@readany/core/feedback";
 import type { DeviceInfo, FeedbackRecord, FeedbackType } from "@readany/core/feedback";
+import Constants from "expo-constants";
 import type { TFunction } from "i18next";
 import { Bug, Check, Lightbulb, MessageSquare } from "lucide-react-native";
 import type { LucideIcon } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import Constants from "expo-constants";
 import {
   ActivityIndicator,
   Alert,
   FlatList,
-  KeyboardAvoidingView,
   Platform,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -194,15 +192,13 @@ function SubmitTab({ colors, t, locale }: FeedbackTabProps & { locale: string })
   }, [canSubmit, submitting, type, title, description, includeLogs, deviceInfo, t]);
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    <KeyboardAwareScrollView
+      style={styles.scrollView}
+      contentContainerStyle={styles.formContent}
+      bottomOffset={spacing.xxl * 3}
+      extraKeyboardSpace={spacing.xxl * 2}
+      contentBottomInset={spacing.xxl * 3}
     >
-      <ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.formContent}
-        keyboardShouldPersistTaps="handled"
-      >
         <View style={[styles.introBlock, { borderBottomColor: colors.border }]}>
           <Text style={[styles.introTitle, { color: colors.foreground }]}>
             {t("feedback.title", "反馈建议")}
@@ -329,8 +325,7 @@ function SubmitTab({ colors, t, locale }: FeedbackTabProps & { locale: string })
         <Text style={[styles.remainingText, { color: colors.mutedForeground }]}>
           {t("feedback.remaining", "今日还可提交 {{count}} 次", { count: remaining })}
         </Text>
-      </ScrollView>
-    </KeyboardAvoidingView>
+    </KeyboardAwareScrollView>
   );
 }
 

--- a/packages/app-expo/src/screens/settings/FontSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/FontSettingsScreen.tsx
@@ -550,7 +550,13 @@ export default function FontSettingsScreen() {
           style={s.modalOverlay}
           behavior={Platform.OS === "ios" ? "padding" : "height"}
         >
-          <View style={[s.modalContent, { backgroundColor: colors.card }]}>
+          <ScrollView
+            style={[s.modalContent, s.scrollModal, { backgroundColor: colors.card }]}
+            contentContainerStyle={s.scrollModalContent}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+            showsVerticalScrollIndicator={false}
+          >
             <Text style={[s.modalTitle, { color: colors.foreground }]}>
               {t("fonts.fromUrl", "在线链接")}
             </Text>
@@ -641,7 +647,7 @@ export default function FontSettingsScreen() {
                 </Text>
               </TouchableOpacity>
             </View>
-          </View>
+          </ScrollView>
         </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
@@ -712,7 +718,15 @@ function makeStyles(_colors: ReturnType<typeof useColors>) {
       justifyContent: "center",
       alignItems: "center",
     },
-    modalContent: { borderRadius: radius.xl, padding: 20, width: "85%", maxWidth: 340 },
+    modalContent: {
+      borderRadius: radius.xl,
+      padding: 20,
+      width: "85%",
+      maxWidth: 340,
+      maxHeight: "85%",
+    },
+    scrollModal: { padding: 0 },
+    scrollModalContent: { padding: 20 },
     modalTitle: { fontSize: fontSize.lg, fontWeight: fontWeight.semibold, marginBottom: 8 },
     modalDesc: { fontSize: fontSize.sm, marginBottom: 16 },
     inputLabel: { fontSize: fontSize.sm, fontWeight: fontWeight.medium, marginBottom: 4 },

--- a/packages/app-expo/src/screens/settings/SyncSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/SyncSettingsScreen.tsx
@@ -1,3 +1,4 @@
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
 import { getPlatformService } from "@readany/core/services";
 import { useSyncStore } from "@readany/core/stores";
@@ -13,9 +14,7 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
-  KeyboardAvoidingView,
   Platform,
-  ScrollView,
   Text,
   TextInput,
   TouchableOpacity,
@@ -459,16 +458,10 @@ export default function SyncSettingsScreen() {
     >
       <SettingsHeader title={t("settings.syncTitle")} />
 
-      <KeyboardAvoidingView
-        style={styles.keyboardView}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      <KeyboardAwareScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
       >
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="on-drag"
-        >
           <View
             style={[styles.contentColumn, { width: "100%", maxWidth: layout.centeredContentWidth }]}
           >
@@ -811,8 +804,7 @@ export default function SyncSettingsScreen() {
               />
             </View>
           </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
     </SafeAreaView>
   );
 }

--- a/packages/app-expo/src/screens/settings/TTSSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/TTSSettingsScreen.tsx
@@ -1,30 +1,30 @@
-import { useTTSStore } from "@/stores";
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
 import {
   DEFAULT_SYSTEM_VOICE_VALUE,
+  type NativeSystemVoiceOption,
   findSystemVoiceLabel,
   getSystemVoiceOptionsAsync,
   groupSystemVoiceOptions,
   resolveSystemVoiceValue,
-  type NativeSystemVoiceOption,
 } from "@/lib/platform/system-voices";
 import { previewTTSConfig, stopTTSPreview } from "@/lib/platform/tts-preview";
+import { useTTSStore } from "@/stores";
 import {
   DASHSCOPE_VOICES,
   DEFAULT_XIAOMI_STYLE_PROMPT,
   EDGE_TTS_VOICES,
+  type TTSProfile,
+  type TTSProviderType,
   XIAOMI_TTS_VOICES,
   getActiveTTSProfile,
   getLocaleDisplayLabel,
   groupEdgeTTSVoices,
-  type TTSProviderType,
-  type TTSProfile,
 } from "@readany/core/tts";
+import type { TFunction } from "i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  KeyboardAvoidingView,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -32,7 +32,6 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import type { TFunction } from "i18next";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { PasswordInput } from "../../components/ui/PasswordInput";
 import {
@@ -193,16 +192,10 @@ export default function TTSSettingsScreen() {
         right={previewBtn}
       />
 
-      <KeyboardAvoidingView
-        style={styles.keyboardView}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      <KeyboardAwareScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
       >
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="on-drag"
-        >
           <View style={[styles.contentColumn, { width: "100%", maxWidth: layout.centeredContentWidth }]}>
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>{t("tts.voiceProfile", "朗读方案")}</Text>
@@ -628,8 +621,7 @@ export default function TTSSettingsScreen() {
               </View>
             </View>
           </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
     </SafeAreaView>
   );
 }

--- a/packages/app-expo/src/screens/settings/TranslationSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/TranslationSettingsScreen.tsx
@@ -1,15 +1,15 @@
-import { useSettingsStore } from "@/stores";
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
+import { useSettingsStore } from "@/stores";
 import {
   TRANSLATOR_LANGS,
   TRANSLATOR_PROVIDERS,
   type TranslationTargetLang,
 } from "@readany/core/types/translation";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  KeyboardAvoidingView,
   Modal,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -28,7 +28,6 @@ import {
   useColors,
 } from "../../styles/theme";
 import { SettingsHeader } from "./SettingsHeader";
-import { useState } from "react";
 
 export default function TranslationSettingsScreen() {
   const colors = useColors();
@@ -78,16 +77,10 @@ export default function TranslationSettingsScreen() {
         subtitle={t("settings.realtimeHint")}
       />
 
-      <KeyboardAvoidingView
-        style={styles.keyboardView}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      <KeyboardAwareScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
       >
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={[styles.scrollContent, { alignItems: "center" }]}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="on-drag"
-        >
           <View style={[styles.contentColumn, { width: "100%", maxWidth: layout.centeredContentWidth }]}>
             {/* Provider */}
             <View style={styles.section}>
@@ -231,8 +224,7 @@ export default function TranslationSettingsScreen() {
               </View>
             </View>
           </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
 
       {/* Model Picker Modal */}
       <Modal

--- a/packages/app-expo/src/screens/settings/VectorModelSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/VectorModelSettingsScreen.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeftIcon, EditIcon, PlusIcon, Trash2Icon, XIcon } from "@/components/ui/Icon";
+import { KeyboardAwareScrollView } from "@/components/ui/KeyboardAwareScrollView";
 import { useResponsiveLayout } from "@/hooks/use-responsive-layout";
 import { useVectorModelStore } from "@/stores/vector-model-store";
 import {
@@ -6,6 +7,7 @@ import {
   fontSize,
   fontWeight,
   radius,
+  spacing,
   useColors,
   withOpacity,
 } from "@/styles/theme";
@@ -23,9 +25,6 @@ import {
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
   StyleSheet,
   Switch,
   Text,
@@ -62,17 +61,14 @@ export default function VectorModelSettingsScreen() {
         </View>
       </View>
 
-      <KeyboardAvoidingView
-        style={s.keyboardView}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      <KeyboardAwareScrollView
+        style={s.scrollView}
+        contentContainerStyle={s.scrollContent}
+        showsVerticalScrollIndicator={false}
+        bottomOffset={spacing.xxl * 3}
+        extraKeyboardSpace={spacing.xxl * 2}
+        contentBottomInset={spacing.xxl * 3}
       >
-        <ScrollView
-          style={s.scrollView}
-          contentContainerStyle={s.scrollContent}
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="on-drag"
-        >
           <View style={{ width: "100%", maxWidth: layout.centeredContentWidth }}>
             {/* Enable switch */}
             <View style={s.section}>
@@ -169,8 +165,7 @@ export default function VectorModelSettingsScreen() {
 
             <View style={{ height: 24 }} />
           </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
     </SafeAreaView>
   );
 }

--- a/packages/app-expo/src/screens/stats/GoalsSection.tsx
+++ b/packages/app-expo/src/screens/stats/GoalsSection.tsx
@@ -1,3 +1,4 @@
+import { useColors, withOpacity } from "@/styles/theme";
 /**
  * GoalsSection.tsx — Mobile goal progress rings + inline add form.
  * Feature-parity with desktop GoalsSection (packages/app/src/components/stats/GoalsSection.tsx).
@@ -5,9 +6,18 @@
 import type { GoalPeriod, GoalProgress, GoalType, StatsDimension } from "@readany/core/stats";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Modal, Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import Svg, { Circle } from "react-native-svg";
-import { useColors, withOpacity } from "@/styles/theme";
 import { formatCharacterCount } from "./stats-utils";
 
 const GOAL_TYPE_DEFAULTS: Record<GoalType, number> = {
@@ -385,28 +395,32 @@ function GoalAddFormModal({
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View
-        style={{
-          flex: 1,
-          backgroundColor: "rgba(0,0,0,0.5)",
-          alignItems: "center",
-          justifyContent: "center",
-          paddingHorizontal: 20,
-        }}
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        <Pressable onPress={onClose} style={StyleSheet.absoluteFill} />
         <View
           style={{
-            width: "100%",
-            maxWidth: 360,
-            borderRadius: 20,
-            backgroundColor: colors.card,
-            borderWidth: StyleSheet.hairlineWidth,
-            borderColor: withOpacity(colors.border, 0.5),
-            padding: 18,
-            gap: 16,
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            alignItems: "center",
+            justifyContent: "center",
+            paddingHorizontal: 20,
           }}
         >
+          <Pressable onPress={onClose} style={StyleSheet.absoluteFill} />
+          <View
+            style={{
+              width: "100%",
+              maxWidth: 360,
+              borderRadius: 20,
+              backgroundColor: colors.card,
+              borderWidth: StyleSheet.hairlineWidth,
+              borderColor: withOpacity(colors.border, 0.5),
+              padding: 18,
+              gap: 16,
+            }}
+          >
           <Text
             style={{
               fontSize: 16,
@@ -540,8 +554,9 @@ function GoalAddFormModal({
               </Text>
             </TouchableOpacity>
           </View>
+          </View>
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,9 @@ importers:
       react-native-get-random-values:
         specifier: ~1.11.0
         version: 1.11.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      react-native-keyboard-controller:
+        specifier: 1.18.5
+        version: 1.18.5(react-native-reanimated@4.1.1(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-markdown-display:
         specifier: ^7.0.2
         version: 7.0.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -7965,6 +7968,13 @@ packages:
     peerDependencies:
       react: 19.1.0
       react-native: '*'
+
+  react-native-keyboard-controller@1.18.5:
+    resolution: {integrity: sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==}
+    peerDependencies:
+      react: 19.1.0
+      react-native: '*'
+      react-native-reanimated: '>=3.0.0'
 
   react-native-markdown-display@7.0.2:
     resolution: {integrity: sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==}
@@ -18655,6 +18665,13 @@ snapshots:
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  react-native-keyboard-controller@1.18.5(react-native-reanimated@4.1.1(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.1(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   react-native-markdown-display@7.0.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- integrate native keyboard-aware layout support for the Expo app
- keep settings, onboarding, notes, book details, and other mobile forms reachable above the keyboard
- fix the book action flow: Move to group -> New group

## Verification
- pnpm --filter @readany/app-expo exec tsc --noEmit --pretty false
- pnpm --filter @readany/app-expo test
- manual Android device verification across reported input flows