### PR TITLE
chore: establish PR-000 open-source baseline

### DIFF
--- a/.codex/PR000_STATE_LEDGER.md
+++ b/.codex/PR000_STATE_LEDGER.md
@@ -1,0 +1,95 @@
+# PR-000 State Ledger
+
+Last updated: 2026-08-11 (Asia/Shanghai)
+
+## Immutable task authority
+
+- Task: PR-000 — Open-source Development Baseline
+- Objective: establish a Windows-first, upstream-syncable, GitHub-reviewable development baseline for the AI Adaptive Agentic Learning Desktop without adding learning features.
+- Authoritative prompt: `C:\Users\Administrator\Downloads\AI_READING_PR000_OPEN_SOURCE_BASELINE_CODEX_PROMPT(1).md`
+- Upstream repository: `https://github.com/codedogQBY/ReadAny`
+- Repository path: `D:\读书学习辅助`
+- Branch: `chore/pr000-open-source-baseline`
+- Upstream `main` observed at task start: `3f8826c37391721289f4d6db47bacc0c73788572`
+- Base full SHA: `3f8826c37391721289f4d6db47bacc0c73788572`
+- Current HEAD: `3f8826c37391721289f4d6db47bacc0c73788572`
+
+## Frozen scope
+
+- Add upstream provenance and synchronization policy.
+- Add the frozen OSS integration registry without downloading or integrating additional projects.
+- Add the concise project charter.
+- Add concise UI/UX/UE design governance for later user-facing PRs.
+- Establish and verify the real Windows development/build spine.
+- Add or correct minimum real Windows pull-request CI.
+- Preserve GPL-3.0-or-later licensing, copyright, and ReadAny attribution.
+
+## Prohibited scope
+
+- No Read-Box, DeepTutor, The Knowledge Guy, or Gutendex integration.
+- No Learner Model, Goal Agent, Reward Engine, Visual Learning, account, cloud sync, or learning feature implementation.
+- No ReadAny RAG or ebook parser replacement.
+- No broad UI redesign, mobile restructuring, final branding, or speculative future abstractions.
+- No reset, rebase, force push, destructive branch replacement, or public-history rewrite.
+
+## Git and GitHub state
+
+- `upstream`: `https://github.com/codedogQBY/ReadAny.git`
+- `origin`: `https://github.com/dongxuelian11/ReadAny.git`
+- GitHub CLI account: `dongxuelian11`; authentication re-verified PASS on 2026-08-11 with `repo` and `workflow` scopes.
+- Public fork: PASS — `https://github.com/dongxuelian11/ReadAny` is PUBLIC, `isFork=true`, parent `codedogQBY/ReadAny`, and fork `main` is `3f8826c37391721289f4d6db47bacc0c73788572`.
+- PR URL/state: NOT_RUN.
+- CI checks: NOT_RUN.
+
+## Materially changed files
+
+- `.codex/PR000_STATE_LEDGER.md` — created as the mandatory compaction-recovery authority.
+- `.github/workflows/pr-windows.yml` — adds real Windows PR lint, test, typecheck/frontend build, and NSIS production-build jobs.
+- `UPSTREAM.md` — records upstream identity, exact baseline, attribution, and non-rewriting sync policy.
+- `INTEGRATIONS.lock.json` — records required future integrations and reference watchlist without vendoring or unverified pins/licenses.
+- `docs/PROJECT_CHARTER.md` — freezes the concise product principles.
+- `docs/UI_UX_GOVERNANCE.md` — freezes required design-skill and interaction-quality governance for later user-facing PRs.
+- `packages/app/src-tauri/tauri.ci.conf.json` — limits PR builds to a real NSIS installer and disables release-only updater signing artifacts while preserving normal release configuration.
+
+## Completed
+
+- PASS — read the authoritative execution prompt.
+- PASS — observed upstream `main` directly with `git ls-remote`.
+- PASS — cloned upstream into the empty workspace.
+- PASS — verified cloned HEAD exactly matches the observed upstream SHA.
+- PASS — renamed the cloned remote from `origin` to `upstream` after approved Git metadata access.
+- PASS — created the required branch from the exact pinned base after approved Git metadata access.
+- PASS — inspected repository scripts, existing workflows, GPL-3.0-or-later license/attribution, and Rust/Tauri configuration.
+- PASS — added the required provenance, integration registry, project charter, UI/UX governance, PR CI workflow, and bounded Tauri PR-build override locally.
+- PASS — completed the baseline install, lint, real test commands, frontend build, and Windows desktop build investigation with failures classified below.
+- PASS — recovery on 2026-08-11 reread the authoritative prompt and ledger, then re-verified branch, HEAD, log, remotes, live upstream SHA, GitHub identity, fork absence, PR absence, and material files before continuing.
+- PASS — created the real public GitHub fork and configured it as `origin`; preserved `codedogQBY/ReadAny` as `upstream`.
+- PASS — completed bounded post-change regression verification: Core 566/566, Expo 3/3, and frontend build passed; lint and CLI reproduced their exact pre-existing Windows baseline failures without new counts or failure classes.
+
+## Pending / next action
+
+- PENDING — commit, push, create PR, and inspect CI.
+- PASS — refreshed the Git index stat cache; `packages/app/src-tauri/Cargo.toml` is clean and has no staged or unstaged content change.
+- PASS — reviewed the complete staged diff and confirmed that it contains only the seven intended PR-000 files.
+- PASS — validated both JSON files, parsed the workflow YAML, and passed `git diff --cached --check`.
+- Next bounded action: commit the reviewed PR-000 change set.
+
+## Test and build truth
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Upstream SHA observation | PASS | `git ls-remote ... refs/heads/main` returned `3f8826c37391721289f4d6db47bacc0c73788572`. |
+| Clone/base match | PASS | `git rev-parse HEAD` matched the observed SHA. |
+| Node version | PASS | `node --version` = `v24.16.0`. |
+| pnpm version | PASS | Global `11.16.0`; baseline commands use repository-pinned `9.15.0` via Corepack. |
+| Rust version | PASS | `rustc 1.96.0 (ac68faa20 2026-05-25)`; `cargo 1.96.0 (30a34c682 2026-05-25)`; `stable-x86_64-pc-windows-msvc`. |
+| Dependency installation | PASS | `corepack pnpm install --frozen-lockfile` completed in 50.2s for all 8 workspace projects. Optional `dtrace-provider` native rebuild could not detect VS but its install script intentionally suppressed the error and pnpm exited 0. |
+| Lint/typecheck | FAIL | `corepack pnpm lint` exited 1 before PR-000 implementation (`BASELINE_FAILURE`): Biome checked 889 files, reported 1,621 errors and 284 warnings. Visible causes include CRLF formatting differences on the Windows checkout and committed `packages/app/public/vendor/pdfjs/pdf.worker.mjs` exceeding Biome's 1 MiB maximum. No fixes applied. |
+| Automated tests | FAIL | Core: PASS, 75 files/566 tests. Expo: PASS, 2 files/3 tests. CLI: `BASELINE_FAILURE`, 5/7 files and 124/135 tests passed; 11 failures remained after an approved unsandboxed rerun and concern Windows Unix/Darwin path simulation plus symlink creation. PR-000 changes no CLI source/tests. |
+| Windows desktop production build | PASS | Baseline `pnpm tauri build` compiled Rust release and produced `app.exe`, MSI, and NSIS, then exited 1 because release-only updater signing lacked `TAURI_SIGNING_PRIVATE_KEY` (`BASELINE_FAILURE`). The PR-only NSIS/no-updater-artifact config was then verified with `pnpm --filter app tauri build --config src-tauri/tauri.ci.conf.json --ci`: exit 0 and `ReadAny_1.3.5_x64-setup.exe` produced. |
+| Post-change regression verification | FAIL (`BASELINE_FAILURE`) | Re-run on 2026-08-11: lint reproduced 1,621 errors/284 warnings; CLI reproduced 11 failures with 124/135 passing. Core PASS 566/566, Expo PASS 3/3, frontend production build PASS. The bounded PR-only Windows Tauri NSIS build had already passed after the CI override was created. |
+| Pull-request CI | NOT_RUN | PR not yet created. |
+
+## Recovery protocol
+
+After compaction/restart: reread the authoritative prompt, reread this ledger, inspect `git status`, branch/HEAD, log/diff, and remotes, then reconcile any PR/check state before continuing. Fail closed on disagreement; never infer success from missing context.

