### PR TITLE
fix(chat): hide reader context card

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -3,7 +3,6 @@
  */
 import { ConfigGuideDialog, type ConfigGuideType } from "@/components/shared/ConfigGuideDialog";
 import { useStreamingChat } from "@/hooks/use-streaming-chat";
-import { useReadingContext } from "@/lib/ai/reading-context-service";
 import { useChatStore } from "@/stores/chat-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { getPlatformService } from "@readany/core/services";
@@ -27,7 +26,6 @@ import {
   FileText,
   History,
   MessageCirclePlus,
-  Quote,
   Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -70,9 +68,6 @@ export function ChatPanel({ book, onNavigateToCitation }: ChatPanelProps) {
   const activeThreadId = bookId ? getActiveThreadId(bookId) : null;
   const activeThread = threads.find((t) => t.id === activeThreadId);
   const bookThreads = bookId ? getThreadsForContext(bookId) : [];
-  const readerContext = useReadingContext();
-  const activeReaderContext =
-    readerContext && readerContext.bookId === bookId ? readerContext : null;
   const firstBookThreadId = bookThreads[0]?.id;
 
   useEffect(() => {
@@ -131,23 +126,6 @@ export function ChatPanel({ book, onNavigateToCitation }: ChatPanelProps) {
   const handleRemoveQuote = useCallback((id: string) => {
     setAttachedQuotes((prev) => prev.filter((q) => q.id !== id));
   }, []);
-
-  const attachCurrentSelection = useCallback(() => {
-    const context = activeReaderContext;
-    if (!context?.selection?.text) return;
-    const selection = context.selection;
-
-    const newQuote: AttachedQuote = {
-      id: crypto.randomUUID(),
-      text: selection.text,
-      source: selection.chapterTitle || context.currentChapter.title,
-    };
-
-    setAttachedQuotes((prev) => {
-      if (prev.some((quote) => quote.text === newQuote.text)) return prev;
-      return [...prev, newQuote];
-    });
-  }, [activeReaderContext]);
 
   // Check for pending quote when component mounts (from reader selection when panel was closed)
   useEffect(() => {
@@ -450,34 +428,6 @@ export function ChatPanel({ book, onNavigateToCitation }: ChatPanelProps) {
           </div>
         )}
       </div>
-
-      {activeReaderContext ? (
-        <div className="mx-3 mb-2 rounded-md border border-border/60 bg-muted/40 px-2.5 py-2">
-          <div className="flex items-start justify-between gap-2">
-            <div className="min-w-0">
-              <p className="truncate text-[11px] font-medium text-foreground">
-                {activeReaderContext.currentChapter.title ||
-                  book?.meta?.title ||
-                  t("chat.aiAssistant")}
-              </p>
-              <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
-                {Math.round(activeReaderContext.currentPosition.percentage * 100)}%
-                {activeReaderContext.selection?.text ? " · selected text ready" : ""}
-              </p>
-            </div>
-            {activeReaderContext.selection?.text ? (
-              <button
-                type="button"
-                onClick={attachCurrentSelection}
-                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-primary/20 bg-primary/5 px-2 py-1 text-[10px] text-primary hover:bg-primary/10"
-              >
-                <Quote className="size-3" />
-                <span>Attach</span>
-              </button>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
 
       {/* Messages or empty state */}
       <div className="flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary
- remove the reader chapter/progress context card from the desktop chat panel
- keep reader context available to AI tools in the background
- preserve the existing Ask AI selection-to-quote flow

## Verification
- `pnpm --filter app exec tsc --noEmit --pretty false`
- `git diff --check`