### PR TITLE
feat(chat): AI 对话顶部显示选中文本原句，提问时可对照

### DIFF
--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -235,7 +235,8 @@ export function BookChatScreen({ route, navigation }: Props) {
     return convertToMessageV2(activeThread.messages);
   }, [activeThread]);
 
-  const activeCurrentMessage = activeThread?.id === currentMessage?.threadId ? currentMessage : null;
+  const activeCurrentMessage =
+    activeThread?.id === currentMessage?.threadId ? currentMessage : null;
   const allMessages = useMemo(
     () => mergeMessagesWithStreaming(messagesV2, activeCurrentMessage, isStreaming),
     [activeCurrentMessage, isStreaming, messagesV2],
@@ -526,6 +527,14 @@ export function BookChatScreen({ route, navigation }: Props) {
           </View>
 
           <View style={s.content}>
+            {selectedText?.trim() ? (
+              <View style={s.selectionContext} accessibilityLabel="Selected text context">
+                <Text style={s.selectionContextLabel}>{t("chat.selectedText", "选中文本")}</Text>
+                <Text style={s.selectionContextText} numberOfLines={4}>
+                  “{selectedText.trim()}”
+                </Text>
+              </View>
+            ) : null}
             <View style={s.content}>
               {allMessages.length > 0 ? (
                 <MessageList
@@ -661,6 +670,28 @@ const makeStyles = (
       justifyContent: "center",
     },
     content: { flex: 1 },
+    selectionContext: {
+      marginHorizontal: layout.isTabletLandscape ? 20 : 12,
+      marginTop: 8,
+      marginBottom: 4,
+      paddingHorizontal: 12,
+      paddingVertical: 9,
+      borderRadius: radius.md,
+      borderLeftWidth: 3,
+      borderLeftColor: colors.primary,
+      backgroundColor: withOpacity(colors.muted, 0.72),
+    },
+    selectionContextLabel: {
+      fontSize: fs.xs,
+      fontWeight: fw.semibold,
+      color: colors.primary,
+      marginBottom: 3,
+    },
+    selectionContextText: {
+      fontSize: fs.sm,
+      lineHeight: 19,
+      color: colors.foreground,
+    },
     emptyContainer: {
       flex: 1,
       justifyContent: "center",

--- a/packages/core/src/i18n/locales/en/chat.json
+++ b/packages/core/src/i18n/locales/en/chat.json
@@ -18,6 +18,7 @@
     "askPlaceholder": "Ask about your books...",
     "askBookPlaceholder": "Ask about your book...",
     "askAboutQuote": "Ask about the selected text...",
+    "selectedText": "Selected text",
     "suggestions": {
       "summarizeReading": "Summarize my recent reading",
       "analyzeArguments": "Analyze key arguments",

--- a/packages/core/src/i18n/locales/zh/chat.json
+++ b/packages/core/src/i18n/locales/zh/chat.json
@@ -18,6 +18,7 @@
     "askPlaceholder": "输入你的问题...",
     "askBookPlaceholder": "关于这本书的问题...",
     "askAboutQuote": "关于选中的文本提问...",
+    "selectedText": "选中文本",
     "suggestions": {
       "summarizeReading": "总结我最近的阅读",
       "analyzeArguments": "分析核心论点",


### PR DESCRIPTION
## 需求
issue #664：选中文本切换到 AI 页面后看不到原句，用户只能凭记忆提问。

## 实现
- 复用现有 `ReaderScreen → navigation.navigate("BookChat", { selectedText })` 数据流，无需新增持久化状态
- AI 对话内容顶部增加「选中文本」上下文卡片（最多 4 行，带引号，主色左边框）
- 无选中文本时不显示该区域
- 与现有初始提问逻辑（selectedText 作为首条消息）互补：既显示原句，也保留提问入口

## 验证
- chat-store / selection-note 相关测试 6 个全部通过
- BookChatScreen.tsx Biome 检查通过

Closes #664