--- a/.codex/PR000_STATE_LEDGER.md
+++ b/.codex/PR000_STATE_LEDGER.md
@@ -1,19 +1,30 @@
-# PR-000 State Ledger
+# PR-000 / R1 State Ledger
 
 Last updated: 2026-08-11 (Asia/Shanghai)
 
 ## Immutable task authority
 
-- Task: PR-000 — Open-source Development Baseline
-- Objective: establish a Windows-first, upstream-syncable, GitHub-reviewable development baseline for the AI Adaptive Agentic Learning Desktop without adding learning features.
-- Authoritative prompt: `C:\Users\Administrator\Downloads\AI_READING_PR000_OPEN_SOURCE_BASELINE_CODEX_PROMPT(1).md`
+- Task: PR-000 R1 — GitHub-native bounded baseline correction on the existing PR-000 branch; this is not PR-001.
+- Objective: retain the qualified PR-000 baseline while making the public fork the product-development repository, moving review/CI into that repository, separating blocking gates from known upstream debt, correcting frozen integration semantics, and preserving all product-scope prohibitions.
+- Authoritative prompts: `AI_READING_PR000_OPEN_SOURCE_BASELINE_CODEX_PROMPT(1).md` and `AI_READING_PR000_R1_GITHUB_NATIVE_BASELINE_CORRECTION_CODEX_PROMPT.md`.
 - Upstream repository: `https://github.com/codedogQBY/ReadAny`
-- Repository path: `D:\读书学习辅助`
+- Product repository: `https://github.com/dongxuelian11/ReadAny`
+- Repository path: `<LOCAL_WORKTREE>`
 - Branch: `chore/pr000-open-source-baseline`
 - Upstream `main` observed at task start: `3f8826c37391721289f4d6db47bacc0c73788572`
 - Base full SHA: `3f8826c37391721289f4d6db47bacc0c73788572`
 - Implementation commit before final ledger reconciliation: `1886d9b12a0ffeacae8b795f13db89a5b87edfa1`
 - Final branch HEAD: the commit containing the final ledger reconciliation; its exact SHA is verified from Git and GitHub after that commit because a Git commit cannot contain its own SHA.
