### PR TITLE
fix(reader): 让 "使用书籍自带字体" 真正作用于正文字体

### DIFF
--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -3352,16 +3352,27 @@ function getRendererStyles(settings: ViewSettings, theme: AppTheme): string {
   const layoutScale = settings.fontSize / BASELINE_FONT_SIZE;
   const scaledParagraphSpacing = Math.round(settings.paragraphSpacing * layoutScale);
 
-  // When useBookFonts is enabled (default), do not force the reader font
-  // family onto every element so the book's own fonts (e.g. embedded
-  // @font-face families) render where the book specifies them.
-  const bodyStarFontOverride =
+  // When useBookFonts is enabled (default), do not force the reader font onto
+  // html/body with !important: the book's own font-family (on html, body, or
+  // any element) must win where specified, so body text follows the book too.
+  // The reader font stays as a zero-specificity fallback via :where(). Target
+  // only `html` (not body): body then INHERITS html's font-family, so when the
+  // book sets one on html it propagates to body text instead of body being
+  // pinned to the reader font by a direct rule. When disabled, force the
+  // reader font on html/body and every descendant.
+  const readerFontOverride =
     settings.useBookFonts === false
-      ? `body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
+      ? `html, body {
+  font-family: var(--readany-font-family) !important;
+}
+body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
   font-family: var(--readany-font-family) !important;
 }
 `
-      : "";
+      : `:where(html) {
+  font-family: var(--readany-font-family);
+}
+`;
 
   return `${settings.customFontFaceCSS ? `/* Custom font faces */\n${settings.customFontFaceCSS}\n\n` : ""}/* Font styles */
 html {
@@ -3375,13 +3386,12 @@ html {
 html, body {
   background-color: ${bgColor} !important;
   color: ${fgColor} !important;
-  font-family: var(--readany-font-family) !important;
   font-size: ${settings.fontSize}px !important;
   -webkit-text-size-adjust: none;
   text-size-adjust: none;
 }
 
-${bodyStarFontOverride}
+${readerFontOverride}
 body :not(#__readany_font_size_override):not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *):not(rt):not(rp) {
   font-size: ${settings.fontSize}px !important;
 }


### PR DESCRIPTION
### 症状

开启"使用书籍自带字体"（useBookFonts，默认开）后，正文（段落文本）**始终**渲染成阅读器字体（黑体），从未跟随书籍指定的字体（如宋体/方正博雅刊宋）。只有标题、引用块等自己声明了 font-family 的元素才用书字体。

### 根因

阅读器无条件注入了：

```css
html, body { font-family: var(--readany-font-family) !important; }
```

正文继承 `body`/`html` 的字体 → 永远被 `!important` 强制成阅读器字体。useBookFonts 只影响 `body *`（后代元素）的覆盖，**管不到正文**——这是 #642 实现里留下的缺陷。

### 修复

`getRendererStyles`：useBookFonts **开启**（默认）时，去掉 `html, body` 的 `!important` 字体强制，改用**零特异性**的 `:where(html)` 回退：

```css
:where(html) { font-family: var(--readany-font-family); }
```

- 书在 `html`/`body`/任何元素上声明的 font-family（0,0,1 及以上）**胜出**；
- `body` 无直接字体规则 → **从 html 继承**书的字体 → 正文跟随书籍；
- 书没声明字体时，阅读器字体作为回退（`:where` 零特异性）。

**关键细节**：只写 `:where(html)` 而非 `:where(html, body)`——如果直接写 body，body 就有自己的 font-family，不再继承 html 的书字体，正文依旧不会跟随（这正是初版踩过的坑）。

useBookFonts **关闭**时保持原行为：`html, body` + `body *` 全部 `!important` 强制阅读器字体。

### 验证

- 用指定了 serif 字体的书（如 `html { font-family: 宋体, serif }`）：
  - 开：正文显示宋体（书籍字体）
  - 关：正文显示阅读器字体（黑体）
- 未指定字体的书：两种状态下正文都用阅读器字体（回退正常）。
