### PR TITLE
fix(core): reject oversized AI chat input with friendly message

### DIFF
--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -51,6 +51,28 @@ beforeEach(() => {
 });
 
 describe("streamReadingAgent tool registration", () => {
+  it("returns a friendly message without calling the model for oversized input", async () => {
+    const events = [];
+
+    for await (const event of streamReadingAgent(
+      {
+        aiConfig: makeAIConfig(),
+        book: null,
+        bookId: "book-1",
+        semanticContext: null,
+        enabledSkills: [],
+        isVectorized: false,
+        getAvailableTools,
+      },
+      "a".repeat(32_001),
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{ type: "token", content: "内容过长，请分段提问。" }]);
+    expect(createReactAgentMock).not.toHaveBeenCalled();
+  });
+
   it("registers fallback tools when only bookId is available", async () => {
     createReactAgentMock.mockReturnValue({
       streamEvents: vi.fn(() => ({

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -3,6 +3,7 @@ import type { BaseMessage } from "@langchain/core/messages";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import i18n from "i18next";
 import { z } from "zod";
+import { estimateTokens } from "../../rag/chunker";
 /**
  * Reading Agent — AI-powered reading assistant using LangGraph ReAct agent
  *
@@ -29,6 +30,8 @@ const CHAPTER_TASK_RECURSION_LIMIT = 24;
 const DEFAULT_TOOL_TIMEOUT_MS = 45_000;
 const TOOL_EXECUTION_LIMIT = 12;
 const REPEATED_TOOL_CALL_LIMIT = 2;
+const MAX_USER_INPUT_TOKENS = 8_000;
+const USER_INPUT_TOO_LONG_MESSAGE = "内容过长，请分段提问。";
 
 const CHAPTER_LOOKUP_STOP_TOOL_NAMES = new Set([
   "resolveChapterReference",
@@ -714,6 +717,12 @@ export async function* streamReadingAgent(
   try {
     // Early abort check
     if (isAborted()) return;
+
+    // Reject oversized input before creating a model or making an API request.
+    if (estimateTokens(userInput.normalize("NFKC").trim()) > MAX_USER_INPUT_TOKENS) {
+      yield { type: "token", content: USER_INPUT_TOO_LONG_MESSAGE };
+      return;
+    }
 
     // Create chat model
     const model = await createChatModel(aiConfig, {


### PR DESCRIPTION
## 问题

用户反馈：**复制多了文字，AI 会直接断掉，无法全部解读**。

## 根因

1. 聊天输入框（ChatInput）没有长度限制
2. message-pipeline 只限制消息条数（8 条滑动窗口），不管单条长度
3. `streamReadingAgent` 把用户输入直接作为 HumanMessage 发给模型，没有任何 token 预算检查——超长输入导致 API 400 错误，流式中断

## 修复（方案A）

在 `reading-agent.ts` 发送前用 `estimateTokens()` 估算输入 token：
- 超过 8000 token → 直接返回友好提示「内容过长，请分段提问。」
- 不创建模型、不发 API 请求

## 测试

新增单元测试：验证超长输入（32001 字符）时：
- 返回友好提示消息
- 不调用模型（createReactAgentMock 未被调用）

✅ 12 个测试全部通过