### PR TITLE
fix(ai): 修复内置模型下载失败，支持镜像端点切换与重试

### DIFF
--- a/packages/core/src/ai/embedding-worker.ts
+++ b/packages/core/src/ai/embedding-worker.ts
@@ -19,6 +19,25 @@
 let pipeline: any = null;
 let currentModelId: string | null = null;
 
+const MODEL_LOAD_MAX_ATTEMPTS = 3;
+const MODEL_LOAD_RETRY_BASE_MS = 500;
+const DEFAULT_REMOTE_HOSTS = ["https://hf-mirror.com/", "https://huggingface.co/"];
+
+function getRemoteHosts(): string[] {
+  const configured = (globalThis as { __READANY_HF_REMOTE_HOST__?: unknown })
+    .__READANY_HF_REMOTE_HOST__;
+  const hosts =
+    typeof configured === "string" ? [configured, ...DEFAULT_REMOTE_HOSTS] : DEFAULT_REMOTE_HOSTS;
+  return [...new Set(hosts.map((host) => `${host.trim().replace(/\/+$/, "")}/`).filter(Boolean))];
+}
+
+function describeError(error: unknown): { type: string; message: string } {
+  if (error instanceof Error) return { type: error.name || "Error", message: error.message };
+  return { type: typeof error, message: String(error) };
+}
+
+const wait = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
 self.onmessage = async (e: MessageEvent) => {
   const msg = e.data;
 
@@ -34,43 +53,77 @@ self.onmessage = async (e: MessageEvent) => {
 };
 
 async function handleLoad(modelId: string, hfModelId: string) {
-  try {
-    // Reuse if same model already loaded
-    if (pipeline && currentModelId === modelId) {
+  let lastError: unknown;
+  const remoteHosts = getRemoteHosts();
+
+  for (let attempt = 1; attempt <= MODEL_LOAD_MAX_ATTEMPTS; attempt++) {
+    const remoteHost = remoteHosts[(attempt - 1) % remoteHosts.length];
+    try {
+      // Reuse if same model already loaded
+      if (pipeline && currentModelId === modelId) {
+        self.postMessage({ type: "load:done" });
+        return;
+      }
+
+      // Dispose previous pipeline
+      if (pipeline) {
+        try {
+          await pipeline.dispose?.();
+        } catch {
+          /* ignore */
+        }
+        pipeline = null;
+        currentModelId = null;
+      }
+
+      const { pipeline: createPipeline, env } = await import("@huggingface/transformers");
+      env.allowLocalModels = false;
+      env.remoteHost = remoteHost;
+
+      console.info("[EmbeddingWorker] loading model", {
+        modelId,
+        hfModelId,
+        attempt,
+        remoteHost,
+      });
+
+      pipeline = await createPipeline("feature-extraction", hfModelId, {
+        progress_callback: (p: any) => {
+          if (p.status === "progress") {
+            self.postMessage({ type: "load:progress", progress: Math.round(p.progress ?? 0) });
+          }
+        },
+      });
+
+      currentModelId = modelId;
       self.postMessage({ type: "load:done" });
       return;
-    }
+    } catch (err) {
+      lastError = err;
+      const details = describeError(err);
+      console.warn("[EmbeddingWorker] model load failed", {
+        modelId,
+        hfModelId,
+        attempt,
+        remoteHost,
+        errorType: details.type,
+        error: details.message,
+      });
 
-    // Dispose previous pipeline
-    if (pipeline) {
-      try {
-        await pipeline.dispose?.();
-      } catch {
-        /* ignore */
+      // A partial model download can poison subsequent attempts. Clear only this
+      // model before retrying, then switch to the next configured host.
+      if (attempt < MODEL_LOAD_MAX_ATTEMPTS) {
+        await clearModelCacheEntries(hfModelId);
+        await wait(MODEL_LOAD_RETRY_BASE_MS * 2 ** (attempt - 1));
       }
-      pipeline = null;
-      currentModelId = null;
     }
-
-    const { pipeline: createPipeline, env } = await import("@huggingface/transformers");
-    env.allowLocalModels = false;
-
-    pipeline = await createPipeline("feature-extraction", hfModelId, {
-      progress_callback: (p: any) => {
-        if (p.status === "progress") {
-          self.postMessage({ type: "load:progress", progress: Math.round(p.progress ?? 0) });
-        }
-      },
-    });
-
-    currentModelId = modelId;
-    self.postMessage({ type: "load:done" });
-  } catch (err) {
-    self.postMessage({
-      type: "load:error",
-      error: err instanceof Error ? err.message : String(err),
-    });
   }
+
+  const details = describeError(lastError);
+  self.postMessage({
+    type: "load:error",
+    error: `模型下载失败（${details.type}）：${details.message}`,
+  });
 }
 
 async function handleEmbed(requestId: string, texts: string[]) {
@@ -136,19 +189,7 @@ async function handleClearCache(hfModelId: string) {
     }
 
     // Transformers.js uses the Cache API with cache name "transformers-cache"
-    const cacheNames = await caches.keys();
-    let deletedCount = 0;
-    for (const cacheName of cacheNames) {
-      const cache = await caches.open(cacheName);
-      const keys = await cache.keys();
-      for (const key of keys) {
-        // Match URLs containing the HuggingFace model ID
-        if (key.url.includes(hfModelId)) {
-          await cache.delete(key);
-          deletedCount++;
-        }
-      }
-    }
+    const deletedCount = await clearModelCacheEntries(hfModelId);
 
     self.postMessage({ type: "clearCache:done", deletedCount });
   } catch (err) {
@@ -157,4 +198,19 @@ async function handleClearCache(hfModelId: string) {
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+async function clearModelCacheEntries(hfModelId: string): Promise<number> {
+  if (typeof caches === "undefined") return 0;
+  const cacheNames = await caches.keys();
+  let deletedCount = 0;
+  for (const cacheName of cacheNames) {
+    const cache = await caches.open(cacheName);
+    for (const key of await cache.keys()) {
+      if (key.url.includes(hfModelId) && (await cache.delete(key))) deletedCount++;
+    }
+  }
+  if (deletedCount > 0)
+    console.info("[EmbeddingWorker] cleared cached model files", { hfModelId, deletedCount });
+  return deletedCount;
 }


### PR DESCRIPTION
## 问题
内置模型（Xenova/* embedding 模型）从 HuggingFace 直连下载，国内用户频繁报 `Failed to fetch`（#515 #555 #620）。下载失败后无重试、无诊断、残缺缓存会持续毒化后续加载。

## 修复
- **镜像端点切换**：默认优先 `hf-mirror.com`（国内可达），失败自动切换 `huggingface.co`
- **可配置端点**：支持 `globalThis.__READANY_HF_REMOTE_HOST__` 自定义
- **自动重试**：最多 3 次，指数退避（500ms/1s），重试前清理该模型残缺缓存
- **诊断日志**：记录模型 ID、远端地址、尝试次数、错误类型/信息
- 统一缓存清理逻辑，兼容无 Cache API 环境

## 验证
- `pnpm --filter @readany/core test`：580 个测试全部通过
- Biome 格式检查通过（仅保留原有的 2 个 any 警告）

Fixes #515 #555 #620