### PR TITLE
fix(mobile): keep Android chat composer above keyboard

### DIFF
--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -532,6 +532,7 @@ export function BookChatScreen({ route, navigation }: Props) {
             style={s.content}
             behavior="height"
             enabled={Platform.OS === "android"}
+            keyboardVerticalOffset={insets.top}
           >
             {selectedText?.trim() ? (
               <View style={s.selectionContext} accessibilityLabel="Selected text context">

--- a/packages/app-expo/src/screens/BookChatScreen.tsx
+++ b/packages/app-expo/src/screens/BookChatScreen.tsx
@@ -13,6 +13,7 @@ import {
   Image,
   Keyboard,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -21,6 +22,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useStreamingChat } from "@/hooks";
@@ -526,7 +528,11 @@ export function BookChatScreen({ route, navigation }: Props) {
             </View>
           </View>
 
-          <View style={s.content}>
+          <KeyboardAvoidingView
+            style={s.content}
+            behavior="height"
+            enabled={Platform.OS === "android"}
+          >
             {selectedText?.trim() ? (
               <View style={s.selectionContext} accessibilityLabel="Selected text context">
                 <Text style={s.selectionContextLabel}>{t("chat.selectedText", "选中文本")}</Text>
@@ -581,7 +587,7 @@ export function BookChatScreen({ route, navigation }: Props) {
               onRemoveQuote={handleRemoveQuote}
               keyboardBottomOffset={insets.bottom}
             />
-          </View>
+          </KeyboardAvoidingView>
         </View>
       </View>
 

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -13,6 +13,7 @@ import {
   Image,
   Keyboard,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -21,6 +22,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useStreamingChat } from "@/hooks";
@@ -459,7 +461,11 @@ export function ChatScreen() {
           </View>
 
           {/* Content */}
-          <View style={s.content}>
+          <KeyboardAvoidingView
+            style={s.content}
+            behavior="height"
+            enabled={Platform.OS === "android"}
+          >
             <View style={s.content}>
               {allMessages.length > 0 ? (
                 <MessageList
@@ -485,7 +491,7 @@ export function ChatScreen() {
               isStreaming={isStreaming}
               keyboardBottomOffset={tabBarHeight}
             />
-          </View>
+          </KeyboardAvoidingView>
         </View>
       </View>
 

--- a/packages/app-expo/src/screens/ChatScreen.tsx
+++ b/packages/app-expo/src/screens/ChatScreen.tsx
@@ -179,9 +179,14 @@ export function ChatScreen() {
     ? threads.find((th) => th.id === generalActiveThreadId)
     : null;
 
-  const activeCurrentMessage = activeThread?.id === currentMessage?.threadId ? currentMessage : null;
+  const activeCurrentMessage =
+    activeThread?.id === currentMessage?.threadId ? currentMessage : null;
   const displayMessages = convertToMessageV2(activeThread?.messages || []);
-  const allMessages = mergeMessagesWithStreaming(displayMessages, activeCurrentMessage, isStreaming);
+  const allMessages = mergeMessagesWithStreaming(
+    displayMessages,
+    activeCurrentMessage,
+    isStreaming,
+  );
 
   // Handlers
   const handleSend = useCallback(
@@ -465,6 +470,7 @@ export function ChatScreen() {
             style={s.content}
             behavior="height"
             enabled={Platform.OS === "android"}
+            keyboardVerticalOffset={insets.top}
           >
             <View style={s.content}>
               {allMessages.length > 0 ? (

--- a/packages/app-expo/src/screens/chat-keyboard-layout.test.ts
+++ b/packages/app-expo/src/screens/chat-keyboard-layout.test.ts
@@ -14,7 +14,7 @@ describe("Android chat keyboard layout", () => {
         /import\s+\{\s*KeyboardAvoidingView\s*\}\s+from\s+"react-native-keyboard-controller";/,
       );
       expect(source).toMatch(
-        /<KeyboardAvoidingView\b[\s\S]*?behavior="height"[\s\S]*?enabled=\{Platform\.OS === "android"\}[\s\S]*?<ChatInput\b[\s\S]*?<\/KeyboardAvoidingView>/,
+        /<KeyboardAvoidingView\b[\s\S]*?behavior="height"[\s\S]*?enabled=\{Platform\.OS === "android"\}[\s\S]*?keyboardVerticalOffset=\{insets\.top\}[\s\S]*?<ChatInput\b[\s\S]*?<\/KeyboardAvoidingView>/,
       );
     });
   }

--- a/packages/app-expo/src/screens/chat-keyboard-layout.test.ts
+++ b/packages/app-expo/src/screens/chat-keyboard-layout.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const chatScreens = ["ChatScreen.tsx", "BookChatScreen.tsx"] as const;
+
+describe("Android chat keyboard layout", () => {
+  for (const screen of chatScreens) {
+    it(`${screen} keeps ChatInput inside Android keyboard avoidance`, () => {
+      const source = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), screen), "utf8");
+
+      expect(source).toMatch(
+        /import\s+\{\s*KeyboardAvoidingView\s*\}\s+from\s+"react-native-keyboard-controller";/,
+      );
+      expect(source).toMatch(
+        /<KeyboardAvoidingView\b[\s\S]*?behavior="height"[\s\S]*?enabled=\{Platform\.OS === "android"\}[\s\S]*?<ChatInput\b[\s\S]*?<\/KeyboardAvoidingView>/,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- keep the complete Android chat composer above an overlay IME in both mobile chat screens
- account for the top safe-area inset so Deep Thinking, Spoiler-Free, dismiss, and send remain visible at maximum multiline input height
- cover the reader flow that opens BookChat from selected text via the sparkle action
- preserve the existing iOS keyboard behavior
- add focused regression coverage for both chat layouts

## Root cause
The original fix correctly wrapped each chat's content and `ChatInput` in `react-native-keyboard-controller`'s `KeyboardAvoidingView`, but the wrapper is nested below the screen safe area and header. Its overlap calculation therefore remained short by the Android top safe-area inset. The text field moved above the keyboard, while the action row underneath it could still be covered when the multiline input reached its maximum height.

Both screens already read `insets` through `useSafeAreaInsets()`. Supplying `keyboardVerticalOffset={insets.top}` corrects that coordinate offset without hard-coded padding or changing the screen/header structure.

This is a focused follow-up to the broader keyboard work in #405 and #635 for the two chat containers that still depended on Android window resizing.

## User impact
Before this PR, selecting text in a book, tapping the AI sparkle action, and focusing the question input could hide the typed text behind the keyboard. After the first fix, long text was visible but the Deep Thinking and Spoiler-Free row could still sit underneath Gboard. The entire composer now clears the keyboard in both the regular AI tab and selected-text book chat.

## Verification
- TDD: strengthened layout contract failed for both screens before the offset was added, then passed 2/2
- `TZ=UTC pnpm --filter @readany/core test` — 81 files / 601 tests passed
- `TZ=UTC pnpm --filter @readany/app-expo test` — 11 files / 142 tests passed
- `pnpm --filter @readany/app-expo exec tsc --noEmit`
- focused Biome and `git diff --check` passed
- exact Shlai preview SHA `da63ccd79fda3216b20caf7e15bed5408654f742` built successfully: https://github.com/cha1latte/ReadAny/actions/runs/31965394987
- preview APK SHA-256: `F803F873742103719FE7B9B7CC0CBFFF68BDC47307F47839097F9B8383FB60A0`
- Pixel 9a, targetSdk 36, Gboard IME frame begins at y=1459
- regular AI tab, maximum input, both toggles enabled: final composer hint ends at y=1438
- selected text (`Beyond`) -> sparkle -> BookChat, maximum input, both toggles enabled: final composer hint ends at y=1438
- both switches were tapped successfully while the keyboard remained open; dismiss and send remained visible