+- R1 starting HEAD, re-verified locally and on GitHub: `434838b36bdb369435018e87faedf997489f1b17`.
+
+## R1 bounded correction scope
+
+- Keep the existing branch and public commit history; no reset, rebase, force push, or history rewrite.
+- Comment on and close mistaken upstream PR #648 without merging it.
+- Create the replacement PR inside `dongxuelian11/ReadAny`, base `main`, head `chore/pr000-open-source-baseline`.
+- Split CI into real blocking quality/Windows NSIS gates and an explicitly non-gating known-upstream-debt observation for full lint and full CLI tests.
+- Correct the five frozen first-release integration decisions and six canonical GitHub watchlist identities without integrating or downloading those projects.
+- Remove unnecessary local absolute paths from this public ledger while retaining recovery authority.
 
 ## Frozen scope
 
@@ -39,8 +50,11 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 - `origin`: `https://github.com/dongxuelian11/ReadAny.git`
 - GitHub CLI account: `dongxuelian11`; authentication re-verified PASS on 2026-08-11 with `repo` and `workflow` scopes.
 - Public fork: PASS — `https://github.com/dongxuelian11/ReadAny` is PUBLIC, `isFork=true`, parent `codedogQBY/ReadAny`, and fork `main` is `3f8826c37391721289f4d6db47bacc0c73788572`.
-- PR URL/state: OPEN — `https://github.com/codedogQBY/ReadAny/pull/648`; base `main` at `3f8826c37391721289f4d6db47bacc0c73788572`, head `chore/pr000-open-source-baseline` at `1886d9b12a0ffeacae8b795f13db89a5b87edfa1` before final ledger reconciliation.
-- CI checks: BLOCKED (`action_required`) — GitHub created `Windows PR` run `31447662495`, but an upstream maintainer must approve the first-time fork workflow before jobs can start: `https://github.com/codedogQBY/ReadAny/actions/runs/31447662495`.
+- R1 recovery verification: PASS — local HEAD, tracked origin branch, and GitHub branch all equal `434838b36bdb369435018e87faedf997489f1b17`; origin/upstream identities match authority; origin/upstream `main` both equal the frozen base.
+- Mistaken upstream PR: OPEN — `https://github.com/codedogQBY/ReadAny/pull/648`; exact base `3f8826c37391721289f4d6db47bacc0c73788572`, exact head `434838b36bdb369435018e87faedf997489f1b17`; no comment yet.
+- Upstream PR CI: BLOCKED (`action_required`) — final observed upstream run for the R1 starting head is `31447755045`; jobs never started because upstream-maintainer approval is required.
+- Fork-internal replacement PR: NOT_RUN — no PR exists yet for the branch in `dongxuelian11/ReadAny`.
+- Fork-internal CI: NOT_RUN.
 
 ## Materially changed files
 
@@ -51,6 +65,7 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 - `docs/PROJECT_CHARTER.md` — freezes the concise product principles.
 - `docs/UI_UX_GOVERNANCE.md` — freezes required design-skill and interaction-quality governance for later user-facing PRs.
 - `packages/app/src-tauri/tauri.ci.conf.json` — limits PR builds to a real NSIS installer and disables release-only updater signing artifacts while preserving normal release configuration.
+- R1 changes only `.github/workflows/pr-windows.yml`, `INTEGRATIONS.lock.json`, and this ledger: blocking gates are separated from visible non-gating debt, frozen integration semantics are corrected, canonical watchlist identities are recorded, and local absolute paths are removed.
 
 ## Completed
 
@@ -69,14 +84,23 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 - PASS — committed and pushed the reviewed PR-000 change set to `dongxuelian11/ReadAny:chore/pr000-open-source-baseline` without rewriting history.
 - PASS — created upstream pull request `https://github.com/codedogQBY/ReadAny/pull/648` against the exact pinned `main` base.
 - BLOCKED — upstream pull-request CI was created but cannot start until an upstream maintainer approves the fork workflow; current run conclusion is `action_required` and the contributor account cannot approve repository Actions policy.
+- PASS — R1 recovery fully reread both authoritative prompts and this ledger, then reconciled local Git, remote refs, fork identity, upstream PR #648, its blocked CI, and the absence of a fork-internal PR.
+- PASS — R1 CI correction creates two independent blocking jobs for quality and Windows NSIS production build, plus an explicitly non-gating baseline-debt observation whose real failing commands remain visibly failed and are summarized without fragile log parsing.
+- PASS — R1 integration-registry correction marks the four non-ReadAny required projects `REQUIRED_FOR_FIRST_RELEASE` and records all six canonical watchlist repository identities without guessing refs or licenses.
+- PASS — R1 structural verification parsed both JSON files and workflow YAML, enforced all 11 integration identities/statuses, found no public-ledger local absolute path, and passed `git diff --check`.
+- PASS — R1 local blocking-command verification: dependency install completed with repository-pinned pnpm 9.15.0; Core 566/566, Expo 3/3, frontend production build, and Windows Tauri NSIS production build passed.
+- FAIL (`BASELINE_FAILURE`) — R1 debt observation reproduced full lint at 1,621 errors/284 warnings and full CLI at 124/135 passing with 11 failures; no product code or baseline-debt source was changed.
 
 ## Pending / next action
 
-- BLOCKED — upstream maintainer approval is required for GitHub Actions run `31447662495`; no further contributor-side code or Git action can start these jobs.
+- PASS — implemented and locally verified the R1 workflow, integration-registry, and public-ledger corrections.
+- PENDING — commit and push R1 on the existing branch without rewriting history.
+- PENDING — comment on and close upstream PR #648 without merging it.
+- NOT_RUN — create the fork-internal replacement PR and inspect its real blocking and baseline-observation CI.
 - PASS — refreshed the Git index stat cache; `packages/app/src-tauri/Cargo.toml` is clean and has no staged or unstaged content change.
 - PASS — reviewed the complete staged diff and confirmed that it contains only the seven intended PR-000 files.
 - PASS — validated both JSON files, parsed the workflow YAML, and passed `git diff --cached --check`.
