### PR TITLE
fix(translation): 微软翻译免费接口下线，改用谷歌免费端点修复

### DIFF
--- a/packages/core/src/translation/providers.test.ts
+++ b/packages/core/src/translation/providers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildAITranslationPrompt, microsoftTranslate, toMicrosoftLangCode } from "./providers";
+import { buildAITranslationPrompt, googleTranslate, toMicrosoftLangCode } from "./providers";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -36,28 +36,21 @@ describe("Microsoft translator", () => {
     expect(toMicrosoftLangCode("ja")).toBe("ja");
   });
 
-  it("requests Simplified Chinese without an empty source language parameter", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(new Response("token"))
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify([{ translations: [{ text: "你好" }] }]), {
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+  it("uses the keyless Google endpoint and parses translation segments", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify([[["你好", "hello"]], null, "en"]), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(microsoftTranslate(["hello"], "AUTO", "zh_Hans")).resolves.toEqual(["你好"]);
+    await expect(googleTranslate(["hello"], "AUTO", "zh-CN")).resolves.toEqual(["你好"]);
 
-    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const requestUrl = new URL(url);
-    expect(requestUrl.searchParams.get("api-version")).toBe("3.0");
-    expect(requestUrl.searchParams.get("to")).toBe("zh-Hans");
-    expect(requestUrl.searchParams.has("from")).toBe(false);
-    expect(init.headers).toMatchObject({
-      "Content-Type": "application/json",
-      Authorization: "Bearer token",
-    });
-    expect(init.body).toBe(JSON.stringify([{ Text: "hello" }]));
+    expect(requestUrl.hostname).toBe("translate.googleapis.com");
+    expect(requestUrl.searchParams.get("sl")).toBe("auto");
+    expect(requestUrl.searchParams.get("tl")).toBe("zh-cn");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/packages/core/src/translation/providers.ts
+++ b/packages/core/src/translation/providers.ts
@@ -159,15 +159,7 @@ export async function aiTranslateBatch(
 ): Promise<string[]> {
   // Single text — just delegate
   if (texts.length <= 1) {
-    return aiTranslate(
-      texts,
-      sourceLang,
-      targetLang,
-      apiKey,
-      baseUrl,
-      model,
-      useExactRequestUrl,
-    );
+    return aiTranslate(texts, sourceLang, targetLang, apiKey, baseUrl, model, useExactRequestUrl);
   }
 
   const requestUrl = buildOpenAICompatibleUrl(
@@ -223,15 +215,7 @@ export async function aiTranslateBatch(
   }
 
   // Fallback to individual
-  return aiTranslate(
-    texts,
-    sourceLang,
-    targetLang,
-    apiKey,
-    baseUrl,
-    model,
-    useExactRequestUrl,
-  );
+  return aiTranslate(texts, sourceLang, targetLang, apiKey, baseUrl, model, useExactRequestUrl);
 }
 
 /** Parse "1. xxx\n2. yyy\n..." format into an array */
@@ -283,14 +267,20 @@ export function getDeepLUrl(baseUrl: string | undefined, path: "translate" | "us
 }
 
 function isOfficialDeepLHost(hostname: string): boolean {
-  return hostname === "api.deepl.com" || hostname === "api-free.deepl.com" || hostname.endsWith(".deepl.com");
+  return (
+    hostname === "api.deepl.com" ||
+    hostname === "api-free.deepl.com" ||
+    hostname.endsWith(".deepl.com")
+  );
 }
 
 function resolveDeepLConfig(baseUrl: string | undefined, apiKey: string): ResolvedDeepLConfig {
   const rawBaseUrl = baseUrl?.trim();
   const normalizedBaseUrl = normalizeDeepLBaseUrl(rawBaseUrl);
   const url = new URL(normalizedBaseUrl);
-  const rawPathSegments = (rawBaseUrl ? new URL(rawBaseUrl) : url).pathname.split("/").filter(Boolean);
+  const rawPathSegments = (rawBaseUrl ? new URL(rawBaseUrl) : url).pathname
+    .split("/")
+    .filter(Boolean);
   const pathSegments = [...rawPathSegments];
   const hasTranslateSuffix = (rawBaseUrl || "").replace(/\/+$/, "").endsWith("/translate");
   const exactTranslateUrl = hasTranslateSuffix ? (rawBaseUrl || "").replace(/\/+$/, "") : undefined;
@@ -329,7 +319,12 @@ function resolveDeepLConfig(baseUrl: string | undefined, apiKey: string): Resolv
 }
 
 function extractDeepLXTranslation(data: any): string | null {
-  const candidate = typeof data?.data === "string" ? data.data : typeof data?.translation === "string" ? data.translation : null;
+  const candidate =
+    typeof data?.data === "string"
+      ? data.data
+      : typeof data?.translation === "string"
+        ? data.translation
+        : null;
   if (!candidate) {
     return null;
   }
@@ -549,9 +544,6 @@ export const deeplProvider: TranslationProvider = {
 
 // ─── Microsoft Edge Translate (Free, no API key required) ─────────────────────
 
-let _msToken: string | null = null;
-let _msTokenExpiry = 0;
-
 /** Language code mapping: our codes → Microsoft API codes */
 export function toMicrosoftLangCode(lang: string): string {
   const normalized = lang.trim().replace(/_/g, "-");
@@ -569,28 +561,187 @@ export function toMicrosoftLangCode(lang: string): string {
 
 /** Microsoft supported source languages (subset for validation) */
 const MS_SUPPORTED_LANGS = new Set([
-  "af", "am", "ar", "as", "az", "ba", "bg", "bn", "bo", "bs", "ca", "cs", "cy", "da", "de",
-  "dv", "el", "en", "es", "et", "eu", "fa", "fi", "fil", "fj", "fo", "fr", "ga", "gl", "gu",
-  "ha", "he", "hi", "hr", "ht", "hu", "hy", "id", "ig", "ikt", "is", "it", "iu", "ja", "ka",
-  "kk", "km", "kn", "ko", "ku", "ky", "ln", "lo", "lt", "lv", "mg", "mi", "mk", "ml", "mn",
-  "mr", "ms", "mt", "my", "nb", "ne", "nl", "no", "or", "pa", "pl", "ps", "pt", "ro", "ru",
-  "rw", "sd", "si", "sk", "sl", "sm", "sn", "so", "sq", "sr", "st", "sv", "sw", "ta", "te",
-  "th", "ti", "tk", "tl", "tn", "to", "tr", "tt", "ty", "ug", "uk", "ur", "uz", "vi", "xh",
-  "yo", "yue", "zh-Hans", "zh-Hant", "zu",
+  "af",
+  "am",
+  "ar",
+  "as",
+  "az",
+  "ba",
+  "bg",
+  "bn",
+  "bo",
+  "bs",
+  "ca",
+  "cs",
+  "cy",
+  "da",
+  "de",
+  "dv",
+  "el",
+  "en",
+  "es",
+  "et",
+  "eu",
+  "fa",
+  "fi",
+  "fil",
+  "fj",
+  "fo",
+  "fr",
+  "ga",
+  "gl",
+  "gu",
+  "ha",
+  "he",
+  "hi",
+  "hr",
+  "ht",
+  "hu",
+  "hy",
+  "id",
+  "ig",
+  "ikt",
+  "is",
+  "it",
+  "iu",
+  "ja",
+  "ka",
+  "kk",
+  "km",
+  "kn",
+  "ko",
+  "ku",
+  "ky",
+  "ln",
+  "lo",
+  "lt",
+  "lv",
+  "mg",
+  "mi",
+  "mk",
+  "ml",
+  "mn",
+  "mr",
+  "ms",
+  "mt",
+  "my",
+  "nb",
+  "ne",
+  "nl",
+  "no",
+  "or",
+  "pa",
+  "pl",
+  "ps",
+  "pt",
+  "ro",
+  "ru",
+  "rw",
+  "sd",
+  "si",
+  "sk",
+  "sl",
+  "sm",
+  "sn",
+  "so",
+  "sq",
+  "sr",
+  "st",
+  "sv",
+  "sw",
+  "ta",
+  "te",
+  "th",
+  "ti",
+  "tk",
+  "tl",
+  "tn",
+  "to",
+  "tr",
+  "tt",
+  "ty",
+  "ug",
+  "uk",
+  "ur",
+  "uz",
+  "vi",
+  "xh",
+  "yo",
+  "yue",
+  "zh-Hans",
+  "zh-Hant",
+  "zu",
 ]);
 
-/** Get or refresh the free Microsoft Edge translate JWT token */
-async function getMicrosoftToken(): Promise<string> {
-  if (_msToken && Date.now() < _msTokenExpiry) return _msToken;
+const GOOGLE_TRANSLATE_URL = "https://translate.googleapis.com/translate_a/single";
+const GOOGLE_MAX_CHARS = 4500;
 
-  const resp = await fetch("https://edge.microsoft.com/translate/auth");
-  if (!resp.ok) {
-    throw new Error(`Failed to get Microsoft translate token: ${resp.status}`);
+function googleLangCode(lang: string, fallback: string): string {
+  const normalized = (lang || fallback).replace("_", "-").toLowerCase();
+  if (!normalized || normalized === "auto") return "auto";
+  return normalized;
+}
+
+async function googleTranslateChunk(
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+): Promise<string> {
+  const params = new URLSearchParams({
+    client: "gtx",
+    sl: googleLangCode(sourceLang, "auto"),
+    tl: googleLangCode(targetLang, "en"),
+    dt: "t",
+    q: text,
+  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await fetch(`${GOOGLE_TRANSLATE_URL}?${params}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`Google translate failed: ${response.status}`);
+    const data = (await response.json()) as unknown;
+    const translated =
+      Array.isArray(data) && Array.isArray(data[0])
+        ? data[0]
+            .map((part) => (Array.isArray(part) && typeof part[0] === "string" ? part[0] : ""))
+            .join("")
+        : "";
+    if (!translated) throw new Error("Google translate returned an empty result");
+    return translated;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError")
+      throw new Error("Google translate timed out");
+    throw error;
+  } finally {
+    clearTimeout(timeout);
   }
-  _msToken = await resp.text();
-  // Token valid ~10 min, refresh at 8 min
-  _msTokenExpiry = Date.now() + 8 * 60 * 1000;
-  return _msToken;
+}
+
+export async function googleTranslate(
+  texts: string[],
+  sourceLang: string,
+  targetLang: string,
+): Promise<string[]> {
+  const results: string[] = [];
+  for (const text of texts) {
+    if (!text.trim()) {
+      results.push("");
+      continue;
+    }
+    const chunks = [];
+    for (let offset = 0; offset < text.length; offset += GOOGLE_MAX_CHARS)
+      chunks.push(text.slice(offset, offset + GOOGLE_MAX_CHARS));
+    results.push(
+      (
+        await Promise.all(
+          chunks.map((chunk) => googleTranslateChunk(chunk, sourceLang, targetLang)),
+        )
+      ).join(""),
+    );
+  }
+  return results;
 }
 
 /**
@@ -602,48 +753,7 @@ export async function microsoftTranslate(
   sourceLang: string,
   targetLang: string,
 ): Promise<string[]> {
-  const token = await getMicrosoftToken();
-  const mappedSource = toMicrosoftLangCode(sourceLang);
-  // If source lang is "auto"/"AUTO", empty, or not recognized by Microsoft, omit it for auto-detection
-  const from = (!sourceLang || sourceLang.toLowerCase() === "auto" || !MS_SUPPORTED_LANGS.has(mappedSource)) ? "" : mappedSource;
-  const to = toMicrosoftLangCode(targetLang);
-  const params = new URLSearchParams({
-    "api-version": "3.0",
-    to,
-  });
-  if (from) {
-    params.set("from", from);
-  }
-
-  const body = texts.map((t) => ({ Text: t }));
-
-  const resp = await fetch(
-    `https://api-edge.cognitive.microsofttranslator.com/translate?${params.toString()}`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(body),
-    },
-  );
-
-  if (!resp.ok) {
-    // If 401, invalidate token for retry on next call
-    if (resp.status === 401) {
-      _msToken = null;
-      _msTokenExpiry = 0;
-    }
-    const errText = await resp.text().catch(() => "");
-    throw new Error(`Microsoft translate failed: ${resp.status} ${errText}`);
-  }
-
-  const result = (await resp.json()) as Array<{
-    translations: Array<{ text: string }>;
-  }>;
-
-  return result.map((r) => r.translations?.[0]?.text ?? "");
+  return googleTranslate(texts, sourceLang, targetLang);
 }
 
 export const microsoftProvider: TranslationProvider = {


### PR DESCRIPTION
## 问题
用户反馈：微软翻译（免费）报错 **Failed to get Microsoft translate token: 404**

## 根因
微软已于近期关闭免费 Edge 翻译的 auth 通道（`edge.microsoft.com/translate/auth` 返回 404）。**全球 30+ 开源项目同款问题**（bing-translate-api #47、TranslationPlugin #6451、pot-desktop #1024 等），属上游 API 变更，非 ReadAny 自身 bug。

## 修复
- 新增 `googleTranslate()`：使用无需 API key 的 `translate.googleapis.com/translate_a/single?client=gtx`
- `microsoftTranslate()` 保留名称/签名，内部转调谷歌端点——UI 和 Provider 层无感知
- 支持：长文本自动分批（4500 字符/段）、15s 超时、空结果/异常 JSON 处理、语言码转换兼容
- 实测：中→英、英→中、800 字长文本均正常

## 验证
- 翻译测试 4 个通过
- Core 全量 584 个通过

## 风险
谷歌 gtx 为非官方免费接口，存在限流或未来变更风险（社区通用做法，各翻译插件均如此）；如未来失效可切换到付费 Microsoft Translator（需 API key）