### PR TITLE
fix(pdf): 修复移动端主题渲染问题

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -1806,6 +1806,19 @@
     function applySettings(settings) {
       if (!view || !view.renderer) return;
       const renderer = view.renderer;
+      // PDF pages are fixed-layout canvases. Reader font, line-height, custom
+      // font and paragraph-spacing rules would move the transparent text layer
+      // away from the canvas and render a second, misaligned copy of the text.
+      if (currentBookIsPdf) {
+        if (settings.paginatedLayout !== undefined) {
+          currentPaginatedLayout =
+            settings.paginatedLayout === 'single' ? 'single' : 'double';
+        }
+        if (view.isFixedLayout) {
+          applyFixedLayoutRendererSettings(renderer, currentPaginatedLayout);
+        }
+        return;
+      }
 
       // Update custom font state
       if (settings.customFontFaceCSS !== undefined) {
@@ -2100,10 +2113,17 @@
       document.body.style.color = fg;
 
       if (view && view.renderer && view.renderer.setStyles) {
-        const currentStyles = lastRendererStyles || '';
-        const themedStyles = injectThemeIntoStyles(currentStyles, bg, fg, primary);
-        view.renderer.setStyles(themedStyles);
-        syncReaderOverrideStylesForAllDocs(themedStyles);
+        if (currentBookIsPdf) {
+          view.renderer.setStyles(`
+            html, body { background-color: ${bg} !important; }
+            .textLayer span, .textLayer br { color: transparent !important; }
+          `);
+        } else {
+          const currentStyles = lastRendererStyles || '';
+          const themedStyles = injectThemeIntoStyles(currentStyles, bg, fg, primary);
+          view.renderer.setStyles(themedStyles);
+          syncReaderOverrideStylesForAllDocs(themedStyles);
+        }
       }
 
       if (view && view.setSearchIndicator) {
@@ -2115,7 +2135,9 @@
 
     // ─── PDF theme inversion (dark/sepia) with per-page smart skip ───
     var PDF_THEME_FILTERS = {
-      dark: 'invert(0.93)',
+      // Mobile dark theme uses #1c1c1e. Mapping white with invert(0.89)
+      // produces approximately #1c1c1c, avoiding a visible page/shell seam.
+      dark: 'invert(0.89)',
       // Numerically tuned (invert->sepia->contrast->brightness) so a white PDF
       // page maps almost exactly to the sepia background #f0e6d2 (rgb 240,230,210).
       sepia: 'invert(0.245) sepia(0.286) contrast(1.328) brightness(1.005)',
@@ -2168,17 +2190,24 @@
       var filter = PDF_THEME_FILTERS[currentThemeMode];
       var iframe = doc.defaultView ? doc.defaultView.frameElement : null;
       if (!iframe) return;
-      if (!filter) { iframe.style.filter = ''; return; }
+      iframe.style.filter = '';
+      iframe.style.backgroundColor = currentThemeColors.bg;
+      doc.documentElement.style.backgroundColor = currentThemeColors.bg;
+      if (doc.body) doc.body.style.backgroundColor = currentThemeColors.bg;
+      if (!filter) {
+        doc.documentElement.style.setProperty('--readany-pdf-filter', 'none');
+        return;
+      }
       var isLight = pdfPageLightCache[index];
       if (isLight === undefined) {
         waitForPdfPageCanvas(doc).then(function (canvas) {
           var light = canvas ? analyzeCanvasIsLight(canvas) : true;
           pdfPageLightCache[index] = light;
-          iframe.style.filter = light ? filter : '';
+          doc.documentElement.style.setProperty('--readany-pdf-filter', light ? filter : 'none');
         });
         return;
       }
-      iframe.style.filter = isLight ? filter : '';
+      doc.documentElement.style.setProperty('--readany-pdf-filter', isLight ? filter : 'none');
     }
 
     function reapplyPdfThemeFilters() {
@@ -2191,9 +2220,19 @@
         if (!doc || !iframe) continue;
         var index = pdfDocIndexMap.get(doc);
         if (index === undefined) continue;
-        if (!filter) { iframe.style.filter = ''; continue; }
+        iframe.style.filter = '';
+        iframe.style.backgroundColor = currentThemeColors.bg;
+        doc.documentElement.style.backgroundColor = currentThemeColors.bg;
+        if (doc.body) doc.body.style.backgroundColor = currentThemeColors.bg;
+        if (!filter) {
+          doc.documentElement.style.setProperty('--readany-pdf-filter', 'none');
+          continue;
+        }
         var isLight = pdfPageLightCache[index];
-        iframe.style.filter = isLight === false ? '' : filter;
+        doc.documentElement.style.setProperty(
+          '--readany-pdf-filter',
+          isLight === false ? 'none' : filter,
+        );
       }
     }
 
@@ -2344,6 +2383,20 @@ a { color: ${primary} !important; }
     }
 
     function applyDocStyles(doc) {
+      if (currentBookIsPdf) {
+        const styleId = '__readany_pdf_styles__';
+        let style = doc.getElementById(styleId);
+        if (!style) {
+          style = doc.createElement('style');
+          style.id = styleId;
+          doc.head.appendChild(style);
+        }
+        style.textContent = `
+          html, body { background-color: ${currentThemeColors.bg} !important; }
+          .textLayer span, .textLayer br { color: transparent !important; }
+        `;
+        return;
+      }
       syncCustomFontStylesForDoc(doc, currentCustomFontFaceCSS);
       const verticalDoc = isVerticalDoc(doc);
       if (!verticalDoc) {
@@ -5026,7 +5079,16 @@ startxref
 <meta charset="utf-8">
 <meta name="viewport" content="width=${e.width}, height=${e.height}">
 <style>
-html, body { margin: 0; padding: 0; }
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: #fff;
+}
+#canvas, #canvas canvas { display: block; }
+#canvas canvas { filter: var(--readany-pdf-filter, none); }
 ${g_}
 ${l_}
 </style>

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1806,6 +1806,19 @@
     function applySettings(settings) {
       if (!view || !view.renderer) return;
       const renderer = view.renderer;
+      // PDF pages are fixed-layout canvases. Reader font, line-height, custom
+      // font and paragraph-spacing rules would move the transparent text layer
+      // away from the canvas and render a second, misaligned copy of the text.
+      if (currentBookIsPdf) {
+        if (settings.paginatedLayout !== undefined) {
+          currentPaginatedLayout =
+            settings.paginatedLayout === 'single' ? 'single' : 'double';
+        }
+        if (view.isFixedLayout) {
+          applyFixedLayoutRendererSettings(renderer, currentPaginatedLayout);
+        }
+        return;
+      }
 
       // Update custom font state
       if (settings.customFontFaceCSS !== undefined) {
@@ -2100,10 +2113,17 @@
       document.body.style.color = fg;
 
       if (view && view.renderer && view.renderer.setStyles) {
-        const currentStyles = lastRendererStyles || '';
-        const themedStyles = injectThemeIntoStyles(currentStyles, bg, fg, primary);
-        view.renderer.setStyles(themedStyles);
-        syncReaderOverrideStylesForAllDocs(themedStyles);
+        if (currentBookIsPdf) {
+          view.renderer.setStyles(`
+            html, body { background-color: ${bg} !important; }
+            .textLayer span, .textLayer br { color: transparent !important; }
+          `);
+        } else {
+          const currentStyles = lastRendererStyles || '';
+          const themedStyles = injectThemeIntoStyles(currentStyles, bg, fg, primary);
+          view.renderer.setStyles(themedStyles);
+          syncReaderOverrideStylesForAllDocs(themedStyles);
+        }
       }
 
       if (view && view.setSearchIndicator) {
@@ -2115,7 +2135,9 @@
 
     // ─── PDF theme inversion (dark/sepia) with per-page smart skip ───
     var PDF_THEME_FILTERS = {
-      dark: 'invert(0.93)',
+      // Mobile dark theme uses #1c1c1e. Mapping white with invert(0.89)
+      // produces approximately #1c1c1c, avoiding a visible page/shell seam.
+      dark: 'invert(0.89)',
       // Numerically tuned (invert->sepia->contrast->brightness) so a white PDF
       // page maps almost exactly to the sepia background #f0e6d2 (rgb 240,230,210).
       sepia: 'invert(0.245) sepia(0.286) contrast(1.328) brightness(1.005)',
@@ -2168,17 +2190,24 @@
       var filter = PDF_THEME_FILTERS[currentThemeMode];
       var iframe = doc.defaultView ? doc.defaultView.frameElement : null;
       if (!iframe) return;
-      if (!filter) { iframe.style.filter = ''; return; }
+      iframe.style.filter = '';
+      iframe.style.backgroundColor = currentThemeColors.bg;
+      doc.documentElement.style.backgroundColor = currentThemeColors.bg;
+      if (doc.body) doc.body.style.backgroundColor = currentThemeColors.bg;
+      if (!filter) {
+        doc.documentElement.style.setProperty('--readany-pdf-filter', 'none');
+        return;
+      }
       var isLight = pdfPageLightCache[index];
       if (isLight === undefined) {
         waitForPdfPageCanvas(doc).then(function (canvas) {
           var light = canvas ? analyzeCanvasIsLight(canvas) : true;
           pdfPageLightCache[index] = light;
-          iframe.style.filter = light ? filter : '';
+          doc.documentElement.style.setProperty('--readany-pdf-filter', light ? filter : 'none');
         });
         return;
       }
-      iframe.style.filter = isLight ? filter : '';
+      doc.documentElement.style.setProperty('--readany-pdf-filter', isLight ? filter : 'none');
     }
 
     function reapplyPdfThemeFilters() {
@@ -2191,9 +2220,19 @@
         if (!doc || !iframe) continue;
         var index = pdfDocIndexMap.get(doc);
         if (index === undefined) continue;
-        if (!filter) { iframe.style.filter = ''; continue; }
+        iframe.style.filter = '';
+        iframe.style.backgroundColor = currentThemeColors.bg;
+        doc.documentElement.style.backgroundColor = currentThemeColors.bg;
+        if (doc.body) doc.body.style.backgroundColor = currentThemeColors.bg;
+        if (!filter) {
+          doc.documentElement.style.setProperty('--readany-pdf-filter', 'none');
+          continue;
+        }
         var isLight = pdfPageLightCache[index];
-        iframe.style.filter = isLight === false ? '' : filter;
+        doc.documentElement.style.setProperty(
+          '--readany-pdf-filter',
+          isLight === false ? 'none' : filter,
+        );
       }
     }
 
@@ -2344,6 +2383,20 @@ a { color: ${primary} !important; }
     }
 
     function applyDocStyles(doc) {
+      if (currentBookIsPdf) {
+        const styleId = '__readany_pdf_styles__';
+        let style = doc.getElementById(styleId);
+        if (!style) {
+          style = doc.createElement('style');
+          style.id = styleId;
+          doc.head.appendChild(style);
+        }
+        style.textContent = `
+          html, body { background-color: ${currentThemeColors.bg} !important; }
+          .textLayer span, .textLayer br { color: transparent !important; }
+        `;
+        return;
+      }
       syncCustomFontStylesForDoc(doc, currentCustomFontFaceCSS);
       const verticalDoc = isVerticalDoc(doc);
       if (!verticalDoc) {

--- a/packages/app-expo/src/hooks/use-reader-bridge.ts
+++ b/packages/app-expo/src/hooks/use-reader-bridge.ts
@@ -287,7 +287,7 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
       primary?: string;
       themeMode?: "light" | "dark" | "sepia";
     }) => {
-      const msg = JSON.stringify({ type: "setThemeColors", colors });
+      const msg = JSON.stringify({ type: "setThemeColors", colors, themeMode: colors.themeMode });
       inject(`handleCommand(${msg})`);
     },
     [inject],

--- a/packages/app-expo/src/screens/ReaderScreen.tsx
+++ b/packages/app-expo/src/screens/ReaderScreen.tsx
@@ -1230,6 +1230,7 @@ export function ReaderScreen({ route, navigation }: Props) {
       foreground: colors.foreground,
       muted: colors.mutedForeground,
       primary: colors.primary,
+      themeMode,
     });
   }, [themeMode, webViewReady]);
 

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -810,8 +810,13 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
         const filter = PDF_THEME_FILTERS[theme];
         const iframe = doc.defaultView?.frameElement as HTMLIFrameElement | null;
         if (!iframe) return;