-- Next bounded action after external approval: inspect the completed PR checks only; do not enter PR-001.
+- Next bounded action: review the complete three-file R1 diff, commit, and push the existing branch without rewriting history.
 
 ## Test and build truth
 
@@ -92,13 +116,17 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 | Automated tests | FAIL | Core: PASS, 75 files/566 tests. Expo: PASS, 2 files/3 tests. CLI: `BASELINE_FAILURE`, 5/7 files and 124/135 tests passed; 11 failures remained after an approved unsandboxed rerun and concern Windows Unix/Darwin path simulation plus symlink creation. PR-000 changes no CLI source/tests. |
 | Windows desktop production build | PASS | Baseline `pnpm tauri build` compiled Rust release and produced `app.exe`, MSI, and NSIS, then exited 1 because release-only updater signing lacked `TAURI_SIGNING_PRIVATE_KEY` (`BASELINE_FAILURE`). The PR-only NSIS/no-updater-artifact config was then verified with `pnpm --filter app tauri build --config src-tauri/tauri.ci.conf.json --ci`: exit 0 and `ReadAny_1.3.5_x64-setup.exe` produced. |
 | Post-change regression verification | FAIL (`BASELINE_FAILURE`) | Re-run on 2026-08-11: lint reproduced 1,621 errors/284 warnings; CLI reproduced 11 failures with 124/135 passing. Core PASS 566/566, Expo PASS 3/3, frontend production build PASS. The bounded PR-only Windows Tauri NSIS build had already passed after the CI override was created. |
-| Pull-request CI | BLOCKED (`action_required`) | `Windows PR` run `31447662495` exists for the exact PR head, but GitHub requires upstream-maintainer approval before jobs start. No CI job result exists yet. |
+| Upstream pull-request CI | BLOCKED (`action_required`) | `Windows PR` run `31447755045` exists for R1 starting head `434838b36bdb369435018e87faedf997489f1b17`, but GitHub requires upstream-maintainer approval before jobs start. No CI job result exists. |
+| R1 dependency installation | PASS | CI-mode `corepack pnpm install --frozen-lockfile` completed for all 8 workspace projects with repository-pinned pnpm 9.15.0. An initial Windows file-lock retry and a sandbox network denial were local-environment events; the approved network retry completed successfully. |
+| R1 blocking quality commands | PASS | Core 75 files/566 tests; Expo 2 files/3 tests; frontend TypeScript/Vite production build completed. Local root-script wrappers encounter Codex runtime pnpm 11 precedence, so equivalent repository-defined package filters were executed with Corepack pnpm 9.15.0; GitHub Actions installs pnpm 9 before running the root scripts. |
+| R1 blocking Windows NSIS command | PASS | `corepack pnpm --filter app tauri build --config src-tauri/tauri.ci.conf.json --ci` exited 0 and produced `ReadAny_1.3.5_x64-setup.exe`. |
+| R1 baseline-debt observation | FAIL (`BASELINE_FAILURE`, non-gating by design) | Full lint reproduced 1,621 errors/284 warnings; full CLI tests reproduced 5/7 files and 124/135 tests passing with 11 failures. The workflow runs both commands in full, writes their real outcomes and frozen baseline to the step summary, and leaves the observation visibly failed without gating the two blocking jobs. |
+| R1 fork-internal pull-request CI | NOT_RUN | Replacement PR has not yet been created. |
 
 ## Completion determination
 
-- Fork, commit, push, and PR creation: COMPLETE.
-- Required local verification: COMPLETE with the exact pre-existing lint and CLI `BASELINE_FAILURE` results retained above.
-- Pull-request CI execution: BLOCKED by upstream-maintainer workflow approval; not falsely declared PASS or NOT_RUN.
+- Original PR-000 fork, commit, push, and upstream PR creation: COMPLETE, but upstream PR target was incorrect and is being corrected by R1.
+- R1 implementation, replacement PR, and fork-internal CI: PENDING / NOT_RUN as recorded above.
 - PR-001: NOT_STARTED and out of scope.
 
 ## Recovery protocol

--- a/.codex/PR000_STATE_LEDGER.md
+++ b/.codex/PR000_STATE_LEDGER.md
@@ -12,7 +12,8 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 - Branch: `chore/pr000-open-source-baseline`
 - Upstream `main` observed at task start: `3f8826c37391721289f4d6db47bacc0c73788572`
 - Base full SHA: `3f8826c37391721289f4d6db47bacc0c73788572`
-- Current HEAD: `3f8826c37391721289f4d6db47bacc0c73788572`
+- Implementation commit before final ledger reconciliation: `1886d9b12a0ffeacae8b795f13db89a5b87edfa1`
+- Final branch HEAD: the commit containing the final ledger reconciliation; its exact SHA is verified from Git and GitHub after that commit because a Git commit cannot contain its own SHA.
 
 ## Frozen scope
 
