### PR TITLE
fix(ai): stabilize tool calls and citation jumps

### DIFF
--- a/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
+++ b/packages/core/src/ai/__tests__/reading-agent-tools.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import type { AIConfig } from "../../types";
 import { isOutputLimitTermination, streamReadingAgent } from "../agents/reading-agent";
 import type { ToolDefinition } from "../tools";
@@ -61,7 +62,9 @@ describe("isOutputLimitTermination", () => {
 
   it("does not guess from normal completion metadata", () => {
     expect(isOutputLimitTermination({ response_metadata: { finish_reason: "stop" } })).toBe(false);
-    expect(isOutputLimitTermination({ additional_kwargs: { finish_reason: "tool_calls" } })).toBe(false);
+    expect(isOutputLimitTermination({ additional_kwargs: { finish_reason: "tool_calls" } })).toBe(
+      false,
+    );
     expect(isOutputLimitTermination(undefined)).toBe(false);
   });
 });
@@ -122,6 +125,86 @@ describe("streamReadingAgent tool registration", () => {
     expect(toolNames).toContain("fallbackSearch");
     expect(toolNames).toContain("fallbackChapterContext");
     expect(toolNames).toContain("addCitation");
+  });
+
+  it("registers tool schemas that can be represented as JSON Schema", async () => {
+    createReactAgentMock.mockReturnValue({
+      streamEvents: vi.fn(() => ({
+        [Symbol.asyncIterator]: async function* () {
+          // no-op stream
+        },
+      })),
+    });
+
+    for await (const _event of streamReadingAgent(
+      {
+        aiConfig: makeAIConfig(),
+        book: null,
+        bookId: "book-1",
+        semanticContext: null,
+        enabledSkills: [],
+        isVectorized: false,
+        getAvailableTools,
+      },
+      "介绍一下这本书",
+    )) {
+      // drain stream
+    }
+
+    const call = createReactAgentMock.mock.calls[createReactAgentMock.mock.calls.length - 1]?.[0];
+    for (const registeredTool of call.tools as Array<{
+      schema: Parameters<typeof z.toJSONSchema>[0];
+    }>) {
+      expect(() => z.toJSONSchema(registeredTool.schema)).not.toThrow();
+    }
+  });
+
+  it("normalizes common string and JSON-shaped tool arguments before execution", async () => {
+    createReactAgentMock.mockReturnValue({
+      streamEvents: vi.fn(() => ({
+        [Symbol.asyncIterator]: async function* () {
+          // no-op stream
+        },
+      })),
+    });
+    const execute = vi.fn(async () => ({ ok: true }));
+    const tools: ToolDefinition[] = [
+      {
+        name: "flexibleTool",
+        description: "Accept common model argument variants",
+        parameters: {
+          count: { type: "number", description: "Count", required: true },
+          enabled: { type: "boolean", description: "Enabled", required: true },
+          updates: { type: "string", description: "Updates JSON", required: true },
+        },
+        execute,
+      },
+    ];
+
+    for await (const _event of streamReadingAgent(
+      {
+        aiConfig: makeAIConfig(),
+        book: null,
+        bookId: "book-1",
+        semanticContext: null,
+        enabledSkills: [],
+        isVectorized: false,
+        getAvailableTools: () => tools,
+      },
+      "run tool",
+    )) {
+      // drain stream
+    }
+
+    const call = createReactAgentMock.mock.calls[createReactAgentMock.mock.calls.length - 1]?.[0];
+    const registeredTool = (call.tools as Array<{ func: (input: unknown) => Promise<string> }>)[0];
+    await registeredTool.func({ count: "3", enabled: "true", updates: { title: "New" } });
+
+    expect(execute).toHaveBeenCalledWith({
+      count: 3,
+      enabled: true,
+      updates: JSON.stringify({ title: "New" }),
+    });
   });
 
   it("returns a structured error when a tool execution times out", async () => {

--- a/packages/core/src/ai/__tests__/system-prompt.test.ts
+++ b/packages/core/src/ai/__tests__/system-prompt.test.ts
@@ -37,7 +37,8 @@ describe("buildSystemPrompt citations", () => {
 
     expect(prompt).toContain("Fallback Source Requirements");
     expect(prompt).toContain("If the exact fallback result/chunk you cite has a non-empty cfi");
-    expect(prompt).toContain("Call addCitation before writing the final response body");
+    expect(prompt).toContain("If the result has no cfi, still call addCitation with an empty cfi");
+    expect(prompt).toContain("resolve the paragraph CFI");
     expect(prompt).toContain("Use [1], [2], [3] markers only after addCitation succeeds");
     expect(prompt).toContain("Never invent a CFI");
     expect(prompt).toContain("addCitation");
@@ -107,7 +108,29 @@ describe("buildSystemPrompt citations", () => {
     expect(prompt).toContain("- addCitation");
     expect(prompt).not.toContain("- getReadingProgress");
     expect(prompt).not.toContain("Get overall reading progress");
-    expect(prompt).not.toContain("- ragSearch");
+    expect(prompt).not.toContain("ragSearch");
+    expect(prompt).not.toContain("ragContext");
+    expect(prompt).not.toContain("fallbackSearch");
     expect(prompt).not.toContain("Semantic/keyword search across book content");
+  });
+
+  it("keeps workflow instructions aligned with library-only tools", () => {
+    const prompt = buildSystemPrompt({
+      book: makeBook(),
+      semanticContext: null,
+      enabledSkills: [],
+      isVectorized: true,
+      userLanguage: "en",
+      questionCategory: "library_request",
+      allowedToolNames: ["listBooks", "getReadingStats"],
+    });
+
+    expect(prompt).toContain("- listBooks");
+    expect(prompt).toContain("- getReadingStats");
+    expect(prompt).toContain("This turn does not expose book-content retrieval tools");
+    expect(prompt).not.toContain("ragSearch");
+    expect(prompt).not.toContain("fallbackSearch");
+    expect(prompt).not.toContain("addCitation");
+    expect(prompt).not.toContain("mindmap");
   });
 });

--- a/packages/core/src/ai/__tests__/tools.test.ts
+++ b/packages/core/src/ai/__tests__/tools.test.ts
@@ -799,6 +799,39 @@ describe("fallback content tools", () => {
     expect(result.cfi).toBe("epubcfi(/6/2!/4/4)");
   });
 
+  it("resolves a fallback citation when the model abbreviates the quote with an ellipsis", async () => {
+    registerFallbackChapters([
+      {
+        index: 11,
+        title: "重游泰国",
+        content:
+          "找人帮忙代填表格，结果第一道填错了，中间还重新排了一次队。工作人员告知，签证需要6~8个工作日才能办下来。",
+        segments: [
+          {
+            text: "找人帮忙代填表格，结果第一道填错了，中间还重新排了一次队。工作人员告知，签证需要6~8个工作日才能办下来。",
+            cfi: "epubcfi(/6/24!/4/8)",
+          },
+        ],
+      },
+    ]);
+    vi.mocked(getChunks).mockResolvedValue([]);
+
+    const tools = getAvailableTools({ bookId: "book-1", isVectorized: false, enabledSkills: [] });
+    const tool = findTool(tools, "addCitation");
+    const result = (await tool.execute({
+      citationIndex: 1,
+      chapterTitle: "重游泰国",
+      chapterIndex: 11,
+      cfi: "",
+      quotedText:
+        "找人帮忙代填表格，结果第一道填错了……工作人员告知，签证需要6-8个工作日才能办下来。",
+      reasoning: "fallback source",
+    })) as any;
+
+    expect(result.type).toBe("citation");
+    expect(result.cfi).toBe("epubcfi(/6/24!/4/8)");
+  });
+
   it("rejects fallback citations that cannot be resolved", async () => {
     registerFallbackChapters();
     vi.mocked(getChunks).mockResolvedValue([]);

--- a/packages/core/src/ai/agents/reading-agent.ts
+++ b/packages/core/src/ai/agents/reading-agent.ts
@@ -30,6 +30,32 @@ const CHAPTER_TASK_RECURSION_LIMIT = 24;
 const DEFAULT_TOOL_TIMEOUT_MS = 45_000;
 const TOOL_EXECUTION_LIMIT = 12;
 const REPEATED_TOOL_CALL_LIMIT = 2;
+const TOOL_TIMEOUT_MS_BY_NAME: Record<string, number> = {
+  getSelection: 5_000,
+  getCurrentChapter: 5_000,
+  getReadingProgress: 5_000,
+  getSurroundingContext: 8_000,
+  getRecentHighlights: 8_000,
+  getAnnotations: 8_000,
+  addCitation: 20_000,
+  ragSearch: 30_000,
+  ragToc: 20_000,
+  ragContext: 30_000,
+  summarize: 35_000,
+  extractEntities: 35_000,
+  analyzeArguments: 35_000,
+  findQuotes: 35_000,
+  compareSections: 35_000,
+  fallbackSearch: 60_000,
+  fallbackToc: 45_000,
+  fallbackChapterContext: 60_000,
+  classifyBooks: 60_000,
+  tagBooks: 30_000,
+  manageBookTags: 30_000,
+  updateBookMetadata: 30_000,
+  manageBookGroups: 30_000,
+  mindmap: 10_000,
+};
 const MAX_USER_INPUT_TOKENS = 8_000;
 const USER_INPUT_TOO_LONG_MESSAGE = "内容过长，请分段提问。";
 
@@ -52,7 +78,8 @@ export function isOutputLimitTermination(output: unknown): boolean {
 
   return metadata.some((value) => {
     if (!value || typeof value !== "object") return false;
-    const reason = (value as Record<string, unknown>).finish_reason ??
+    const reason =
+      (value as Record<string, unknown>).finish_reason ??
       (value as Record<string, unknown>).finishReason;
     return typeof reason === "string" && OUTPUT_LIMIT_FINISH_REASONS.has(reason.toLowerCase());
   });
@@ -581,13 +608,17 @@ function buildZodSchema(
 
     switch (param.type) {
       case "number":
-        fieldSchema = z.number().describe(param.description);
+        fieldSchema = z.union([z.number(), z.string()]).describe(param.description);
         break;
       case "boolean":
-        fieldSchema = z.boolean().describe(param.description);
+        fieldSchema = z.union([z.boolean(), z.string()]).describe(param.description);
         break;
       default:
-        fieldSchema = z.string().describe(param.description);
+        fieldSchema = /json/i.test(param.description)
+          ? z
+              .union([z.string(), z.record(z.string(), z.unknown()), z.array(z.unknown())])
+              .describe(param.description)
+          : z.string().describe(param.description);
         break;
     }
 
@@ -599,6 +630,31 @@ function buildZodSchema(
   }
 
   return z.object(shape);
+}
+
+function normalizeToolInput(
+  parameters: Record<string, ToolParameter>,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const normalized = { ...input };
+  for (const [key, param] of Object.entries(parameters)) {
+    const value = normalized[key];
+    if (param.type === "number" && typeof value === "string" && value.trim()) {
+      const numberValue = Number(value);
+      if (Number.isFinite(numberValue)) normalized[key] = numberValue;
+    } else if (param.type === "boolean" && typeof value === "string") {
+      const booleanValue = value.trim().toLowerCase();
+      if (booleanValue === "true") normalized[key] = true;
+      else if (booleanValue === "false") normalized[key] = false;
+    } else if (
+      param.type === "string" &&
+      /json/i.test(param.description) &&
+      (Array.isArray(value) || (value !== null && typeof value === "object"))
+    ) {
+      normalized[key] = JSON.stringify(value);
+    }
+  }
+  return normalized;
 }
 
 function countToolParameters(tools: ToolDefinition[]): number {
@@ -620,16 +676,68 @@ function withToolTimeout<T>(promise: Promise<T>, timeoutMs: number, toolName: st
   });
 }
 
+function getToolTimeoutMs(tool: ToolDefinition, defaultTimeoutMs: number): number {
+  return tool.timeoutMs ?? TOOL_TIMEOUT_MS_BY_NAME[tool.name] ?? defaultTimeoutMs;
+}
+
+function compactToolLogValue(value: unknown, maxLength = 240): unknown {
+  if (typeof value === "string") {
+    if (value.length <= maxLength) return value;
+    return `${value.slice(0, maxLength)}...(${value.length} chars)`;
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 8).map((item) => compactToolLogValue(item, 120));
+  }
+  if (!value || typeof value !== "object") return value;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, childValue] of Object.entries(value as Record<string, unknown>).slice(0, 12)) {
+    result[key] = compactToolLogValue(childValue, 120);
+  }
+  return result;
+}
+
 async function executeTool(
   tool: ToolDefinition,
   args: Record<string, unknown>,
   timeoutMs: number,
 ): Promise<unknown> {
+  const startedAt = Date.now();
+  console.log(
+    "[ReadingAgent][tool-start]",
+    JSON.stringify({
+      name: tool.name,
+      timeoutMs,
+      args: compactToolLogValue(args),
+    }),
+  );
   try {
-    return await withToolTimeout(Promise.resolve(tool.execute(args)), timeoutMs, tool.name);
+    const result = await withToolTimeout(Promise.resolve(tool.execute(args)), timeoutMs, tool.name);
+    console.log(
+      "[ReadingAgent][tool-end]",
+      JSON.stringify({
+        name: tool.name,
+        durationMs: Date.now() - startedAt,
+        ok: true,
+        result: compactToolLogValue(result),
+      }),
+    );
+    return result;
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const payload = {
+      name: tool.name,
+      durationMs: Date.now() - startedAt,
+      ok: false,
+      error: message,
+    };
+    if (/timed out/i.test(message)) {
+      console.warn("[ReadingAgent][tool-timeout]", JSON.stringify(payload));
+    } else {
+      console.warn("[ReadingAgent][tool-error]", JSON.stringify(payload));
+    }
     return {
-      error: error instanceof Error ? error.message : String(error),
+      error: message,
     };
   }
 }
@@ -892,7 +1000,7 @@ export async function* streamReadingAgent(
         description: tool.description,
         schema,
         func: async (input) => {
-          const toolInput = { ...(input as Record<string, unknown>) };
+          const toolInput = normalizeToolInput(tool.parameters, input as Record<string, unknown>);
           const isChapterLookupTool = CHAPTER_LOOKUP_STOP_TOOL_NAMES.has(tool.name);
 
           if (chapterReferenceState.limitReached && isChapterLookupTool) {
@@ -981,7 +1089,7 @@ export async function* streamReadingAgent(
             return JSON.stringify(cachedResult);
           }
 
-          const result = await executeTool(tool, toolInput, toolTimeoutMs);
+          const result = await executeTool(tool, toolInput, getToolTimeoutMs(tool, toolTimeoutMs));
           if (exactCacheKey) {
             toolResultCache.set(exactCacheKey, result);
           }
@@ -1025,8 +1133,8 @@ export async function* streamReadingAgent(
     );
 
     // Track tool calls already emitted (from streaming chunks or on_chat_model_end)
-    // so we can deduplicate against on_tool_start events.
-    let pendingEarlyToolCalls = 0;
+    // so we can deduplicate against on_tool_start events without hiding unrelated calls.
+    const pendingEarlyToolStartNames: string[] = [];
 
     // Accumulate tool_call_chunks from streaming to emit tool_call as early as possible.
     // Key: chunk index, Value: { name accumulated so far, args accumulated so far }
@@ -1142,7 +1250,7 @@ export async function* streamReadingAgent(
               // Emit as soon as we have a tool name (don't wait for full args)
               if (entry.name && !entry.emitted) {
                 entry.emitted = true;
-                pendingEarlyToolCalls++;
+                pendingEarlyToolStartNames.push(entry.name);
                 yield {
                   type: "tool_call" as const,
                   name: entry.name,
@@ -1183,25 +1291,38 @@ export async function* streamReadingAgent(
 
         if (output) {
           if (Array.isArray(toolCalls)) {
+            const alreadyEmittedNames = [...pendingEarlyToolStartNames];
             for (const tc of toolCalls) {
+              const toolName =
+                typeof tc?.name === "string"
+                  ? tc.name
+                  : typeof tc?.function?.name === "string"
+                    ? tc.function.name
+                    : "";
+              if (!toolName) continue;
+
               // Check if already emitted from streaming chunks
-              if (pendingEarlyToolCalls > 0) {
-                // Already emitted — skip but don't decrement yet (that's for on_tool_start)
+              const alreadyEmittedIndex = alreadyEmittedNames.findIndex(
+                (name) => name === toolName,
+              );
+              if (alreadyEmittedIndex >= 0) {
+                alreadyEmittedNames.splice(alreadyEmittedIndex, 1);
                 continue;
               }
               let args: Record<string, unknown>;
+              const rawArgs = tc.args ?? tc.function?.arguments;
               try {
-                args = (typeof tc.args === "string" ? JSON.parse(tc.args) : tc.args) as Record<
+                args = (typeof rawArgs === "string" ? JSON.parse(rawArgs) : rawArgs) as Record<
                   string,
                   unknown
                 >;
               } catch {
                 args = {};
               }
-              pendingEarlyToolCalls++;
+              pendingEarlyToolStartNames.push(toolName);
               yield {
                 type: "tool_call" as const,
-                name: tc.name,
+                name: toolName,
                 args,
               };
             }
@@ -1212,8 +1333,11 @@ export async function* streamReadingAgent(
       // Tool call started — skip if already emitted earlier
       if (event.event === "on_tool_start") {
         pendingToolCallNames.push(event.name);
-        if (pendingEarlyToolCalls > 0) {
-          pendingEarlyToolCalls--;
+        const pendingEarlyIndex = pendingEarlyToolStartNames.findIndex(
+          (name) => name === event.name,
+        );
+        if (pendingEarlyIndex >= 0) {
+          pendingEarlyToolStartNames.splice(pendingEarlyIndex, 1);
         } else {
           // Fallback: emit if not already emitted (e.g. non-OpenAI model)
           yield {

--- a/packages/core/src/ai/fallback-source-resolver.ts
+++ b/packages/core/src/ai/fallback-source-resolver.ts
@@ -1,5 +1,9 @@
 import { getBook } from "../db/database";
-import { type FallbackChapter, type FallbackTextSegment, fallbackContentService } from "./fallback-content-service";
+import {
+  type FallbackChapter,
+  type FallbackTextSegment,
+  fallbackContentService,
+} from "./fallback-content-service";
 
 export interface FallbackChaptersResult {
   bookTitle: string;
@@ -32,7 +36,10 @@ export async function getFallbackChaptersForBook(
 }
 
 export function normalizeForLookup(value: string): string {
-  return value.toLowerCase().replace(/\s+/g, "").trim();
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, "")
+    .trim();
 }
 
 function normalizeForTerms(value: string): string {
@@ -47,6 +54,17 @@ function getQuoteNeedles(quotedText: string): string[] {
   if (normalized.length > 80) needles.push(normalized.slice(0, 80));
   if (normalized.length > 40) needles.push(normalized.slice(0, 40));
   if (normalized.length > 24) needles.push(normalized.slice(-40));
+
+  // Models often shorten a quote with an ellipsis. Match the substantial
+  // fragments on either side instead of requiring the omitted text to be
+  // adjacent in the source paragraph.
+  for (const fragment of quotedText.split(/(?:…{1,}|\.{3,})/u)) {
+    const normalizedFragment = normalizeForLookup(fragment);
+    if (normalizedFragment.length >= 8) {
+      needles.push(normalizedFragment);
+      if (normalizedFragment.length > 40) needles.push(normalizedFragment.slice(0, 40));
+    }
+  }
 
   return Array.from(new Set(needles.filter((needle) => needle.length >= 8)));
 }

--- a/packages/core/src/ai/system-prompt.ts
+++ b/packages/core/src/ai/system-prompt.ts
@@ -49,13 +49,14 @@ export function buildSystemPrompt(ctx: PromptContext): string {
       !!(ctx.book?.id || ctx.bookId),
       ctx.allowedToolNames,
     ),
-    buildWorkflowSection(ctx.isVectorized, !!(ctx.book?.id || ctx.bookId)),
+    buildWorkflowSection(ctx.isVectorized, !!(ctx.book?.id || ctx.bookId), ctx.allowedToolNames),
     buildConstraintsSection(
       ctx.userLanguage,
       ctx.isVectorized,
       ctx.spoilerFree,
       ctx.book,
       ctx.semanticContext,
+      ctx.allowedToolNames,
     ),
   ];
 
@@ -291,9 +292,12 @@ function buildToolsSection(
       "- **getAnnotations**: Get user's highlights and notes (params: type)",
     );
     if (isVectorized && canUse("addCitation")) {
+      const citationSourceHint = canUse("ragSearch")
+        ? "ragSearch/tool results"
+        : "available tool results";
       pushTool(
         "addCitation",
-        "- **addCitation**: CRITICAL - Register a citation with CFI for precise navigation. You MUST extract the 'cfi' field from ragSearch/tool results and pass it here. The citationIndex param determines which [N] marker it maps to (params: citationIndex [REQUIRED - the number N for [N]], chapterTitle, chapterIndex, cfi [REQUIRED from tool results], quotedText, reasoning)",
+        `- **addCitation**: CRITICAL - Register a citation with CFI for precise navigation. You MUST extract the 'cfi' field from ${citationSourceHint} and pass it here. The citationIndex param determines which [N] marker it maps to (params: citationIndex [REQUIRED - the number N for [N]], chapterTitle, chapterIndex, cfi [REQUIRED from tool results], quotedText, reasoning)`,
       );
     } else if (canUse("addCitation")) {
       pushTool(
@@ -317,7 +321,35 @@ function buildToolsSection(
   return `## Available Tools\n\n${tools.join("\n")}`;
 }
 
-function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): string {
+function buildWorkflowSection(
+  isVectorized: boolean,
+  hasBookContext: boolean,
+  allowedToolNames?: string[],
+): string {
+  const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
+  const canUse = (name: string) => !allowed || allowed.has(name);
+  const anyCanUse = (names: string[]) => names.some(canUse);
+  const analysisTools = [
+    "summarize",
+    "extractEntities",
+    "analyzeArguments",
+    "findQuotes",
+    "compareSections",
+  ].filter(canUse);
+  const contentToolNames = [
+    "getSelection",
+    "getCurrentChapter",
+    "getReadingProgress",
+    "getSurroundingContext",
+    "resolveChapterReference",
+    "ragSearch",
+    "ragToc",
+    "ragContext",
+    "fallbackSearch",
+    "fallbackToc",
+    "fallbackChapterContext",
+    ...analysisTools,
+  ];
   const steps: string[] = [
     "## Core Workflow",
     "",
@@ -332,38 +364,77 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     return steps.join("\n");
   }
 
-  if (isVectorized) {
+  if (!anyCanUse(contentToolNames)) {
     steps.push(
-      "   - **resolveChapterReference**: first step for user-mentioned chapter numbers/titles; do not convert human chapter numbers to chapterIndex yourself",
+      "This turn does not expose book-content retrieval tools. Use only the tools listed in Turn-Available Tools; do not call or plan with retrieval/citation tools that are not listed.",
     );
-    steps.push(
-      "   - **ragSearch**: primary path for indexed book-content questions by topic/keyword",
-    );
-    steps.push("   - **ragToc**: for compact/paginated structure browsing");
-    steps.push(
-      "   - **summarize/extractEntities/analyzeArguments/findQuotes**: for indexed content analysis",
-    );
-  } else {
-    steps.push(
-      "   - **resolveChapterReference**: first step for user-mentioned chapter numbers/titles; do not convert human chapter numbers to chapterIndex yourself",
-    );
-    steps.push("   - **fallbackSearch**: for keyword exploration when the book is not vectorized");
-    steps.push("   - **fallbackToc**: for compact/paginated structure browsing without an index");
-    steps.push("   - **fallbackChapterContext**: for reading a specific chapter without an index");
+    return steps.join("\n");
   }
 
-  steps.push("   - **getSurroundingContext**: for current page content");
+  if (isVectorized) {
+    if (canUse("resolveChapterReference")) {
+      steps.push(
+        "   - **resolveChapterReference**: first step for user-mentioned chapter numbers/titles; do not convert human chapter numbers to chapterIndex yourself",
+      );
+    }
+    if (canUse("ragSearch")) {
+      steps.push(
+        "   - **ragSearch**: primary path for indexed book-content questions by topic/keyword",
+      );
+    }
+    if (canUse("ragToc")) steps.push("   - **ragToc**: for compact/paginated structure browsing");
+    if (analysisTools.length > 0) {
+      steps.push(`   - **${analysisTools.join("/")}**: for indexed content analysis`);
+    }
+  } else {
+    if (canUse("resolveChapterReference")) {
+      steps.push(
+        "   - **resolveChapterReference**: first step for user-mentioned chapter numbers/titles; do not convert human chapter numbers to chapterIndex yourself",
+      );
+    }
+    if (canUse("fallbackSearch")) {
+      steps.push(
+        "   - **fallbackSearch**: for keyword exploration when the book is not vectorized",
+      );
+    }
+    if (canUse("fallbackToc")) {
+      steps.push("   - **fallbackToc**: for compact/paginated structure browsing without an index");
+    }
+    if (canUse("fallbackChapterContext")) {
+      steps.push(
+        "   - **fallbackChapterContext**: for reading a specific chapter without an index",
+      );
+    }
+  }
 
-  steps.push("3. **Register citations before answering** — If your answer uses book content:");
-  steps.push("   - Call **addCitation** before writing the final response body");
-  steps.push(
-    "   - Wait for addCitation to return successfully before using the matching [N] marker",
-  );
-  steps.push("   - This rule applies to BOTH indexed books and non-indexed fallback content");
-  steps.push("4. **Synthesize and answer** — Only after citation registration, write your answer");
+  if (canUse("getSurroundingContext")) {
+    steps.push("   - **getSurroundingContext**: for current page content");
+  }
+
+  if (canUse("addCitation")) {
+    steps.push("3. **Register citations before answering** — If your answer uses book content:");
+    steps.push(
+      "   - Call **addCitation** with the returned CFI when available; for fallback results without a CFI, pass an empty cfi plus the exact chapterIndex and quotedText so the tool can resolve a jump target",
+    );
+    steps.push("   - Wait for addCitation to succeed before using the matching [N] marker");
+    steps.push("4. **Synthesize and answer** — Use only successfully registered [N] markers");
+  } else {
+    steps.push("3. **Use plain source references** — If your answer uses book content:");
+    steps.push(
+      "   - The citation tool is not available this turn; do not use clickable [N] citation markers. Cite plainly with chapter/title/excerpt information from available results.",
+    );
+    steps.push("4. **Synthesize and answer** — Write your answer using only retrieved content");
+  }
   steps.push("");
 
-  if (isVectorized) {
+  if (isVectorized && canUse("addCitation")) {
+    const sourceTools = [
+      "ragSearch",
+      "ragContext",
+      ...analysisTools,
+      "getSurroundingContext",
+      "getCurrentChapter",
+    ].filter(canUse);
     steps.push("## CRITICAL: Citation Requirements");
     steps.push("");
     steps.push("**You MUST cite all factual claims about the book's content.**");
@@ -371,7 +442,7 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     steps.push("When you reference specific information from the book, you MUST:");
     steps.push("");
     steps.push("1. **Call addCitation tool** for each source location:");
-    steps.push("   - Use chapterTitle, chapterIndex, cfi from ragSearch/tool results");
+    steps.push("   - Use chapterTitle, chapterIndex, cfi from available tool results");
     steps.push("   - Provide a short quotedText excerpt (max 200 chars)");
     steps.push("   - Each citation registers a verifiable source");
     steps.push("");
@@ -385,16 +456,18 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     steps.push("   - Specific facts, data, or statistics from the book");
     steps.push("   - Author's arguments, claims, or opinions");
     steps.push("   - Plot events, character descriptions, or story details");
-    steps.push("   - Any content retrieved via ragSearch, summarize, or content tools");
+    steps.push("   - Any content retrieved via available content tools");
     steps.push("   - General knowledge not from this book does not need citation");
     steps.push(
       "   - Your own analysis does not need citation, but cite the content you're analyzing",
     );
     steps.push("");
     steps.push("4. **Citation workflow with CFI:**");
-    steps.push(
-      "   - Step 1: Use ragSearch/ragContext or indexed analysis tools to retrieve content",
-    );
+    if (sourceTools.length > 0) {
+      steps.push(`   - Step 1: Use ${sourceTools.join("/")} to retrieve content`);
+    } else {
+      steps.push("   - Step 1: Use the available content tool results");
+    }
     steps.push("   - Step 2: Extract chapterTitle, chapterIndex, and **CFI** from tool results");
     steps.push(
       "   - Step 3: Call addCitation with the extracted CFI and set citationIndex to the number you will use in [N]",
@@ -407,14 +480,14 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
       "   - Step 5: Write your final response using [1], [2] to reference citations — each must match the citationIndex you set",
     );
     steps.push(
-      "   - **Example**: ragSearch returns {cfi: 'epubcfi(/6/52!/4...)', ...} → pass this exact CFI to addCitation",
+      "   - **Example**: a tool result returns {cfi: 'epubcfi(/6/52!/4...)', ...} -> pass this exact CFI to addCitation",
     );
     steps.push("");
     steps.push(
       "**This is MANDATORY for academic integrity and user trust. Never skip citations for book content.**",
     );
     steps.push("");
-  } else {
+  } else if (!isVectorized && canUse("addCitation")) {
     steps.push("## CRITICAL: Fallback Source Requirements");
     steps.push("");
     steps.push(
@@ -425,7 +498,9 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
     steps.push(
       "1. If the exact fallback result/chunk you cite has a non-empty cfi, call addCitation with that cfi, chapterTitle, chapterIndex, and quotedText",
     );
-    steps.push("2. Call addCitation before writing the final response body");
+    steps.push(
+      "2. If the result has no cfi, still call addCitation with an empty cfi, the exact chapterIndex, and a verbatim quotedText excerpt; the tool will resolve the paragraph CFI",
+    );
     steps.push("3. Use [1], [2], [3] markers only after addCitation succeeds");
     steps.push(
       "4. The citationIndex values MUST follow the final response marker order exactly: the source for [1] uses citationIndex=1, [2] uses citationIndex=2, etc. Never swap citationIndex values even if tool calls complete out of order.",
@@ -441,32 +516,51 @@ function buildWorkflowSection(isVectorized: boolean, hasBookContext: boolean): s
   }
 
   steps.push("### Tool-Calling Discipline (CRITICAL)");
-  steps.push(
-    '- **NEVER call the same tool repeatedly with similar/identical arguments.** If ragSearch("人物") returned results, DO NOT call ragSearch("人物介绍"), ragSearch("人物关系") etc. Use the results you already have.',
-  );
+  const primarySearchTool = canUse("ragSearch")
+    ? "ragSearch"
+    : canUse("fallbackSearch")
+      ? "fallbackSearch"
+      : undefined;
+  if (primarySearchTool) {
+    steps.push(
+      `- **NEVER call the same tool repeatedly with similar/identical arguments.** If ${primarySearchTool}("人物") returned results, DO NOT call ${primarySearchTool}("人物介绍"), ${primarySearchTool}("人物关系") etc. Use the results you already have.`,
+    );
+  } else {
+    steps.push(
+      "- **NEVER call the same available tool repeatedly with similar/identical arguments.** Use the results you already have.",
+    );
+  }
   steps.push(
     '- **When a tool returns `content` + `instruction` fields**: the `content` IS your data. Read it, follow the `instruction` to analyze it, then write your answer. Do NOT call more tools to "find more".',
   );
   steps.push(
-    '- **Each tool call must have a distinct purpose.** Good: ragToc → summarize(chapter 1) → summarize(chapter 2). Bad: ragSearch("主题") → ragSearch("主要主题") → ragSearch("书的主题").',
+    "- **Each tool call must have a distinct purpose.** Do not use multiple similar queries to fish for the same answer.",
   );
   steps.push(
-    "- If a content retrieval/analysis tool returns enough information to answer, do NOT call more retrieval tools. If the answer uses that book content, call addCitation first, then answer.",
+    canUse("addCitation")
+      ? "- If a content retrieval/analysis tool returns enough information to answer, do NOT call more retrieval tools. Call addCitation first; for fallback content without a returned CFI, pass an empty cfi with the exact chapterIndex and verbatim quotedText so it can resolve the jump target."
+      : "- If a content retrieval/analysis tool returns enough information to answer, do NOT call more retrieval tools. If citations are unavailable, answer with plain chapter/source references.",
   );
   steps.push(
     "- If a tool returns no results or an error, tell the user honestly. Do NOT retry with rephrased queries.",
   );
-  steps.push(
-    isVectorized
-      ? "- For indexed books, prefer ragSearch/ragContext for broad content questions. Use current selection/page/chapter context first only when the user explicitly asks about what they are reading right now, then fall back to indexed retrieval if needed."
-      : "- For non-indexed books, prefer fallbackSearch/fallbackChapterContext for broad content questions. Use current selection/page/chapter context first only when the user explicitly asks about what they are reading right now, then fall back to original-file retrieval if needed.",
-  );
-  steps.push(
-    "- For a specific chapter request, call resolveChapterReference first. If matched=false, present the candidates or ask for clarification instead of guessing chapterIndex.",
-  );
-  steps.push(
-    "- For chapter lookup failures, chapter search gets at most three chances in one turn. The first uses the user's original wording, the second may use one simplified query, and the third is the last chance. After that, STOP and tell the user: 未能可靠定位章节，请补充更准确的章节名",
-  );
+  if (isVectorized && (canUse("ragSearch") || canUse("ragContext"))) {
+    steps.push(
+      "- For indexed books, prefer available indexed retrieval tools for broad content questions. Use current selection/page/chapter context first only when the user explicitly asks about what they are reading right now, then fall back to indexed retrieval if needed.",
+    );
+  } else if (!isVectorized && (canUse("fallbackSearch") || canUse("fallbackChapterContext"))) {
+    steps.push(
+      "- For non-indexed books, prefer available fallback content tools for broad content questions. Use current selection/page/chapter context first only when the user explicitly asks about what they are reading right now, then fall back to original-file retrieval if needed.",
+    );
+  }
+  if (canUse("resolveChapterReference")) {
+    steps.push(
+      "- For a specific chapter request, call resolveChapterReference first. If matched=false, present the candidates or ask for clarification instead of guessing chapterIndex.",
+    );
+    steps.push(
+      "- For chapter lookup failures, chapter search gets at most three chances in one turn. The first uses the user's original wording, the second may use one simplified query, and the third is the last chance. After that, STOP and tell the user: 未能可靠定位章节，请补充更准确的章节名",
+    );
+  }
   steps.push(
     '- For multi-step tasks (e.g. "summarize each chapter"), you MAY call tools many times — but each call must target a DIFFERENT chapter/scope. Never repeat the same query.',
   );
@@ -485,10 +579,15 @@ function buildConstraintsSection(
   spoilerFree?: boolean,
   book?: Book | null,
   semanticContext?: SemanticContext | null,
+  allowedToolNames?: string[],
 ): string {
-  const citationGuideline = isVectorized
-    ? "- When citing indexed book content, use [1], [2] format with registered citations via addCitation tool"
-    : "- When citing non-indexed fallback content, use [1], [2] only after addCitation succeeds with a returned fallback cfi; otherwise use plain chapter names/indices and quoted excerpts";
+  const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
+  const canUse = (name: string) => !allowed || allowed.has(name);
+  const citationGuideline = canUse("addCitation")
+    ? isVectorized
+      ? "- When citing indexed book content, use [1], [2] format with registered citations via addCitation tool"
+      : "- When citing non-indexed fallback content, use [1], [2] only after addCitation succeeds with a returned fallback cfi; otherwise use plain chapter names/indices and quoted excerpts"
+    : "- When citing book content, do not use clickable [N] markers unless the citation tool is available; use plain chapter names/indices and quoted excerpts instead";
   const lines = [
     "## Response Guidelines",
     `- **IMPORTANT: You MUST respond in ${language || "English"}. This is non-negotiable regardless of the book's language.**`,
@@ -512,7 +611,9 @@ function buildConstraintsSection(
     "    B -->|No| D[Action 2]",
     "```",
     "",
-    "Note: Do NOT use Mermaid for mindmaps - use the dedicated `mindmap` tool instead.",
+    canUse("mindmap")
+      ? "Note: Do NOT use Mermaid for mindmaps - use the dedicated `mindmap` tool instead."
+      : "Note: Use Mermaid diagrams only when they help the answer; do not reference unavailable tools.",
   ];
 
   if (spoilerFree && book) {
@@ -531,8 +632,20 @@ function buildConstraintsSection(
     lines.push(
       "1. **NEVER reveal** plot events, character fates, twists, deaths, relationships, or any narrative developments that occur after the reader's current position.",
     );
+    const spoilerSensitiveTools = [
+      "ragSearch",
+      "ragContext",
+      "summarize",
+      "extractEntities",
+      "findQuotes",
+      "compareSections",
+      "fallbackSearch",
+      "fallbackChapterContext",
+    ].filter(canUse);
     lines.push(
-      "2. **NEVER use tools** (ragSearch, ragContext, summarize, extractEntities, findQuotes, compareSections) to retrieve or analyze content from chapters beyond the current reading position. If a tool call would target a later chapter, DO NOT make that call.",
+      spoilerSensitiveTools.length > 0
+        ? `2. **NEVER use tools** (${spoilerSensitiveTools.join(", ")}) to retrieve or analyze content from chapters beyond the current reading position. If a tool call would target a later chapter, DO NOT make that call.`
+        : "2. **NEVER retrieve or analyze** content from chapters beyond the current reading position.",
     );
     lines.push(
       '3. **If the user explicitly asks about later content** (e.g., "What happens in Chapter 5?", "How does the book end?", "Does X character die?"), **politely decline**: explain that you want to protect their reading experience, and suggest they keep reading.',

--- a/packages/core/src/ai/tools/annotation-tools.ts
+++ b/packages/core/src/ai/tools/annotation-tools.ts
@@ -54,7 +54,7 @@ export function createAddCitationTool(bookId: string): ToolDefinition {
   return {
     name: "addCitation",
     description:
-      "CRITICAL: Register a citation for specific content from the book. You MUST call this tool whenever you reference factual information from the book in your response. This creates a verifiable citation that users can click to jump to the exact location. Returns citation metadata that you should reference using [1], [2], [3] format in your response text. The citationIndex parameter determines the number — pass 1 for [1], 2 for [2], etc.",
+      "Register a clickable citation for specific book content. Use a precise CFI returned by retrieval when available. For fallback content without a returned CFI, pass an empty cfi together with the exact chapterIndex and a verbatim quotedText excerpt; the tool will resolve the paragraph CFI. Never guess a CFI. After a successful call, use the matching [1], [2], [3] marker.",
     parameters: {
       citationIndex: {
         type: "number",

--- a/packages/core/src/ai/tools/tool-types.ts
+++ b/packages/core/src/ai/tools/tool-types.ts
@@ -7,6 +7,7 @@ export interface ToolDefinition {
   name: string;
   description: string;
   parameters: Record<string, ToolParameter>;
+  timeoutMs?: number;
   execute: (args: Record<string, unknown>) => Promise<unknown>;
 }
 


### PR DESCRIPTION
## 修复内容

- 让系统提示与本轮实际注册的 AI 工具保持一致
- 工具参数兼容数字/布尔字符串和 JSON 对象
- 为不同工具保留合理超时与诊断日志
- 按工具名称去重工具调用 UI
- 修复 Zod transform 导致的 JSON Schema 构建失败
- fallback 引用缺少 CFI 时按章节和原文反查可跳转 CFI，支持省略号和标点差异

## 验证

- Core TypeScript 检查通过
- 5 个 AI 测试文件，102 项通过
- 桌面端验证工具调用、引用登记和点击跳转