### PR TITLE
feat(ai): add OrcaRouter as a named model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - **Chat with your library** - Ask questions about the current book or selected passages, with answers grounded in your reading context
 - **Find ideas semantically** - Hybrid vector retrieval + BM25 search helps you find concepts even when the exact keyword is missing
 - **Keep knowledge private** - Local embeddings and a local vector store keep your books, highlights, and notes offline-capable
-- **Use your preferred model** - Connect OpenAI, Claude, Gemini, Ollama, DeepSeek, or custom-compatible providers
+- **Use your preferred model** - Connect OpenAI, Claude, Gemini, Ollama, DeepSeek, OrcaRouter, or custom-compatible providers
 
 ## Why ReadAny?
 
@@ -122,7 +122,7 @@
 - **Intelligent Chat** - Ask questions about your books, AI knows your position, selected text, and highlights
 - **Semantic Search** - Beyond keywords, vector retrieval + BM25 hybrid search
 - **Instant Translation** - AI translation or DeepL, 19 languages supported
-- **Multiple AI Providers** - OpenAI, Claude, Gemini, Ollama, DeepSeek
+- **Multiple AI Providers** - OpenAI, Claude, Gemini, Ollama, DeepSeek, OrcaRouter
 - **Skills System** - Built-in skills (summarizer, concept explainer, character tracker, etc.) + create custom skills
 
 ### 📝 Annotation & Knowledge Management