@@ -38,8 +39,8 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 - `origin`: `https://github.com/dongxuelian11/ReadAny.git`
 - GitHub CLI account: `dongxuelian11`; authentication re-verified PASS on 2026-08-11 with `repo` and `workflow` scopes.
 - Public fork: PASS — `https://github.com/dongxuelian11/ReadAny` is PUBLIC, `isFork=true`, parent `codedogQBY/ReadAny`, and fork `main` is `3f8826c37391721289f4d6db47bacc0c73788572`.
-- PR URL/state: NOT_RUN.
-- CI checks: NOT_RUN.
+- PR URL/state: OPEN — `https://github.com/codedogQBY/ReadAny/pull/648`; base `main` at `3f8826c37391721289f4d6db47bacc0c73788572`, head `chore/pr000-open-source-baseline` at `1886d9b12a0ffeacae8b795f13db89a5b87edfa1` before final ledger reconciliation.
+- CI checks: BLOCKED (`action_required`) — GitHub created `Windows PR` run `31447662495`, but an upstream maintainer must approve the first-time fork workflow before jobs can start: `https://github.com/codedogQBY/ReadAny/actions/runs/31447662495`.
 
 ## Materially changed files
 
@@ -65,14 +66,17 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 - PASS — recovery on 2026-08-11 reread the authoritative prompt and ledger, then re-verified branch, HEAD, log, remotes, live upstream SHA, GitHub identity, fork absence, PR absence, and material files before continuing.
 - PASS — created the real public GitHub fork and configured it as `origin`; preserved `codedogQBY/ReadAny` as `upstream`.
 - PASS — completed bounded post-change regression verification: Core 566/566, Expo 3/3, and frontend build passed; lint and CLI reproduced their exact pre-existing Windows baseline failures without new counts or failure classes.
+- PASS — committed and pushed the reviewed PR-000 change set to `dongxuelian11/ReadAny:chore/pr000-open-source-baseline` without rewriting history.
+- PASS — created upstream pull request `https://github.com/codedogQBY/ReadAny/pull/648` against the exact pinned `main` base.
+- BLOCKED — upstream pull-request CI was created but cannot start until an upstream maintainer approves the fork workflow; current run conclusion is `action_required` and the contributor account cannot approve repository Actions policy.
 
 ## Pending / next action
 
-- PENDING — commit, push, create PR, and inspect CI.
+- BLOCKED — upstream maintainer approval is required for GitHub Actions run `31447662495`; no further contributor-side code or Git action can start these jobs.
 - PASS — refreshed the Git index stat cache; `packages/app/src-tauri/Cargo.toml` is clean and has no staged or unstaged content change.
 - PASS — reviewed the complete staged diff and confirmed that it contains only the seven intended PR-000 files.
 - PASS — validated both JSON files, parsed the workflow YAML, and passed `git diff --cached --check`.
-- Next bounded action: commit the reviewed PR-000 change set.
+- Next bounded action after external approval: inspect the completed PR checks only; do not enter PR-001.
 
 ## Test and build truth
 
@@ -88,7 +92,14 @@ Last updated: 2026-08-11 (Asia/Shanghai)
 | Automated tests | FAIL | Core: PASS, 75 files/566 tests. Expo: PASS, 2 files/3 tests. CLI: `BASELINE_FAILURE`, 5/7 files and 124/135 tests passed; 11 failures remained after an approved unsandboxed rerun and concern Windows Unix/Darwin path simulation plus symlink creation. PR-000 changes no CLI source/tests. |
 | Windows desktop production build | PASS | Baseline `pnpm tauri build` compiled Rust release and produced `app.exe`, MSI, and NSIS, then exited 1 because release-only updater signing lacked `TAURI_SIGNING_PRIVATE_KEY` (`BASELINE_FAILURE`). The PR-only NSIS/no-updater-artifact config was then verified with `pnpm --filter app tauri build --config src-tauri/tauri.ci.conf.json --ci`: exit 0 and `ReadAny_1.3.5_x64-setup.exe` produced. |
 | Post-change regression verification | FAIL (`BASELINE_FAILURE`) | Re-run on 2026-08-11: lint reproduced 1,621 errors/284 warnings; CLI reproduced 11 failures with 124/135 passing. Core PASS 566/566, Expo PASS 3/3, frontend production build PASS. The bounded PR-only Windows Tauri NSIS build had already passed after the CI override was created. |
-| Pull-request CI | NOT_RUN | PR not yet created. |
+| Pull-request CI | BLOCKED (`action_required`) | `Windows PR` run `31447662495` exists for the exact PR head, but GitHub requires upstream-maintainer approval before jobs start. No CI job result exists yet. |
+
+## Completion determination
+
+- Fork, commit, push, and PR creation: COMPLETE.
+- Required local verification: COMPLETE with the exact pre-existing lint and CLI `BASELINE_FAILURE` results retained above.
+- Pull-request CI execution: BLOCKED by upstream-maintainer workflow approval; not falsely declared PASS or NOT_RUN.
+- PR-001: NOT_STARTED and out of scope.
 
 ## Recovery protocol
 

--- a/.github/workflows/pr-windows.yml
+++ b/.github/workflows/pr-windows.yml
@@ -1,0 +1,83 @@
+name: Windows PR
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint, tests, and typecheck
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Core tests
+        if: ${{ !cancelled() }}
+        run: pnpm test
+
+      - name: CLI tests
+        if: ${{ !cancelled() }}
+        run: pnpm cli:test
+
+      - name: Expo tests
+        if: ${{ !cancelled() }}
+        run: pnpm --filter @readany/app-expo test
+
+      - name: Typecheck and frontend production build
+        if: ${{ !cancelled() }}
+        run: pnpm build
+
+  windows-desktop:
+    name: Windows desktop production build
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./packages/app/src-tauri -> target"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Windows desktop installer
+        run: pnpm --filter app tauri build --config src-tauri/tauri.ci.conf.json --ci

