### PR TITLE
fix: report incomplete streaming responses

### DIFF
--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AIConfig } from "../../types";
-import { streamReadingAgent } from "../agents/reading-agent";
+import { isOutputLimitTermination, streamReadingAgent } from "../agents/reading-agent";
 import type { ToolDefinition } from "../tools";
 import { getAvailableTools } from "../tools";
 
@@ -48,6 +48,22 @@ beforeEach(() => {
   getReadingContextSnapshotMock.mockReset();
   getReadingContextSnapshotMock.mockReturnValue(null);
   vi.useRealTimers();
+});
+
+describe("isOutputLimitTermination", () => {
+  it.each([
+    { response_metadata: { finish_reason: "length" } },
+    { response_metadata: { finishReason: "max_tokens" } },
+    { additional_kwargs: { finish_reason: "MAX_COMPLETION_TOKENS" } },
+  ])("recognizes explicit output-limit finish reasons", (output) => {
+    expect(isOutputLimitTermination(output)).toBe(true);
+  });
+
+  it("does not guess from normal completion metadata", () => {
+    expect(isOutputLimitTermination({ response_metadata: { finish_reason: "stop" } })).toBe(false);
+    expect(isOutputLimitTermination({ additional_kwargs: { finish_reason: "tool_calls" } })).toBe(false);
+    expect(isOutputLimitTermination(undefined)).toBe(false);
+  });
 });
 
 describe("streamReadingAgent tool registration", () => {

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -30,6 +30,31 @@ const DEFAULT_TOOL_TIMEOUT_MS = 45_000;
 const TOOL_EXECUTION_LIMIT = 12;
 const REPEATED_TOOL_CALL_LIMIT = 2;
 
+const OUTPUT_LIMIT_FINISH_REASONS = new Set([
+  "length",
+  "max_tokens",
+  "max_completion_tokens",
+  "token_limit",
+]);
+
+/**
+ * Providers expose the stop reason in slightly different places. Only treat
+ * explicit output-limit reasons as truncation: guessing from punctuation would
+ * turn legitimate short answers into false failures.
+ */
+export function isOutputLimitTermination(output: unknown): boolean {
+  if (!output || typeof output !== "object") return false;
+  const record = output as Record<string, unknown>;
+  const metadata = [record.response_metadata, record.additional_kwargs];
+
+  return metadata.some((value) => {
+    if (!value || typeof value !== "object") return false;
+    const reason = (value as Record<string, unknown>).finish_reason ??
+      (value as Record<string, unknown>).finishReason;
+    return typeof reason === "string" && OUTPUT_LIMIT_FINISH_REASONS.has(reason.toLowerCase());
+  });
+}
+
 const CHAPTER_LOOKUP_STOP_TOOL_NAMES = new Set([
   "resolveChapterReference",
   "ragSearch",
@@ -1003,14 +1028,22 @@ export async function* streamReadingAgent(
       if (isAborted()) {
         return { done: true, value: undefined };
       }
+      let onAbort: (() => void) | undefined;
       const abortPromise = new Promise<IteratorResult<unknown>>((resolve) => {
-        const onAbort = () => {
-          signal?.removeEventListener("abort", onAbort);
+        const handler = () => {
+          signal?.removeEventListener("abort", handler);
           resolve({ done: true, value: undefined });
         };
-        signal?.addEventListener("abort", onAbort);
+        onAbort = handler;
+        signal?.addEventListener("abort", handler);
       });
-      return Promise.race([iterator.next(), abortPromise]);
+      try {
+        return await Promise.race([iterator.next(), abortPromise]);
+      } finally {
+        // The next event normally arrives before cancellation. Do not retain
+        // an abort listener for every streamed event in that case.
+        if (onAbort) signal?.removeEventListener("abort", onAbort);
+      }
     };
 
     const iterator = eventStream[Symbol.asyncIterator]();
@@ -1129,6 +1162,15 @@ export async function* streamReadingAgent(
 
         // Clear streaming accumulator for the next LLM turn
         streamingToolCalls.clear();
+
+        if (isOutputLimitTermination(output)) {
+          yield {
+            type: "error",
+            error:
+              "The model reached its output limit before finishing. Increase Max Tokens or try again.",
+          };
+          return;
+        }
 
         if (output) {
           if (Array.isArray(toolCalls)) {

--- a/packages/core/src/ai/streaming.ts
+++ b/packages/core/src/ai/streaming.ts
@@ -125,14 +125,22 @@ export class StreamingChat {
         if (signal.aborted) {
           return { done: true, value: undefined };
         }
+        let onAbort: (() => void) | undefined;
         const abortPromise = new Promise<IteratorResult<unknown>>((resolve) => {
-          const onAbort = () => {
-            signal.removeEventListener("abort", onAbort);
+          const handler = () => {
+            signal.removeEventListener("abort", handler);
             resolve({ done: true, value: undefined });
           };
-          signal.addEventListener("abort", onAbort);
+          onAbort = handler;
+          signal.addEventListener("abort", handler);
         });
-        return Promise.race([iterator.next(), abortPromise]);
+        try {
+          return await Promise.race([iterator.next(), abortPromise]);
+        } finally {
+          // iterator.next() usually wins. Remove its unused abort listener so a
+          // long conversation does not accumulate one listener per event.
+          if (onAbort) signal.removeEventListener("abort", onAbort);
+        }
       };
 
       const iterator = stream[Symbol.asyncIterator]();
@@ -189,6 +197,15 @@ export class StreamingChat {
       if (signal.aborted) {
         options.onAbort?.(fullText, toolCalls.length > 0 ? toolCalls : undefined);
       } else {
+        const incompleteToolCalls = toolCalls.filter((toolCall) => toolCall.result === undefined);
+        if (incompleteToolCalls.length > 0) {
+          options.onError(
+            new Error(
+              "The response stream ended before its tool call completed. Please try again.",
+            ),
+          );
+          return;
+        }
         options.onComplete(fullText, toolCalls.length > 0 ? toolCalls : undefined);
       }
     } catch (error) {


### PR DESCRIPTION
## What changed

- Report an explicit error when a provider ends because of an output-token limit.
- Report an error instead of silently completing when a streamed tool call has no result.
- Remove per-event abort listeners after each stream race.

## Why

Previously, an interrupted response could be saved as a normal completed answer, leaving users with a partial sentence and no diagnosis.

## Validation

- `pnpm --filter @readany/core test` — 579 tests passed
- TypeScript check for `packages/core`
- `git diff --check`
