### PR TITLE
fix(reader): 目录/链接点击不再被"点按翻页"误判

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -2472,6 +2472,20 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
         };
 
         const handlePointerUp = (ev: PointerEvent) => {
+          // Clicks on links are handled by their own navigation (internal
+          // links / footnotes); never treat them as page-turn taps. Use
+          // composedPath() with a realm-independent nodeType check: ev.target
+          // can be a Text node, and elements from content iframes fail
+          // `instanceof Element` (different realm than the parent window).
+          let pointerUpOnLink = false;
+          try {
+            const path = ev.composedPath?.() ?? [];
+            pointerUpOnLink = path.some((node) => {
+              if (!node || (node as Node).nodeType !== 1) return false;
+              const el = node as Element;
+              return typeof el.closest === "function" && Boolean(el.closest("a[href]"));
+            });
+          } catch {}
           // Capture coordinates immediately (before setTimeout)
           const clientX = ev.clientX;
           const clientY = ev.clientY;
@@ -2530,7 +2544,7 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
             } else {
               // No previous selection and no new selection
               // This is a simple click - toggle toolbar if there was no selection before
-              if (!hadSelectionOnPointerDown.current && !hasSelectionNow) {
+              if (!hadSelectionOnPointerDown.current && !hasSelectionNow && !pointerUpOnLink) {
                 // Send message to toggle toolbar
                 console.log("[ReaderTap][iframe:post]", {
                   bookKey,


### PR DESCRIPTION
### 症状

点击书内目录页的章节链接时，"闪一下又跳回目录页"或"跳到上一章末尾"，且间歇性——取决于链接在屏幕上的左右位置。点击注脚链接则正常。

### 根因

内容 iframe 的"单击检测器"把链接点击也当成了点按翻页：

1. 点链接 → foliate 正常导航到目标章节；
2. 同时 pointerup 处理器把这次点击作为"单击"postMessage 给父窗口；
3. 父窗口按点击 x 坐标分区：链接在屏幕左区 → 触发 `prev()`，其 `#turnPage` 在等待后台预加载后把阅读位置拉回上一章，覆盖链接导航。

**为什么注脚链接没问题**：注脚 handler 在 click 阶段置位 `annotationClickedRef`，挡住了翻页消息；普通链接不经过该路径。

### 修复

`FoliateViewer` 的 `handlePointerUp`：用 `composedPath()` + **realm 无关的 `nodeType === 1`** 判断点击路径中是否命中 `a[href]`，命中即跳过翻页消息。

不能用 `ev.target instanceof Element` 的原因（前期排查踩过的坑）：
- `ev.target` 落在文本节点上时不是 Element；
- 内容 iframe 的元素与父窗口不在同一 realm，父窗口的 `Element` 构造函数对其 `instanceof` 恒为 false。

### 验证

- 反复点击各章节链接，稳定落在目标章节，不再闪回/跳错章。
- 注脚点击、正文选区、左右区点按翻页行为不变。