--- a/.github/workflows/pr-windows.yml
+++ b/.github/workflows/pr-windows.yml
@@ -12,12 +12,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
-    name: Lint, tests, and typecheck
+  blocking-quality:
+    name: Blocking gate - quality
     runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -32,27 +34,53 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint
-        run: pnpm lint
+      - name: Check patch whitespace
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "pull_request") {
+            git diff --check "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+          } else {
+            git diff --check "origin/main...HEAD"
+          }
+
+      - name: Validate changed JSON and YAML configuration
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "pull_request") {
+            $range = "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+          } else {
+            $range = "origin/main...HEAD"
+          }
+
+          $files = @(git diff --name-only $range -- "*.json" "*.yml" "*.yaml")
+          foreach ($file in $files) {
+            if ([string]::IsNullOrWhiteSpace($file)) {
+              continue
+            }
+
+            Write-Host "Validating $file"
+            if ($file.EndsWith(".json")) {
+              node -e "const fs=require('node:fs'); JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));" $file
+            } else {
+              node -e "const fs=require('node:fs'); require('yaml').parse(fs.readFileSync(process.argv[1], 'utf8'));" $file
+            }
+
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }
 
       - name: Core tests
-        if: ${{ !cancelled() }}
         run: pnpm test
 
-      - name: CLI tests
-        if: ${{ !cancelled() }}
-        run: pnpm cli:test
-
       - name: Expo tests
-        if: ${{ !cancelled() }}
         run: pnpm --filter @readany/app-expo test
 
       - name: Typecheck and frontend production build
-        if: ${{ !cancelled() }}
         run: pnpm build
 
-  windows-desktop:
-    name: Windows desktop production build
+  blocking-windows-desktop:
+    name: Blocking gate - Windows NSIS production build
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -79,5 +107,58 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Windows desktop installer
+      - name: Build Windows NSIS installer
         run: pnpm --filter app tauri build --config src-tauri/tauri.ci.conf.json --ci
+
+  known-upstream-baseline-debt:
+    name: Non-gating observation - known upstream lint and CLI debt
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: "Known upstream debt: run full lint (failure is not PASS)"
+        id: full_lint
+        continue-on-error: true
+        run: pnpm lint
+
+      - name: "Known upstream debt: run full CLI tests (failure is not PASS)"
+        id: full_cli
+        continue-on-error: true
+        run: pnpm cli:test
+
+      - name: Record baseline-debt observation
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          @'
+          ## Known upstream baseline debt (non-gating observation)
+
+          | Command | Real step outcome | Frozen Windows baseline |
+          | --- | --- | --- |
+          | `pnpm lint` | `${{ steps.full_lint.outcome }}` | FAIL: 1,621 errors / 284 warnings |
+          | `pnpm cli:test` | `${{ steps.full_cli.outcome }}` | FAIL: 124/135 pass, 11 fail |
+
+          These commands ran in full. A failure is known upstream debt, not PASS. Raw logs are authoritative; any changed failure set requires review and must not be silently classified as the frozen baseline.
+          '@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Keep observed debt visibly failed without gating blocking jobs
+        if: ${{ steps.full_lint.outcome == 'failure' || steps.full_cli.outcome == 'failure' }}
+        shell: pwsh
+        run: |
+          Write-Error "Known upstream baseline debt remains failing. See the step summary and raw command logs."
+          exit 1

--- a/INTEGRATIONS.lock.json
+++ b/INTEGRATIONS.lock.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "repo": "codedogQBY/ReadAny",
+    "exact_ref": "3f8826c37391721289f4d6db47bacc0c73788572"
+  },
+  "integrations": [
+    {
+      "repo": "codedogQBY/ReadAny",
+      "role": "Upstream desktop reader foundation",
+      "integration_intent": "Maintain this repository as an upstream-syncable public fork.",
+      "status": "BASELINE",
+      "exact_ref": "3f8826c37391721289f4d6db47bacc0c73788572",
+      "license": "GPL-3.0-or-later",
+      "integration_mode": "FORK"
+    },
+    {
+      "repo": "wenhui426/read-box",
+      "role": "Candidate reading service",
+      "integration_intent": "Evaluate adapter-based reuse in a later, separately reviewed PR.",
+      "status": "FROZEN_FUTURE",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "ADAPTER"
+    },
+    {
+      "repo": "vitalysim/the-knowledge-guy",
+      "role": "Candidate knowledge workflow",
+      "integration_intent": "Evaluate isolated worker reuse in a later, separately reviewed PR.",
+      "status": "FROZEN_FUTURE",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "WORKER"
+    },
+    {
+      "repo": "HKUDS/DeepTutor",
+      "role": "Candidate tutoring engine",
+      "integration_intent": "Evaluate isolated tutoring-worker integration after alignment review.",
+      "status": "FROZEN_FUTURE",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "WORKER"
+    },
+    {
+      "repo": "garethbjohnson/gutendex",
+      "role": "Candidate public-domain catalog service",
+      "integration_intent": "Evaluate API-only catalog access in a later PR.",
+      "status": "FROZEN_FUTURE",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "API"
+    },
+    {
+      "repo": "OpenTutor",
+      "role": "Tutoring approach watchlist",
+      "integration_intent": "Reference during future alignment and reuse evaluation.",
+      "status": "WATCHLIST",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "REFERENCE"
+    },
+    {
+      "repo": "pyBKT",
+      "role": "Knowledge-tracing watchlist",
+      "integration_intent": "Reference during future learner-model evaluation.",
+      "status": "WATCHLIST",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "REFERENCE"
+    },
+    {
+      "repo": "ts-fsrs",
+      "role": "Scheduling algorithm watchlist",
+      "integration_intent": "Evaluate as a dependency only after a later alignment gate.",
+      "status": "WATCHLIST",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "REFERENCE"
+    },
+    {
+      "repo": "GenMentor",
+      "role": "Mentoring approach watchlist",
+      "integration_intent": "Reference during future agent-planning evaluation.",
+      "status": "WATCHLIST",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "REFERENCE"
+    },
+    {
+      "repo": "LearnGraph",
+      "role": "Learning-graph approach watchlist",
+      "integration_intent": "Reference during future knowledge-model evaluation.",
+      "status": "WATCHLIST",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "REFERENCE"
+    },
+    {
+      "repo": "OpenMAIC",
+      "role": "Multi-agent learning approach watchlist",
+      "integration_intent": "Reference during future agent architecture evaluation.",
+      "status": "WATCHLIST",
+      "exact_ref": null,
+      "license": "UNKNOWN",
+      "integration_mode": "REFERENCE"
+    }
+  ]
+}

