### PR TITLE
feat(mobile): add OLED black theme

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -2136,8 +2136,11 @@
       const primary = colors.primary || '#3b82f6';
 
       currentThemeColors = { bg, fg, muted, primary };
-      if (themeMode === 'dark' || themeMode === 'sepia') currentThemeMode = themeMode;
-      else currentThemeMode = 'light';
+      if (themeMode === 'dark' || themeMode === 'oled' || themeMode === 'sepia') {
+        currentThemeMode = themeMode;
+      } else {
+        currentThemeMode = 'light';
+      }
 
       document.documentElement.style.setProperty('--bg', bg);
       document.documentElement.style.setProperty('--fg', fg);
@@ -2172,6 +2175,8 @@
       // Mobile dark theme uses #1c1c1e. Mapping white with invert(0.89)
       // produces approximately #1c1c1c, avoiding a visible page/shell seam.
       dark: 'invert(0.89)',
+      // OLED maps white PDF paper to true black while preserving the dark-page smart skip.
+      oled: 'invert(1)',
       // Numerically tuned (invert->sepia->contrast->brightness) so a white PDF
       // page maps almost exactly to the sepia background #f0e6d2 (rgb 240,230,210).
       sepia: 'invert(0.245) sepia(0.286) contrast(1.328) brightness(1.005)',

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -2136,8 +2136,11 @@
       const primary = colors.primary || '#3b82f6';
 
       currentThemeColors = { bg, fg, muted, primary };
-      if (themeMode === 'dark' || themeMode === 'sepia') currentThemeMode = themeMode;
-      else currentThemeMode = 'light';
+      if (themeMode === 'dark' || themeMode === 'oled' || themeMode === 'sepia') {
+        currentThemeMode = themeMode;
+      } else {
+        currentThemeMode = 'light';
+      }
 
       document.documentElement.style.setProperty('--bg', bg);
       document.documentElement.style.setProperty('--fg', fg);
@@ -2172,6 +2175,8 @@
       // Mobile dark theme uses #1c1c1e. Mapping white with invert(0.89)
       // produces approximately #1c1c1c, avoiding a visible page/shell seam.
       dark: 'invert(0.89)',
+      // OLED maps white PDF paper to true black while preserving the dark-page smart skip.
+      oled: 'invert(1)',
       // Numerically tuned (invert->sepia->contrast->brightness) so a white PDF
       // page maps almost exactly to the sepia background #f0e6d2 (rgb 240,230,210).
       sepia: 'invert(0.245) sepia(0.286) contrast(1.328) brightness(1.005)',

--- a/packages/app-expo/scripts/configure-native-variant.js
+++ b/packages/app-expo/scripts/configure-native-variant.js
@@ -3,8 +3,26 @@ const path = require("node:path");
 const { getAppVariantConfig } = require("./app-variant");
 
 const appRoot = path.resolve(__dirname, "..");