@@ -238,6 +238,7 @@ Mobile app source lives in [`packages/app-expo`](packages/app-expo).
 | Anthropic Claude | [console.anthropic.com](https://console.anthropic.com/) |
 | Google Gemini | [aistudio.google.com](https://aistudio.google.com/) |
 | Ollama / DeepSeek | Local or custom endpoint |
+| OrcaRouter | [orcarouter.ai](https://www.orcarouter.ai/) |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,7 +41,7 @@
 - **和书库对话** - 围绕当前书籍、选中文本和阅读位置提问，答案基于你的阅读上下文生成
 - **按语义找内容** - 向量检索 + BM25 混合搜索，不记得原文关键词也能找回相关概念
 - **知识留在本地** - 本地 embeddings 与本地向量库，让书籍、高亮和笔记具备离线可用能力
-- **接入常用模型** - 支持 OpenAI、Claude、Gemini、Ollama、DeepSeek 以及兼容接口
+- **接入常用模型** - 支持 OpenAI、Claude、Gemini、Ollama、DeepSeek、OrcaRouter 以及兼容接口
 
 ## 为什么选择 ReadAny？
 
@@ -237,6 +237,7 @@ Expo Go。Expo Go 无法加载 ReadAny 当前依赖的原生模块和应用配�
 | Anthropic Claude | [console.anthropic.com](https://console.anthropic.com/) |
 | Google Gemini | [aistudio.google.com](https://aistudio.google.com/) |
 | Ollama / DeepSeek | 本地或自定义端点 |
+| OrcaRouter | [orcarouter.ai](https://www.orcarouter.ai/) |
 
 ---
 

--- a/packages/app-expo/src/components/onboarding/steps/AIPage.tsx
+++ b/packages/app-expo/src/components/onboarding/steps/AIPage.tsx
@@ -37,6 +37,7 @@ const PROVIDER_OPTIONS: { id: AIProviderType; name: string }[] = [
   { id: "lmstudio", name: "LM Studio" },
   { id: "openrouter", name: "OpenRouter" },
   { id: "siliconflow", name: "SiliconFlow" },
+  { id: "orcarouter", name: "OrcaRouter" },
   { id: "custom", name: "Custom" },
 ];
 

--- a/packages/app-expo/src/screens/settings/ai/EndpointEditor.tsx
+++ b/packages/app-expo/src/screens/settings/ai/EndpointEditor.tsx
@@ -33,6 +33,7 @@ const PROVIDERS: { id: AIProviderType; label: string }[] = [
   { id: "lmstudio", label: "LM Studio" },
   { id: "openrouter", label: "OpenRouter" },
   { id: "siliconflow", label: "SiliconFlow" },
+  { id: "orcarouter", label: "OrcaRouter" },
   { id: "moonshot", label: "Moonshot" },
   { id: "zhipu", label: "智谱 GLM" },
   { id: "aliyun", label: "阿里云通义" },

--- a/packages/app/src/components/onboarding/steps/AIPage.tsx
+++ b/packages/app/src/components/onboarding/steps/AIPage.tsx
@@ -29,6 +29,7 @@ const PROVIDER_OPTIONS: { id: AIProviderType; name: string }[] = [
   { id: "lmstudio", name: "LM Studio" },
   { id: "openrouter", name: "OpenRouter" },
   { id: "siliconflow", name: "SiliconFlow" },
+  { id: "orcarouter", name: "OrcaRouter" },
   { id: "custom", name: "Custom" },
 ];
 

--- a/packages/app/src/components/settings/AISettings.tsx
+++ b/packages/app/src/components/settings/AISettings.tsx
@@ -42,6 +42,7 @@ function useProviderOptions(): { value: AIProviderType; label: string }[] {
     { value: "lmstudio", label: "LM Studio" },
     { value: "openrouter", label: "OpenRouter" },
     { value: "siliconflow", label: "SiliconFlow" },
+    { value: "orcarouter", label: "OrcaRouter" },
     { value: "moonshot", label: "Moonshot (Kimi)" },
     { value: "zhipu", label: t("settings.ai_provider_zhipu") },
     { value: "aliyun", label: t("settings.ai_provider_aliyun") },

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -145,6 +145,7 @@ export type AIProviderType =
   | "mistral"
   | "perplexity"
   | "aihubmix"
+  | "orcarouter"
   | "custom";
 
 export interface AIEndpoint {

--- a/packages/core/src/utils/api.test.ts
+++ b/packages/core/src/utils/api.test.ts
@@ -90,6 +90,15 @@ describe("AI API URL helpers", () => {
     expect(detectProviderFromUrl("https://api.atlascloud.ai/v1")).toBe("atlascloud");
   });
 
+  it("supports OrcaRouter as a named OpenAI-compatible provider", () => {
+    expect(getDefaultBaseUrl("orcarouter")).toBe("https://api.orcarouter.ai/v1");
+    expect(resolveProviderBaseUrl("orcarouter")).toBe("https://api.orcarouter.ai/v1");
+    expect(detectProviderFromUrl("https://api.orcarouter.ai/v1")).toBe("orcarouter");
+    expect(buildProviderModelsUrl("orcarouter")).toBe(
+      "https://api.orcarouter.ai/v1/models",
+    );
+  });
+
   describe("ensureUrlProtocol / scheme-less inputs", () => {
     it("prepends https:// when a remote URL has no scheme", () => {
       expect(ensureUrlProtocol("api.openai.com/v1")).toBe("https://api.openai.com/v1");

--- a/packages/core/src/utils/api.ts
+++ b/packages/core/src/utils/api.ts
@@ -97,6 +97,14 @@ export const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
     placeholder: "https://api.siliconflow.cn",
     keyPlaceholder: "sk-...",
   },
+  orcarouter: {
+    id: "orcarouter",
+    name: "OrcaRouter",
+    defaultBaseUrl: "https://api.orcarouter.ai/v1",
+    needsV1Suffix: false,
+    placeholder: "https://api.orcarouter.ai/v1",
+    keyPlaceholder: "sk-orca-...",
+  },
   moonshot: {
     id: "moonshot",
     name: "Moonshot (Kimi)",
@@ -566,6 +574,7 @@ export function detectProviderFromUrl(url: string): string {
   if (urlLower.includes("mistral.ai")) return "mistral";
   if (urlLower.includes("perplexity.ai")) return "perplexity";
   if (urlLower.includes("aihubmix.com")) return "aihubmix";
+  if (urlLower.includes("api.orcarouter.ai")) return "orcarouter";
 
   return "custom";
 }


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class model provider in ReadAny. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key, with gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `packages/core/src/types/chat.ts`: adds `"orcarouter"` to the `AIProviderType` union.
- `packages/core/src/utils/api.ts`: registers OrcaRouter in `PROVIDER_CONFIGS` (base URL `https://api.orcarouter.ai/v1`, keys prefixed `sk-orca-`, no `/v1` auto-append) and in `detectProviderFromUrl`.
- Desktop & mobile UI: adds **OrcaRouter** to the provider dropdown in the chat/AI settings screens (`AISettings.tsx`, `EndpointEditor.tsx`) and the onboarding AI step (`AIPage.tsx` on both desktop and Expo app).
- `packages/core/src/utils/api.test.ts`: unit tests for the new provider.
- `README.md` / `README_CN.md`: mentions OrcaRouter in the provider lists and "Get API Key" table.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In **Settings → AI**, pick **OrcaRouter** as the provider, paste the key, and choose a model id such as `orcarouter/auto`, `deepseek/deepseek-v4-flash`, or `openai/gpt-4o`.
3. ReadAny talks to `https://api.orcarouter.ai/v1` exactly like any OpenAI-compatible endpoint, so model listing, chat, and embeddings all work through the gateway.

## Verification

- `pnpm --filter @readany/core test` — API URL helper tests pass (including the new OrcaRouter case).
- `pnpm exec biome check` on the changed files — clean.
