### PR TITLE
fix(mobile): 修正关于页 GitHub 链接指向错误仓库

### DIFF
--- a/packages/app-expo/src/screens/settings/AboutScreen.tsx
+++ b/packages/app-expo/src/screens/settings/AboutScreen.tsx
@@ -37,7 +37,7 @@ const TECH_STACK = [
 const LINKS = [
   {
     label: "GitHub",
-    url: "https://github.com/nicepkg/ReadAny",
+    url: "https://github.com/codedogQBY/ReadAny",
   },
 ];
 
@@ -154,7 +154,7 @@ export default function AboutScreen() {
               ))}
               <TouchableOpacity
                 style={styles.linkItem}
-                onPress={() => Linking.openURL("https://github.com/nicepkg/ReadAny/issues")}
+                onPress={() => Linking.openURL("https://github.com/codedogQBY/ReadAny/issues")}
                 activeOpacity={0.7}
               >
                 <Text style={styles.linkText}>{t("about.feedback", "问题反馈")}</Text>
@@ -163,7 +163,7 @@ export default function AboutScreen() {
             </View>
           </View>
 
-          <Text style={styles.madeBy}>{t("about.madeBy", "Made with love by nicepkg")}</Text>
+          <Text style={styles.madeBy}>{t("about.madeBy", "Made with love by codedogQBY")}</Text>
         </View>
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
## 问题
移动端 我的→关于 页面的 GitHub 链接指向 **nicepkg/ReadAny**（项目早期遗留），实际仓库是 **codedogQBY/ReadAny**。用户点击会跳到不存在的仓库/错误页面，star 和 issue 反馈都到不了正确位置。

## 修改
AboutScreen.tsx 3 处：
- GitHub 链接: nicepkg/ReadAny → codedogQBY/ReadAny
- Issues 链接: nicepkg/ReadAny/issues → codedogQBY/ReadAny/issues
- madeBy 署名: nicepkg → codedogQBY