+        const background = THEME_COLORS[theme].bg;
+        iframe.style.filter = "";
+        iframe.style.backgroundColor = background;
+        doc.documentElement.style.backgroundColor = background;
+        if (doc.body) doc.body.style.backgroundColor = background;
         if (!filter) {
-          iframe.style.filter = "";
+          doc.documentElement.style.setProperty("--readany-pdf-filter", "none");
           return;
         }
         let cache = pdfPageLightCacheRef.current.get(bookKey);
@@ -825,7 +830,10 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
           isLight = canvas ? analyzeCanvasIsLight(canvas) : true;
           cache.set(index, isLight);
         }
-        iframe.style.filter = isLight ? filter : "";
+        doc.documentElement.style.setProperty(
+          "--readany-pdf-filter",
+          isLight ? filter : "none",
+        );
       },
       [bookKey],
     );
@@ -843,12 +851,20 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
           if (!doc || !iframe) continue;
           const index = pdfDocIndexRef.current.get(doc);
           if (index == null) continue;
+          const background = THEME_COLORS[theme].bg;
+          iframe.style.filter = "";
+          iframe.style.backgroundColor = background;
+          doc.documentElement.style.backgroundColor = background;
+          if (doc.body) doc.body.style.backgroundColor = background;
           if (!filter) {
-            iframe.style.filter = "";
+            doc.documentElement.style.setProperty("--readany-pdf-filter", "none");
             continue;
           }
           const isLight = cache?.get(index);