--- a/INTEGRATIONS.lock.json
+++ b/INTEGRATIONS.lock.json
@@ -16,42 +16,42 @@
     },
     {
       "repo": "wenhui426/read-box",
-      "role": "Candidate reading service",
-      "integration_intent": "Evaluate adapter-based reuse in a later, separately reviewed PR.",
-      "status": "FROZEN_FUTURE",
+      "role": "Required reading service integration",
+      "integration_intent": "Must be connected through a real adapter before the first formal release; PR-000 records the requirement but does not integrate it.",
+      "status": "REQUIRED_FOR_FIRST_RELEASE",
       "exact_ref": null,
       "license": "UNKNOWN",
       "integration_mode": "ADAPTER"
     },
     {
       "repo": "vitalysim/the-knowledge-guy",
-      "role": "Candidate knowledge workflow",
-      "integration_intent": "Evaluate isolated worker reuse in a later, separately reviewed PR.",
-      "status": "FROZEN_FUTURE",
+      "role": "Required knowledge workflow integration",
+      "integration_intent": "Must be connected through a real isolated worker before the first formal release; PR-000 records the requirement but does not integrate it.",
+      "status": "REQUIRED_FOR_FIRST_RELEASE",
       "exact_ref": null,
       "license": "UNKNOWN",
       "integration_mode": "WORKER"
     },
     {
       "repo": "HKUDS/DeepTutor",
-      "role": "Candidate tutoring engine",
-      "integration_intent": "Evaluate isolated tutoring-worker integration after alignment review.",
-      "status": "FROZEN_FUTURE",
+      "role": "Required tutoring engine integration",
+      "integration_intent": "Must be connected through a real isolated tutoring worker before the first formal release; PR-000 records the requirement but does not integrate it.",
+      "status": "REQUIRED_FOR_FIRST_RELEASE",
       "exact_ref": null,
       "license": "UNKNOWN",
       "integration_mode": "WORKER"
     },
     {
       "repo": "garethbjohnson/gutendex",
-      "role": "Candidate public-domain catalog service",
-      "integration_intent": "Evaluate API-only catalog access in a later PR.",
-      "status": "FROZEN_FUTURE",
+      "role": "Required public-domain catalog integration",
+      "integration_intent": "Must be connected through its real API before the first formal release; PR-000 records the requirement but does not integrate it.",
+      "status": "REQUIRED_FOR_FIRST_RELEASE",
       "exact_ref": null,
       "license": "UNKNOWN",
       "integration_mode": "API"
     },
     {
-      "repo": "OpenTutor",
+      "repo": "zijinz456/OpenTutor",
       "role": "Tutoring approach watchlist",
       "integration_intent": "Reference during future alignment and reuse evaluation.",
       "status": "WATCHLIST",
@@ -60,7 +60,7 @@
       "integration_mode": "REFERENCE"
     },
     {
-      "repo": "pyBKT",
+      "repo": "CAHLR/pyBKT",
       "role": "Knowledge-tracing watchlist",
       "integration_intent": "Reference during future learner-model evaluation.",
       "status": "WATCHLIST",
@@ -69,7 +69,7 @@
       "integration_mode": "REFERENCE"
     },
     {
-      "repo": "ts-fsrs",
+      "repo": "open-spaced-repetition/ts-fsrs",
       "role": "Scheduling algorithm watchlist",
       "integration_intent": "Evaluate as a dependency only after a later alignment gate.",
       "status": "WATCHLIST",
@@ -78,7 +78,7 @@
       "integration_mode": "REFERENCE"
     },
     {
-      "repo": "GenMentor",
+      "repo": "GeminiLight/gen-mentor",
       "role": "Mentoring approach watchlist",
       "integration_intent": "Reference during future agent-planning evaluation.",
       "status": "WATCHLIST",
@@ -87,7 +87,7 @@
       "integration_mode": "REFERENCE"
     },
     {
-      "repo": "LearnGraph",
+      "repo": "fenago/LearnGraph",
       "role": "Learning-graph approach watchlist",
       "integration_intent": "Reference during future knowledge-model evaluation.",
       "status": "WATCHLIST",
@@ -96,7 +96,7 @@
       "integration_mode": "REFERENCE"
     },
     {
-      "repo": "OpenMAIC",
+      "repo": "THU-MAIC/OpenMAIC",
       "role": "Multi-agent learning approach watchlist",
       "integration_intent": "Reference during future agent architecture evaluation.",
       "status": "WATCHLIST",

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,0 +1,28 @@
+# Upstream provenance
+
+This repository is developed as a public fork of
+[`codedogQBY/ReadAny`](https://github.com/codedogQBY/ReadAny), licensed under
+GPL-3.0-or-later. ReadAny attribution, copyright notices, and the original license must be
+preserved.
+
+## Pinned baseline
+
+- Upstream remote: `https://github.com/codedogQBY/ReadAny.git`
+- Upstream branch: `main`
+- PR-000 baseline: `3f8826c37391721289f4d6db47bacc0c73788572`
+- Observed: 2026-08-11 (Asia/Shanghai)
+
+## Synchronizing with upstream
+
+Keep `origin` pointed at the public fork and `upstream` pointed at ReadAny. Update the fork's
+public `main` without rewriting history:
+
+```bash
+git fetch upstream
+git switch main
+git merge --ff-only upstream/main
+git push origin main
+```
+
+If a published feature branch needs a newer upstream commit, merge the reviewed upstream state
+into it. Do not force-push or rebase in ways that erase or rewrite public review history.

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,0 +1,24 @@
+# Project Charter
+
+1. This product is a **Personal Learning OS / Adaptive Agentic Learning System**, not a generic
+   AI reader.
+2. Its core objective is to find the shortest effective learning path required for a user to
+   reach real understanding or a target capability.
+3. The system is learner-centric, not book-completion-centric.
+4. Its core model consists of Goal Model, Learner Model, Knowledge Model, Agent Planning, and
+   Evidence-based Mastery.
+5. **LLM is not Authority.**
+6. Deterministic local state owns Learner, Mastery, Evidence, Goal, and Reward state.
+7. The project is **OSS-first**.
+8. Prefer **integration before invention**.
+9. Apply the **Alignment Gate before the Implementation Gate**.
+10. Core schemas must not be hard-coded as book-only. Books are the current MVP source; future
+    sources may include video, papers, web content, courses, and other knowledge media.
+11. Visual Learning is post-MVP and must not block the current book MVP.
+12. The product is Windows-first, local-first, and single-user-first.
+13. The current MVP requires DeepSeek only, but the architecture must not permanently bind to one
+    model provider.
+14. The formal MVP golden path is one complete end-to-end book-learning loop.
+15. The system optimizes the shortest effective path to understanding, not merely better text
+    explanations.
+16. Visual and interaction quality is part of product correctness, not a cosmetic afterthought.

--- a/docs/UI_UX_GOVERNANCE.md
+++ b/docs/UI_UX_GOVERNANCE.md
@@ -1,0 +1,21 @@
+# UI / UX / UE Governance
+
+PR-000 establishes governance only and makes no broad visual changes.
+
+Every later user-facing PR must use the project-approved `apple-design` and `emil-design-eng`
+skills. A PR that changes motion or animation must also use `review-animations`. The PR evidence
+must record which skills were actually used; it must never claim skill usage that did not occur.
+
+User-facing work must:
+
+- respect reduced-motion preferences;
+- intentionally design loading, empty, error, and active states;
+- use motion to support comprehension rather than decoration;
+- preserve desktop information density and reading focus; and
+- treat interaction and visual quality as correctness requirements.
+
+Apple design principles may inform interaction quality, but implementations must not copy Apple
+branding, SF Symbols, trade dress, or pixel-level UI.
+
+For PR-000, these skills are recorded as not applicable because no user-facing UI or motion was
+changed.

--- a/packages/app/src-tauri/tauri.ci.conf.json
+++ b/packages/app/src-tauri/tauri.ci.conf.json
@@ -1,0 +1,6 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": false,
+    "targets": ["nsis"]
+  }
+}


### PR DESCRIPTION
## Summary

- record the exact ReadAny upstream baseline and non-rewriting sync policy
- freeze the open-source integration watchlist, project charter, and UI/UX governance
- add real Windows pull-request CI for lint, Core/CLI/Expo tests, frontend build, and a Tauri NSIS production build
- keep release updater signing unchanged while using a bounded PR-only Tauri config that disables updater artifacts

## Exact baseline

- upstream: `https://github.com/codedogQBY/ReadAny`
- base SHA: `3f8826c37391721289f4d6db47bacc0c73788572`

## Verification

- Core tests: PASS — 75 files / 566 tests
- Expo tests: PASS — 2 files / 3 tests
- frontend production build: PASS
- Windows Tauri PR build: PASS — NSIS installer produced with `tauri.ci.conf.json`
- lint: BASELINE_FAILURE — 1,621 errors / 284 warnings before and after PR-000 (primarily CRLF checkout formatting and the committed PDF worker exceeding Biome's size limit)
- CLI tests: BASELINE_FAILURE — 5/7 files and 124/135 tests pass; 11 Windows failures reproduce in Unix/Darwin path simulation and symlink cases

No learning features, parser/RAG replacements, UI redesign, mobile restructuring, or third-party code integration are included.