-const iosProjectPath = path.join(appRoot, "ios", "ReadAny.xcodeproj", "project.pbxproj");
-const iosInfoPlistPath = path.join(appRoot, "ios", "ReadAny", "Info.plist");
+const iosRoot = path.join(appRoot, "ios");
+
+function findIosNativePaths() {
+  if (!fs.existsSync(iosRoot)) {
+    return null;
+  }
+
+  const projectEntry = fs.readdirSync(iosRoot, { withFileTypes: true }).find(
+    (entry) => entry.isDirectory() && entry.name.endsWith(".xcodeproj"),
+  );
+  if (!projectEntry) {
+    return null;
+  }
+
+  const projectName = projectEntry.name.slice(0, -".xcodeproj".length);
+  return {
+    projectPath: path.join(iosRoot, projectEntry.name, "project.pbxproj"),
+    infoPlistPath: path.join(iosRoot, projectName, "Info.plist"),
+  };
+}
 
 function replaceAll(content, pattern, replacement) {
   pattern.lastIndex = 0;
@@ -15,7 +33,7 @@ function replaceAll(content, pattern, replacement) {
   return content.replace(pattern, replacement);
 }
 
-function syncIosProject(variant) {
+function syncIosProject(variant, iosProjectPath) {
   if (!fs.existsSync(iosProjectPath)) {
     return false;
   }
@@ -35,7 +53,7 @@ function syncIosProject(variant) {
   return true;
 }
 
-function syncIosInfoPlist(variant) {
+function syncIosInfoPlist(variant, iosInfoPlistPath) {
   if (!fs.existsSync(iosInfoPlistPath)) {
     return false;
   }
@@ -67,8 +85,13 @@ function syncIosInfoPlist(variant) {
 
 function main() {
   const variant = getAppVariantConfig();
-  const syncedProject = syncIosProject(variant);
-  const syncedInfoPlist = syncIosInfoPlist(variant);
+  const nativePaths = findIosNativePaths();
+  const syncedProject = nativePaths
+    ? syncIosProject(variant, nativePaths.projectPath)
+    : false;
+  const syncedInfoPlist = nativePaths
+    ? syncIosInfoPlist(variant, nativePaths.infoPlistPath)
+    : false;
 
   if (syncedProject || syncedInfoPlist) {
     console.log(`Synced iOS native variant: ${variant.key} (${variant.bundleIdentifier})`);

--- a/packages/app-expo/src/App.tsx
+++ b/packages/app-expo/src/App.tsx
@@ -262,7 +262,7 @@ export default function App() {
 }
 
 function AppInner() {
-  const { colors, isDark, mode } = useTheme();
+  const { colors, isDark } = useTheme();
   const loadBooks = useLibraryStore((s) => s.loadBooks);
   useUpdateChecker();
   useAutoSync(loadBooks);
@@ -287,7 +287,7 @@ function AppInner() {
       <KeyboardProvider>
         <SafeAreaProvider>
           <NavigationContainer theme={navTheme} ref={navigationRef}>
-            <StatusBar style={mode === "dark" ? "light" : "dark"} />
+            <StatusBar style={isDark ? "light" : "dark"} />
             <RootNavigator />
           </NavigationContainer>
           <UpdateDialog />

--- a/packages/app-expo/src/App.tsx
+++ b/packages/app-expo/src/App.tsx
@@ -99,7 +99,7 @@ export default function App() {
         // Vectorization and Reader Agent queries use separate core paths.
         // Synchronize the query-side service immediately and after settings
         // hydration/changes so remote semantic search works on mobile too.
-          unsubscribeRagSearch = await subscribeRagSearchConfiguration();
+        unsubscribeRagSearch = await subscribeRagSearchConfiguration();
 
         console.log("[App] bootstrap: register sync adapter");
         setSyncAdapter(new MobileSyncAdapter());

--- a/packages/app-expo/src/components/onboarding/steps/AppearancePage.tsx
+++ b/packages/app-expo/src/components/onboarding/steps/AppearancePage.tsx
@@ -33,6 +33,11 @@ export function AppearancePage() {
       icon: <Moon size={24} color={colors.foreground} />,
     },
     {
+      id: "oled",
+      name: t("settings.oled", "OLED Black"),
+      icon: <Moon size={24} color={colors.foreground} />,
+    },
+    {
       id: "sepia",
       name: t("settings.sepia", "Sepia"),
       icon: <Coffee size={24} color={colors.foreground} />,
@@ -220,9 +225,9 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     marginBottom: 12,
   },
-  themeGrid: { flexDirection: "row", gap: 8 },
+  themeGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
   themeBtn: {
-    flex: 1,
+    width: "48%",
     alignItems: "center",
     paddingVertical: 12,
     borderRadius: 12,

--- a/packages/app-expo/src/components/onboarding/steps/AppearancePage.tsx
+++ b/packages/app-expo/src/components/onboarding/steps/AppearancePage.tsx
@@ -15,7 +15,7 @@ type NavProp = NativeStackNavigationProp<OnboardingStackParamList, "Appearance">
 export function AppearancePage() {
   const { t, i18n } = useTranslation();
   const navigation = useNavigation<NavProp>();
-  const { mode: currentTheme, setMode: setTheme, colors, isDark } = useTheme();
+  const { mode: currentTheme, setMode: setTheme, colors } = useTheme();
   const insets = useSafeAreaInsets();
 
   const handleNext = () => navigation.navigate("AI");

--- a/packages/app-expo/src/hooks/use-reader-bridge.ts
+++ b/packages/app-expo/src/hooks/use-reader-bridge.ts
@@ -285,7 +285,7 @@ export function useReaderBridge(callbacks: ReaderBridgeCallbacks) {
       foreground: string;
       muted: string;
       primary?: string;
-      themeMode?: "light" | "dark" | "sepia";
+      themeMode?: "light" | "dark" | "sepia" | "oled";
     }) => {
       const msg = JSON.stringify({ type: "setThemeColors", colors, themeMode: colors.themeMode });
       inject(`handleCommand(${msg})`);

--- a/packages/app-expo/src/screens/settings/AppearanceSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/AppearanceSettingsScreen.tsx
@@ -20,6 +20,7 @@ import { SettingsHeader } from "./SettingsHeader";
 const THEMES: { id: ThemeMode; labelKey: string; fallback: string; Icon: typeof SunIcon }[] = [
   { id: "light", labelKey: "settings.light", fallback: "Light", Icon: SunIcon },
   { id: "dark", labelKey: "settings.dark", fallback: "Dark", Icon: MoonIcon },
+  { id: "oled", labelKey: "settings.oled", fallback: "OLED Black", Icon: MoonIcon },
   { id: "sepia", labelKey: "settings.sepia", fallback: "Sepia", Icon: BookOpenIcon },
 ];
 
@@ -201,9 +202,9 @@ function makeStyles(colors: ReturnType<typeof useTheme>["colors"]) {
       fontSize: fontSize.base,
       fontWeight: fontWeight.semibold,
     },
-    themeGrid: { flexDirection: "row", gap: 12 },
+    themeGrid: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
     themeCard: {
-      flex: 1,
+      width: "48%",
       alignItems: "center",
       gap: 8,
       borderRadius: radius.xl,

--- a/packages/app-expo/src/screens/settings/AppearanceSettingsScreen.tsx
+++ b/packages/app-expo/src/screens/settings/AppearanceSettingsScreen.tsx
@@ -62,12 +62,12 @@ export default function AppearanceSettingsScreen() {
 
   return (
     <SafeAreaView style={[s.container, { backgroundColor: colors.background }]} edges={["top"]}>
-      <SettingsHeader
-        title={t("settings.general", "通用")}
-        subtitle={t("settings.realtimeHint")}
-      />
+      <SettingsHeader title={t("settings.general", "通用")} subtitle={t("settings.realtimeHint")} />
 
-      <ScrollView style={s.scroll} contentContainerStyle={[s.scrollContent, { alignItems: "center" }]}>
+      <ScrollView
+        style={s.scroll}
+        contentContainerStyle={[s.scrollContent, { alignItems: "center" }]}
+      >
         <View style={{ width: "100%", maxWidth: layout.centeredContentWidth, gap: 24 }}>
           {/* Theme */}
           <View style={s.section}>
@@ -85,7 +85,7 @@ export default function AppearanceSettingsScreen() {
                       { borderColor: colors.border, backgroundColor: colors.card },
                       active && {
                         borderColor: colors.primary,
-                        backgroundColor: colors.primary + "0D",
+                        backgroundColor: `${colors.primary}0D`,
                       },
                     ]}
                     onPress={() => setMode(item.id)}
@@ -122,9 +122,7 @@ export default function AppearanceSettingsScreen() {
               onPress={() => setShowLangPicker(true)}
               activeOpacity={0.7}
             >
-              <Text style={[s.langRowLabel, { color: colors.foreground }]}>
-                {currentLangLabel}
-              </Text>
+              <Text style={[s.langRowLabel, { color: colors.foreground }]}>{currentLangLabel}</Text>
               <ChevronDownIcon size={18} color={colors.mutedForeground} />
             </TouchableOpacity>
           </View>
@@ -157,7 +155,7 @@ export default function AppearanceSettingsScreen() {
                     key={l.code}
                     style={[
                       s.langItem,
-                      { backgroundColor: isActive ? colors.primary + "10" : "transparent" },
+                      { backgroundColor: isActive ? `${colors.primary}10` : "transparent" },
                       idx < LANGUAGES.length - 1 && {
                         borderBottomWidth: StyleSheet.hairlineWidth,
                         borderBottomColor: colors.border,

--- a/packages/app-expo/src/styles/ThemeContext.tsx
+++ b/packages/app-expo/src/styles/ThemeContext.tsx
@@ -7,7 +7,7 @@ import * as SecureStore from "expo-secure-store";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-export type ThemeMode = "light" | "dark" | "sepia";
+export type ThemeMode = "light" | "dark" | "sepia" | "oled";
 
 export interface ThemeColors {
   background: string;
@@ -107,6 +107,12 @@ const darkColors: ThemeColors = {
   stone500: "#78716c",
 };
 
+// OLED theme — true-black canvas with the existing dark elevated surfaces.
+const oledColors: ThemeColors = {
+  ...darkColors,
+  background: "#000000",
+};
+
 // ── Sepia theme (from [data-theme="sepia"] in globals.css) ──
 const sepiaColors: ThemeColors = {
   background: "#f0e6d2",
@@ -143,6 +149,7 @@ const THEME_MAP: Record<ThemeMode, ThemeColors> = {
   light: lightColors,
   dark: darkColors,
   sepia: sepiaColors,
+  oled: oledColors,
 };
 
 const STORAGE_KEY = "readany-theme";
@@ -172,7 +179,7 @@ export function ThemeProvider({
 
   useEffect(() => {
     SecureStore.getItemAsync(STORAGE_KEY).then((saved) => {
-      if (saved === "light" || saved === "dark" || saved === "sepia") {
+      if (saved === "light" || saved === "dark" || saved === "sepia" || saved === "oled") {
         setModeState(saved);
       }
     });
@@ -187,7 +194,7 @@ export function ThemeProvider({
     mode,
     colors: THEME_MAP[mode],
     setMode,
-    isDark: mode === "dark",
+    isDark: mode === "dark" || mode === "oled",
   };
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
@@ -201,4 +208,4 @@ export function useTheme(): ThemeContextValue {
  * Helper: get the initial theme synchronously for static styles.
  * Components that need reactive theme should use useTheme() instead.
  */
-export { lightColors, darkColors, sepiaColors, THEME_MAP };
+export { lightColors, darkColors, sepiaColors, oledColors, THEME_MAP };

--- a/packages/app-expo/src/styles/oled-theme-contract.test.ts
+++ b/packages/app-expo/src/styles/oled-theme-contract.test.ts
@@ -47,4 +47,16 @@ describe("OLED Black mobile theme", () => {
       expect(messages.settings.oled).toBe(label);
     }
   });
+
+  it("carries OLED into the generated reader and treats PDFs as true black", () => {
+    const bridge = read("packages/app-expo/src/hooks/use-reader-bridge.ts");
+    const template = read("packages/app-expo/assets/reader/reader.template.html");
+    const built = read("packages/app-expo/assets/reader/reader.html");
+
+    expect(bridge).toContain('themeMode?: "light" | "dark" | "sepia" | "oled"');
+    for (const source of [template, built]) {
+      expect(source).toContain("themeMode === 'oled'");
+      expect(source).toMatch(/oled:\s*'invert\(1\)'/);
+    }
+  });
 });

--- a/packages/app-expo/src/styles/oled-theme-contract.test.ts
+++ b/packages/app-expo/src/styles/oled-theme-contract.test.ts
@@ -19,4 +19,32 @@ describe("OLED Black mobile theme", () => {
     expect(context).toContain('isDark: mode === "dark" || mode === "oled"');
     expect(app).toContain('<StatusBar style={isDark ? "light" : "dark"} />');
   });
+
+  it("offers OLED in both phone-safe theme pickers and every settings locale", () => {
+    const settings = read("packages/app-expo/src/screens/settings/AppearanceSettingsScreen.tsx");
+    const onboarding = read("packages/app-expo/src/components/onboarding/steps/AppearancePage.tsx");
+
+    for (const source of [settings, onboarding]) {
+      expect(source).toMatch(/id: "oled"/);
+      expect(source).toMatch(/flexWrap: "wrap"/);
+      expect(source).toMatch(/width: "48%"/);
+    }
+
+    const labels = {
+      en: "OLED Black",
+      es: "Negro OLED",
+      fr: "Noir OLED",
+      ja: "OLEDブラック",
+      ko: "OLED 블랙",
+      zh: "OLED 纯黑",
+      "zh-TW": "OLED 純黑",
+    } as const;
+
+    for (const [locale, label] of Object.entries(labels)) {
+      const messages = JSON.parse(
+        read(`packages/core/src/i18n/locales/${locale}/settings.json`),
+      ) as { settings: Record<string, string> };
+      expect(messages.settings.oled).toBe(label);
+    }
+  });
 });

--- a/packages/app-expo/src/styles/oled-theme-contract.test.ts
+++ b/packages/app-expo/src/styles/oled-theme-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "../../../..");
+const read = (path: string) => readFileSync(resolve(root, path), "utf8");
+
+describe("OLED Black mobile theme", () => {
+  it("defines, restores, and maps OLED as a dark theme with a pure-black background", () => {
+    const context = read("packages/app-expo/src/styles/ThemeContext.tsx");
+    const app = read("packages/app-expo/src/App.tsx");
+
+    expect(context).toContain('export type ThemeMode = "light" | "dark" | "sepia" | "oled"');
+    expect(context).toMatch(
+      /const oledColors: ThemeColors = \{[\s\S]*?\.\.\.darkColors,[\s\S]*?background: "#000000"/,
+    );
+    expect(context).toMatch(/oled: oledColors/);
+    expect(context).toMatch(/saved === "oled"/);
+    expect(context).toContain('isDark: mode === "dark" || mode === "oled"');
+    expect(app).toContain('<StatusBar style={isDark ? "light" : "dark"} />');
+  });
+});

--- a/packages/core/src/i18n/locales/en/settings.json
+++ b/packages/core/src/i18n/locales/en/settings.json
@@ -46,6 +46,7 @@
     "system": "System",
     "light": "Light",
     "dark": "Dark",
+    "oled": "OLED Black",
     "sepia": "Sepia",
     "autoSave": "Auto-save interval",
     "autoSaveDesc": "How often to save reading progress",

--- a/packages/core/src/i18n/locales/es/settings.json
+++ b/packages/core/src/i18n/locales/es/settings.json
@@ -46,6 +46,7 @@
     "system": "Sistema",
     "light": "Claro",
     "dark": "Oscuro",
+    "oled": "Negro OLED",
     "sepia": "Sepia",
     "autoSave": "Intervalo de autoguardado",
     "autoSaveDesc": "Con qué frecuencia guardar el progreso de lectura",

--- a/packages/core/src/i18n/locales/fr/settings.json
+++ b/packages/core/src/i18n/locales/fr/settings.json
@@ -46,6 +46,7 @@
     "system": "Système",
     "light": "Clair",
     "dark": "Sombre",
+    "oled": "Noir OLED",
     "sepia": "Sépia",
     "autoSave": "Intervalle de sauvegarde auto",
     "autoSaveDesc": "Fréquence de sauvegarde de la progression de lecture",

--- a/packages/core/src/i18n/locales/ja/settings.json
+++ b/packages/core/src/i18n/locales/ja/settings.json
@@ -46,6 +46,7 @@
     "system": "システム",
     "light": "ライト",
     "dark": "ダーク",
+    "oled": "OLEDブラック",
     "sepia": "セピア",
     "autoSave": "自動保存間隔",
     "autoSaveDesc": "読書進捗を保存する頻度",

--- a/packages/core/src/i18n/locales/ko/settings.json
+++ b/packages/core/src/i18n/locales/ko/settings.json
@@ -46,6 +46,7 @@
     "system": "시스템",
     "light": "라이트",
     "dark": "다크",
+    "oled": "OLED 블랙",
     "sepia": "세피아",
     "autoSave": "자동 저장 간격",
     "autoSaveDesc": "읽기 진행률 저장 빈도",

--- a/packages/core/src/i18n/locales/zh-TW/settings.json
+++ b/packages/core/src/i18n/locales/zh-TW/settings.json
@@ -46,6 +46,7 @@
     "system": "跟隨系統",
     "light": "淺色",
     "dark": "深色",
+    "oled": "OLED 純黑",
     "sepia": "護眼",
     "autoSave": "自動儲存間隔",
     "autoSaveDesc": "閱讀進度儲存頻率",

--- a/packages/core/src/i18n/locales/zh/settings.json
+++ b/packages/core/src/i18n/locales/zh/settings.json
@@ -46,6 +46,7 @@
     "system": "跟随系统",
     "light": "浅色",
     "dark": "深色",
+    "oled": "OLED 纯黑",
     "sepia": "护眼",
     "autoSave": "自动保存间隔",
     "autoSaveDesc": "阅读进度保存频率",


### PR DESCRIPTION
## What changed

- adds an optional OLED Black appearance alongside System, Light, Dark, and Sepia
- uses true #000000 for mobile app backgrounds while preserving the existing dark palette for cards, text, and controls
- treats OLED as dark for status bars and dark-mode behavior
- applies true black to EPUB content and the existing dark inversion behavior to PDFs
- exposes the option in onboarding and Appearance settings with translations for all seven existing locales

## Why

OLED users can turn off background pixels for a genuinely black reading and app surface without changing the existing Dark theme for users who prefer its gray background.

## Validation

- core: 584 tests passed
- Expo: 6 tests passed
- Expo TypeScript: passed
- OLED contract regression test: passed
- reader bundle rebuild: deterministic
- scoped Biome and diff checks: passed
- installed and verified on a physical Pixel 9a across settings, library, chat, and EPUB