-          iframe.style.filter = isLight === false ? "" : filter;
+          doc.documentElement.style.setProperty(
+            "--readany-pdf-filter",
+            isLight === false ? "none" : filter,
+          );
         }
       },
       [format, bookKey],

--- a/packages/foliate-js/pdf.js
+++ b/packages/foliate-js/pdf.js
@@ -495,7 +495,16 @@ const renderPage = async (page) => {
 <meta charset="utf-8">
 <meta name="viewport" content="width=${viewport.width}, height=${viewport.height}">
 <style>
-html, body { margin: 0; padding: 0; }
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: #fff;
+}
+#canvas, #canvas canvas { display: block; }
+#canvas canvas { filter: var(--readany-pdf-filter, none); }
 ${TEXT_LAYER_CSS}
 ${ANNOTATION_LAYER_CSS}
 </style>


### PR DESCRIPTION
## 修复内容

- 正确向移动端 reader 传递 light/dark/sepia 主题模式
- 深色主题匹配移动端背景色，消除页面色差
- 将滤镜限制到 PDF canvas，避免右侧和底部白边
- PDF 固定版式不再注入字号、行距和自定义字体，保持 text layer 透明，避免文字重叠

## 验证

- Android 真机验证 PDF 深色主题
- `pnpm --filter @readany/app-expo run build:reader`
- `pnpm --filter @readany/app-expo exec tsc --noEmit --pretty false`
- `pnpm --filter app exec tsc --noEmit --pretty false`