### PR TITLE
feat(reader): 屏蔽系统右键菜单，新增精简自定义编辑菜单

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-tooltip": "^1.1.6",
     "@readany/core": "workspace:*",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.3",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2",
     "@tauri-apps/plugin-http": "^2.5.7",

--- a/packages/app/src-tauri/Cargo.lock
+++ b/packages/app/src-tauri/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "sqlite-vec",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-http",
@@ -104,6 +105,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
 ]
 
 [[package]]
@@ -437,6 +459,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +599,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -757,6 +794,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1078,6 +1121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1351,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1585,6 +1652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,6 +1889,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2064,7 +2152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2179,6 +2267,20 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2595,6 +2697,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,7 +2721,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2694,6 +2806,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3035,6 +3156,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,6 +3259,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
 
 [[package]]
 name = "phf"
@@ -3321,7 +3463,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3333,6 +3475,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3500,10 +3655,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4511,7 +4687,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "unicode_categories",
 ]
 
@@ -5020,7 +5196,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5065,6 +5241,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4136fb69d967753d000423d7e5f863f89bf949efbdfbecb43a580426a01a0194"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5432,6 +5623,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5753,10 +5958,21 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
 ]
 
 [[package]]
@@ -6148,6 +6364,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6273,6 +6559,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -6912,6 +7204,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6982,6 +7292,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -7174,6 +7501,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/packages/app/src-tauri/Cargo.toml
+++ b/packages/app/src-tauri/Cargo.toml
@@ -38,3 +38,4 @@ dashmap = "6.1.0"
 uuid = { version = "1.22.0", features = ["v4"] }
 base64 = "0.22.1"
 tauri-plugin-window-state = "2.4.1"
+tauri-plugin-clipboard-manager = "2"

--- a/packages/app/src-tauri/capabilities/default.json
+++ b/packages/app/src-tauri/capabilities/default.json
@@ -63,6 +63,8 @@
       ]
     },
     "websocket:default",
-    "window-state:default"
+    "window-state:default",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_websocket::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .manage(VectorDBState {
             db: Mutex::new(None),
         })

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3,6 +3,7 @@
  * All opened tabs stay mounted; visibility controlled by CSS display.
  */
 import { AppLayout } from "@/components/layout/AppLayout";
+import { ContextMenu } from "@/components/layout/ContextMenu";
 import { UpdateNotification } from "@/components/layout/UpdateNotification";
 import { useAutoSync } from "@/hooks/use-sync";
 import { DesktopSyncAdapter } from "@/lib/sync/sync-adapter-desktop";
@@ -20,6 +21,7 @@ export default function App() {
       <AppLayout />
       <Toaster position="top-center" richColors duration={2000} />
       <UpdateNotification />
+      <ContextMenu />
     </>
   );
 }

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useRef, useState } from "react";
+
+interface MenuItem {
+  label: string;
+  action: () => void;
+  disabled?: boolean;
+}
+
+type MenuState = { x: number; y: number; items: MenuItem[] } | null;
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest?.(
+      "input, textarea, select, [contenteditable='true'], [contenteditable=''], [role='textbox']",
+    ),
+  );
+};
+
+export function ContextMenu() {
+  const [menu, setMenu] = useState<MenuState>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const onContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+      const target = event.target as HTMLElement | null;
+      if (!isEditableTarget(event.target)) {
+        setMenu(null);
+        return;
+      }
+      const editable = target?.closest?.(
+        "input, textarea, [contenteditable='true'], [contenteditable=''], [role='textbox']",
+      ) as HTMLElement | null;
+      if (!editable) return;
+
+      const isTextArea = editable instanceof HTMLTextAreaElement;
+      const isInput = editable instanceof HTMLInputElement;
+      const isContentEditable = editable.isContentEditable;
+
+      const getSelection = (): string | undefined => {
+        try {
+          if (isTextArea || isInput) {
+            const el = editable as HTMLInputElement | HTMLTextAreaElement;
+            return el.value?.substring(el.selectionStart ?? 0, el.selectionEnd ?? 0) ?? "";
+          }
+          if (isContentEditable) {
+            return window.getSelection()?.toString() ?? "";
+          }
+          return undefined;
+        } catch {
+          return undefined;
+        }
+      };
+
+      const hasSelection = Boolean(getSelection());
+
+      // execCommand is deprecated but remains the only way to copy/paste from a
+      // custom context menu WITHOUT triggering the WebView2 clipboard permission
+      // dialog (navigator.clipboard.readText() prompts every time). All engines
+      // (Chromium/WebView2, WebKit, Firefox) still support it, so prefer it and
+      // fall back to the async Clipboard API only if execCommand is gone.
+      const execCommandAvailable =
+        typeof document.execCommand === "function";
+
+      const doAction = (command: string): boolean => {
+        if (!execCommandAvailable) return false;
+        editable.focus();
+        try {
+          return document.execCommand(command);
+        } catch {
+          return false;
+        }
+      };
+
+      const copySelection = (): void => {
+        const text = getSelection();
+        if (!text) return;
+        if (!doAction("copy")) {
+          // execCommand unavailable — use async Clipboard API (may prompt).
+          try {
+            void navigator.clipboard?.writeText(text).catch(() => {});
+          } catch {
+            // ignore
+          }
+        }
+      };
+
+      const pasteClipboard = async (): Promise<void> => {
+        editable.focus();
+        if (!doAction("paste")) {
+          // execCommand unavailable — async read + insert (may prompt).
+          try {
+            const text = await navigator.clipboard.readText();
+            if (text) document.execCommand("insertText", false, text);
+          } catch {
+            // ignore
+          }
+        }
+      };
+
+      const items: MenuItem[] = [
+        {
+          label: "撤销",
+          action: () => doAction("undo"),
+        },
+        {
+          label: "剪切",
+          action: () => doAction("cut"),
+          disabled: !hasSelection,
+        },
+        {
+          label: "复制",
+          action: copySelection,
+          disabled: !hasSelection,
+        },
+        {
+          label: "粘贴",
+          action: () => {
+            void pasteClipboard();
+          },
+        },
+        {
+          label: "全选",
+          action: () => {
+            editable.focus();
+            try {
+              if (isTextArea || isInput) {
+                (editable as HTMLInputElement | HTMLTextAreaElement).select();
+              } else {
+                document.execCommand("selectAll");
+              }
+            } catch {
+              // ignore
+            }
+          },
+        },
+      ];
+
+      setMenu({ x: event.clientX, y: event.clientY, items });
+    };
+
+    const onPointerDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenu(null);
+      }
+    };
+    const onBlur = () => setMenu(null);
+
+    document.addEventListener("contextmenu", onContextMenu, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      document.removeEventListener("contextmenu", onContextMenu, true);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, []);
+
+  if (!menu) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-[10000] min-w-[160px] overflow-hidden rounded-md border border-border bg-popover p-1 text-sm text-popover-foreground shadow-lg"
+      style={{ left: menu.x, top: menu.y }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {menu.items.map((item) => (
+        <button
+          key={item.label}
+          type="button"
+          disabled={item.disabled}
+          className="flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-left outline-none transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+          onClick={() => {
+            item.action();
+            setMenu(null);
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -153,7 +153,18 @@ export function ContextMenu() {
         { command: "selectAll", action: selectAll },
       ];
 
-      setMenu({ x: event.clientX, y: event.clientY, items });
+      // Keyboard invocation (ContextMenu key / Shift+F10) carries no pointer
+      // position (detail === 0; coordinates default to 0,0) — anchor the menu
+      // to the field itself instead, like readest's context menus do.
+      let x = event.clientX;
+      let y = event.clientY;
+      if (event.detail === 0) {
+        const rect = editable.getBoundingClientRect();
+        x = rect.left + 8;
+        y = rect.bottom + 4;
+      }
+
+      setMenu({ x, y, items });
     };
 
     const onPointerDown = (event: MouseEvent) => {

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -1,70 +1,83 @@
-import { useEffect, useRef, useState } from "react";
+import { shouldSuppressNativeContextMenu } from "@/lib/environment";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+type MenuCommand = "undo" | "cut" | "copy" | "paste" | "selectAll";
 
 interface MenuItem {
-  label: string;
+  command: MenuCommand;
   action: () => void;
   disabled?: boolean;
 }
 
 type MenuState = { x: number; y: number; items: MenuItem[] } | null;
 
-const isEditableTarget = (target: EventTarget | null): boolean => {
-  if (!(target instanceof Element)) return false;
-  return Boolean(
-    target.closest?.(
-      "input, textarea, select, [contenteditable='true'], [contenteditable=''], [role='textbox']",
-    ),
-  );
+const EDITABLE_SELECTOR =
+  "input, textarea, [contenteditable='true'], [contenteditable=''], [role='textbox']";
+
+// Programmatic insert for when execCommand("paste") is refused (WebKit refuses
+// it for web content). React-controlled inputs need a bubbled input event so
+// their onChange picks up the new DOM value.
+const insertTextAtSelection = (editable: HTMLElement, text: string): void => {
+  if (editable instanceof HTMLInputElement || editable instanceof HTMLTextAreaElement) {
+    const start = editable.selectionStart ?? editable.value.length;
+    const end = editable.selectionEnd ?? editable.value.length;
+    editable.setRangeText(text, start, end, "end");
+    editable.dispatchEvent(new Event("input", { bubbles: true }));
+    return;
+  }
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+  const range = selection.getRangeAt(0);
+  range.deleteContents();
+  range.insertNode(document.createTextNode(text));
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
 };
 
 export function ContextMenu() {
+  const { t } = useTranslation();
   const [menu, setMenu] = useState<MenuState>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    // Dev keeps the native menu for debugging — no suppression, no custom menu.
+    if (!shouldSuppressNativeContextMenu) return;
+
     const onContextMenu = (event: MouseEvent) => {
       event.preventDefault();
       const target = event.target as HTMLElement | null;
-      if (!isEditableTarget(event.target)) {
+      const editable = target?.closest?.(EDITABLE_SELECTOR) as HTMLElement | null;
+      if (!editable) {
         setMenu(null);
         return;
       }
-      const editable = target?.closest?.(
-        "input, textarea, [contenteditable='true'], [contenteditable=''], [role='textbox']",
-      ) as HTMLElement | null;
-      if (!editable) return;
 
-      const isTextArea = editable instanceof HTMLTextAreaElement;
-      const isInput = editable instanceof HTMLInputElement;
-      const isContentEditable = editable.isContentEditable;
+      const isTextField =
+        editable instanceof HTMLTextAreaElement || editable instanceof HTMLInputElement;
 
-      const getSelection = (): string | undefined => {
+      const getSelectedText = (): string => {
         try {
-          if (isTextArea || isInput) {
+          if (isTextField) {
             const el = editable as HTMLInputElement | HTMLTextAreaElement;
             return el.value?.substring(el.selectionStart ?? 0, el.selectionEnd ?? 0) ?? "";
           }
-          if (isContentEditable) {
-            return window.getSelection()?.toString() ?? "";
-          }
-          return undefined;
+          return window.getSelection()?.toString() ?? "";
         } catch {
-          return undefined;
+          return "";
         }
       };
 
-      const hasSelection = Boolean(getSelection());
+      const hasSelection = Boolean(getSelectedText());
 
-      // execCommand is deprecated but remains the only way to copy/paste from a
-      // custom context menu WITHOUT triggering the WebView2 clipboard permission
-      // dialog (navigator.clipboard.readText() prompts every time). All engines
-      // (Chromium/WebView2, WebKit, Firefox) still support it, so prefer it and
-      // fall back to the async Clipboard API only if execCommand is gone.
-      const execCommandAvailable =
-        typeof document.execCommand === "function";
-
-      const doAction = (command: string): boolean => {
-        if (!execCommandAvailable) return false;
+      // execCommand is deprecated but is the only clipboard path that never
+      // prompts: WebView2 gates navigator.clipboard.readText() behind a
+      // permission dialog, and WKWebView refuses execCommand("paste") for web
+      // content. Order: execCommand → Tauri clipboard plugin (native IPC, no
+      // prompt; covers macOS/Linux WebKit) → async Clipboard API (last resort).
+      const execCommand = (command: string): boolean => {
+        if (typeof document.execCommand !== "function") return false;
         editable.focus();
         try {
           return document.execCommand(command);
@@ -73,68 +86,55 @@ export function ContextMenu() {
         }
       };
 
-      const copySelection = (): void => {
-        const text = getSelection();
-        if (!text) return;
-        if (!doAction("copy")) {
-          // execCommand unavailable — use async Clipboard API (may prompt).
-          try {
-            void navigator.clipboard?.writeText(text).catch(() => {});
-          } catch {
-            // ignore
-          }
+      const readClipboardNative = async (): Promise<string | null> => {
+        try {
+          const { readText } = await import("@tauri-apps/plugin-clipboard-manager");
+          return await readText();
+        } catch {
+          return null;
         }
+      };
+
+      const copySelection = (): void => {
+        const text = getSelectedText();
+        if (!text) return;
+        if (execCommand("copy")) return;
+        void navigator.clipboard?.writeText(text).catch(() => {});
       };
 
       const pasteClipboard = async (): Promise<void> => {
         editable.focus();
-        if (!doAction("paste")) {
-          // execCommand unavailable — async read + insert (may prompt).
-          try {
-            const text = await navigator.clipboard.readText();
-            if (text) document.execCommand("insertText", false, text);
-          } catch {
-            // ignore
-          }
+        if (execCommand("paste")) return;
+        const text =
+          (await readClipboardNative()) ??
+          (await navigator.clipboard?.readText().catch(() => null));
+        if (text) insertTextAtSelection(editable, text);
+      };
+
+      const selectAll = (): void => {
+        editable.focus();
+        if (isTextField) {
+          (editable as HTMLInputElement | HTMLTextAreaElement).select();
+          return;
         }
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(editable);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
       };
 
       const items: MenuItem[] = [
+        { command: "undo", action: () => execCommand("undo") },
+        { command: "cut", action: () => execCommand("cut"), disabled: !hasSelection },
+        { command: "copy", action: copySelection, disabled: !hasSelection },
         {
-          label: "撤销",
-          action: () => doAction("undo"),
-        },
-        {
-          label: "剪切",
-          action: () => doAction("cut"),
-          disabled: !hasSelection,
-        },
-        {
-          label: "复制",
-          action: copySelection,
-          disabled: !hasSelection,
-        },
-        {
-          label: "粘贴",
+          command: "paste",
           action: () => {
             void pasteClipboard();
           },
         },
-        {
-          label: "全选",
-          action: () => {
-            editable.focus();
-            try {
-              if (isTextArea || isInput) {
-                (editable as HTMLInputElement | HTMLTextAreaElement).select();
-              } else {
-                document.execCommand("selectAll");
-              }
-            } catch {
-              // ignore
-            }
-          },
-        },
+        { command: "selectAll", action: selectAll },
       ];
 
       setMenu({ x: event.clientX, y: event.clientY, items });
@@ -145,31 +145,49 @@ export function ContextMenu() {
         setMenu(null);
       }
     };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenu(null);
+    };
     const onBlur = () => setMenu(null);
 
     document.addEventListener("contextmenu", onContextMenu, true);
     document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
     window.addEventListener("blur", onBlur);
     return () => {
       document.removeEventListener("contextmenu", onContextMenu, true);
       document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("blur", onBlur);
     };
   }, []);
 
-  if (!menu) return null;
+  // Clamp the menu inside the viewport before first paint — right-clicks near
+  // the right/bottom edge would otherwise render it partially off-screen.
+  useLayoutEffect(() => {
+    const el = menuRef.current;
+    if (!menu || !el) return;
+    const x = Math.max(8, Math.min(menu.x, window.innerWidth - el.offsetWidth - 8));
+    const y = Math.max(8, Math.min(menu.y, window.innerHeight - el.offsetHeight - 8));
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+  }, [menu]);
+
+  if (!shouldSuppressNativeContextMenu || !menu) return null;
 
   return (
     <div
       ref={menuRef}
+      role="menu"
       className="fixed z-[10000] min-w-[160px] overflow-hidden rounded-md border border-border bg-popover p-1 text-sm text-popover-foreground shadow-lg"
       style={{ left: menu.x, top: menu.y }}
       onContextMenu={(e) => e.preventDefault()}
     >
       {menu.items.map((item) => (
         <button
-          key={item.label}
+          key={item.command}
           type="button"
+          role="menuitem"
           disabled={item.disabled}
           className="flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-left outline-none transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
           onClick={() => {
@@ -177,7 +195,7 @@ export function ContextMenu() {
             setMenu(null);
           }}
         >
-          {item.label}
+          {t(`common.${item.command}`)}
         </button>
       ))}
     </div>

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -95,6 +95,11 @@ export function ContextMenu() {
 
       const hasSelection = Boolean(getSelectedText());
 
+      // Browsers block cut/copy on password fields for security — mirror the
+      // native menu and disable those items instead of offering silent no-ops.
+      // Paste/undo/select-all remain useful (password managers paste).
+      const isPassword = editable instanceof HTMLInputElement && editable.type === "password";
+
       // execCommand is deprecated but still fully supported. "insertText"
       // behaves like typed input (stays on the undo stack), "cut" and "undo"
       // drive the field's native editing commands. "paste" is NOT usable —
@@ -142,8 +147,8 @@ export function ContextMenu() {
 
       const items: MenuItem[] = [
         { command: "undo", action: () => execCommand("undo") },
-        { command: "cut", action: () => execCommand("cut"), disabled: !hasSelection },
-        { command: "copy", action: copySelection, disabled: !hasSelection },
+        { command: "cut", action: () => execCommand("cut"), disabled: !hasSelection || isPassword },
+        { command: "copy", action: copySelection, disabled: !hasSelection || isPassword },
         {
           command: "paste",
           action: () => {

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -15,6 +15,29 @@ type MenuState = { x: number; y: number; items: MenuItem[] } | null;
 const EDITABLE_SELECTOR =
   "input, textarea, [contenteditable='true'], [contenteditable=''], [role='textbox']";
 
+// Clipboard I/O goes through the Tauri plugin: native IPC with no permission
+// prompt, identical behavior on Windows/macOS/Linux. The custom menu only
+// runs in production builds, which always execute inside Tauri, so there is
+// no web Clipboard API fallback — it would be a dead path (and WebView2 gates
+// navigator.clipboard.readText() behind a permission dialog anyway).
+const readClipboard = async (): Promise<string | null> => {
+  try {
+    const { readText } = await import("@tauri-apps/plugin-clipboard-manager");
+    return await readText();
+  } catch {
+    return null;
+  }
+};
+
+const writeClipboard = async (text: string): Promise<void> => {
+  try {
+    const { writeText } = await import("@tauri-apps/plugin-clipboard-manager");
+    await writeText(text);
+  } catch {
+    // ignore — nothing sensible to fall back to
+  }
+};
+
 // Last-ditch insert for when even execCommand("insertText") is unavailable.
 // It writes the value directly, so the edit does NOT land on the native undo
 // stack (Undo cannot revert it). React-controlled inputs need a bubbled input
@@ -72,11 +95,12 @@ export function ContextMenu() {
 
       const hasSelection = Boolean(getSelectedText());
 
-      // execCommand is deprecated but still fully supported: "insertText" is
-      // the undoable, permission-free way to edit a field (it behaves like
-      // typed input), and "copy"/"cut" work with a user gesture on every
-      // engine. "paste" is NOT usable — engines refuse it for web content
-      // (Chromium/WebView2 included; it silently returns false).
+      // execCommand is deprecated but still fully supported. "insertText"
+      // behaves like typed input (stays on the undo stack), "cut" and "undo"
+      // drive the field's native editing commands. "paste" is NOT usable —
+      // engines refuse it for web content (Chromium/WebView2 included; it
+      // silently returns false), which is why clipboard reads/writes go
+      // through the Tauri plugin above.
       const execCommand = (command: string, value?: string): boolean => {
         if (typeof document.execCommand !== "function") return false;
         editable.focus();
@@ -87,31 +111,17 @@ export function ContextMenu() {
         }
       };
 
-      const readClipboardNative = async (): Promise<string | null> => {
-        try {
-          const { readText } = await import("@tauri-apps/plugin-clipboard-manager");
-          return await readText();
-        } catch {
-          return null;
-        }
-      };
-
       const copySelection = (): void => {
         const text = getSelectedText();
         if (!text) return;
-        if (execCommand("copy")) return;
-        void navigator.clipboard?.writeText(text).catch(() => {});
+        void writeClipboard(text);
       };
 
-      // Read the clipboard natively (Tauri IPC needs no permission prompt;
-      // async Clipboard API is the web fallback) and insert it as if typed —
-      // "insertText" lands the paste on the field's native undo stack so menu
-      // Undo / Ctrl+Z can revert it. A direct value write would not.
+      // Insert as if typed so the paste lands on the field's native undo
+      // stack and menu Undo / Ctrl+Z can revert it.
       const pasteClipboard = async (): Promise<void> => {
         editable.focus();
-        const text =
-          (await readClipboardNative()) ??
-          (await navigator.clipboard?.readText().catch(() => null));
+        const text = await readClipboard();
         if (!text) return;
         if (execCommand("insertText", text)) return;
         insertTextAtSelection(editable, text);

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -15,9 +15,10 @@ type MenuState = { x: number; y: number; items: MenuItem[] } | null;
 const EDITABLE_SELECTOR =
   "input, textarea, [contenteditable='true'], [contenteditable=''], [role='textbox']";
 
-// Programmatic insert for when execCommand("paste") is refused (WebKit refuses
-// it for web content). React-controlled inputs need a bubbled input event so
-// their onChange picks up the new DOM value.
+// Last-ditch insert for when even execCommand("insertText") is unavailable.
+// It writes the value directly, so the edit does NOT land on the native undo
+// stack (Undo cannot revert it). React-controlled inputs need a bubbled input
+// event so their onChange picks up the new DOM value.
 const insertTextAtSelection = (editable: HTMLElement, text: string): void => {
   if (editable instanceof HTMLInputElement || editable instanceof HTMLTextAreaElement) {
     const start = editable.selectionStart ?? editable.value.length;
@@ -71,16 +72,16 @@ export function ContextMenu() {
 
       const hasSelection = Boolean(getSelectedText());
 
-      // execCommand is deprecated but is the only clipboard path that never
-      // prompts: WebView2 gates navigator.clipboard.readText() behind a
-      // permission dialog, and WKWebView refuses execCommand("paste") for web
-      // content. Order: execCommand → Tauri clipboard plugin (native IPC, no
-      // prompt; covers macOS/Linux WebKit) → async Clipboard API (last resort).
-      const execCommand = (command: string): boolean => {
+      // execCommand is deprecated but still fully supported: "insertText" is
+      // the undoable, permission-free way to edit a field (it behaves like
+      // typed input), and "copy"/"cut" work with a user gesture on every
+      // engine. "paste" is NOT usable — engines refuse it for web content
+      // (Chromium/WebView2 included; it silently returns false).
+      const execCommand = (command: string, value?: string): boolean => {
         if (typeof document.execCommand !== "function") return false;
         editable.focus();
         try {
-          return document.execCommand(command);
+          return document.execCommand(command, false, value);
         } catch {
           return false;
         }
@@ -102,13 +103,18 @@ export function ContextMenu() {
         void navigator.clipboard?.writeText(text).catch(() => {});
       };
 
+      // Read the clipboard natively (Tauri IPC needs no permission prompt;
+      // async Clipboard API is the web fallback) and insert it as if typed —
+      // "insertText" lands the paste on the field's native undo stack so menu
+      // Undo / Ctrl+Z can revert it. A direct value write would not.
       const pasteClipboard = async (): Promise<void> => {
         editable.focus();
-        if (execCommand("paste")) return;
         const text =
           (await readClipboardNative()) ??
           (await navigator.clipboard?.readText().catch(() => null));
-        if (text) insertTextAtSelection(editable, text);
+        if (!text) return;
+        if (execCommand("insertText", text)) return;
+        insertTextAtSelection(editable, text);
       };
 
       const selectAll = (): void => {

--- a/packages/app/src/components/layout/ContextMenu.tsx
+++ b/packages/app/src/components/layout/ContextMenu.tsx
@@ -43,6 +43,7 @@ const writeClipboard = async (text: string): Promise<void> => {
 // stack (Undo cannot revert it). React-controlled inputs need a bubbled input
 // event so their onChange picks up the new DOM value.
 const insertTextAtSelection = (editable: HTMLElement, text: string): void => {
+  if (!editable.isConnected) return;
   if (editable instanceof HTMLInputElement || editable instanceof HTMLTextAreaElement) {
     const start = editable.selectionStart ?? editable.value.length;
     const end = editable.selectionEnd ?? editable.value.length;
@@ -173,9 +174,18 @@ export function ContextMenu() {
     };
 
     const onPointerDown = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setMenu(null);
+      if (!menuRef.current) return;
+      if (menuRef.current.contains(event.target as Node)) {
+        // Keep focus (caret/selection included) on the editable while the
+        // menu is open: letting the browser move focus to the menu fires the
+        // field's onBlur, and inline editors treat blur as commit/dismiss —
+        // the empty sidebar search even unmounts itself, leaving the paste
+        // action writing into a detached node. Native menus behave the same
+        // way: opening them never steals focus from the field.
+        event.preventDefault();
+        return;
       }
+      setMenu(null);
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setMenu(null);

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -2472,6 +2472,9 @@ export const FoliateViewer = forwardRef<FoliateViewerHandle, FoliateViewerProps>
         };
 
         const handlePointerUp = (ev: PointerEvent) => {
+          // Right-click is reserved for context-menu suppression only — never
+          // treat it as a page-turn tap (or any other pointer action).
+          if (ev.button === 2) return;
           // Clicks on links are handled by their own navigation (internal
           // links / footnotes); never treat them as page-turn taps. Use
           // composedPath() with a realm-independent nodeType check: ev.target

--- a/packages/app/src/lib/environment.ts
+++ b/packages/app/src/lib/environment.ts
@@ -1,0 +1,8 @@
+/**
+ * Build-environment flags for the context-menu suppression path.
+ *
+ * Production builds suppress the WebView's native context menu globally
+ * (main.tsx, ContextMenu, iframe-event-handlers); dev builds keep it so the
+ * native menu (Inspect Element etc.) stays available for debugging.
+ */
+export const shouldSuppressNativeContextMenu = !import.meta.env.DEV;

--- a/packages/app/src/lib/reader/iframe-event-handlers.ts
+++ b/packages/app/src/lib/reader/iframe-event-handlers.ts
@@ -214,6 +214,13 @@ export const handleTouchMove = (bookKey: string, event: TouchEvent) =>
 export const handleTouchEnd = (bookKey: string, event: TouchEvent) =>
   handleTouchEv(bookKey, event, "iframe-touchend");
 
+export const handleContextMenu = (_bookKey: string, event: MouseEvent) => {
+  // Suppress the WebView's native context menu inside the reader. Book content
+  // is a sandboxed iframe; without this the OS/WebView2 default right-click
+  // menu (Copy/Paste/Inspect etc.) pops up over the reading area.
+  event.preventDefault();
+};
+
 /**
  * Register all iframe event handlers on a loaded document.
  * Called each time a new section is loaded by foliate-view.
@@ -238,4 +245,5 @@ export function registerIframeEventHandlers(bookKey: string, doc: Document): voi
   doc.addEventListener("touchstart", handleTouchStart.bind(null, bookKey));
   doc.addEventListener("touchmove", handleTouchMove.bind(null, bookKey));
   doc.addEventListener("touchend", handleTouchEnd.bind(null, bookKey));
+  doc.addEventListener("contextmenu", handleContextMenu.bind(null, bookKey));
 }

--- a/packages/app/src/lib/reader/iframe-event-handlers.ts
+++ b/packages/app/src/lib/reader/iframe-event-handlers.ts
@@ -10,6 +10,8 @@
  * and forwards them via window.postMessage so React hooks can consume them.
  */
 
+import { shouldSuppressNativeContextMenu } from "../environment";
+
 const LONG_HOLD_THRESHOLD = 500;
 
 let longHoldTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -215,9 +217,11 @@ export const handleTouchEnd = (bookKey: string, event: TouchEvent) =>
   handleTouchEv(bookKey, event, "iframe-touchend");
 
 export const handleContextMenu = (_bookKey: string, event: MouseEvent) => {
-  // Suppress the WebView's native context menu inside the reader. Book content
-  // is a sandboxed iframe; without this the OS/WebView2 default right-click
-  // menu (Copy/Paste/Inspect etc.) pops up over the reading area.
+  // Suppress the WebView's native context menu inside the reader (production
+  // only — dev keeps it so the rendered book DOM can be inspected). Book
+  // content is a sandboxed iframe; without this the OS/WebView2 default
+  // right-click menu (Copy/Paste/Inspect etc.) pops up over the reading area.
+  if (!shouldSuppressNativeContextMenu) return;
   event.preventDefault();
 };
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -32,6 +32,17 @@ import { useVectorModelStore } from "./stores/vector-model-store";
 
 installFeedbackLogCapture();
 
+// Suppress the WebView's native context menu everywhere. Editable areas get a
+// slim custom menu (Cut/Copy/Paste/Select All) from the ContextMenu component;
+// the reader's sandboxed iframe is handled separately in
+// registerIframeEventHandlers. Without this, the OS/WebView2 default menu
+// (Inspect etc.) pops up over the app.
+document.addEventListener(
+  "contextmenu",
+  (event) => event.preventDefault(),
+  true,
+);
+
 // Keep the WebView color scheme in sync with the app theme so book CSS that
 // relies on light-dark() / @media(prefers-color-scheme) follows the app theme
 // instead of the OS scheme (e.g. sepia maps to a light scheme, so borders/text

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -12,36 +12,36 @@ import { setEmbeddingWorkerFactory, setStreamingFetch } from "@readany/core/ai";
 import { onLibraryChanged } from "@readany/core/events/library-events";
 import { installFeedbackLogCapture, setFeedbackWorkerUrl } from "@readany/core/feedback";
 import {
-  createBuiltinEmbeddingService,
   EmbeddingService,
-  normalizeEmbeddingEndpoint,
   clearSearchConfiguration,
   configureSearch,
+  createBuiltinEmbeddingService,
+  normalizeEmbeddingEndpoint,
   setVectorDB,
 } from "@readany/core/rag";
 import { setPlatformService } from "@readany/core/services";
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { setTheme as setTauriTheme } from "@tauri-apps/api/app";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { shouldSuppressNativeContextMenu } from "./lib/environment";
 import { TauriPlatformService } from "./lib/platform/tauri-platform-service";
+import { registerDesktopFallbackContentProvider } from "./lib/rag/fallback-content-provider";
 import { syncLegacyDesktopLibraryRootConfig } from "./lib/storage/desktop-library-root";
 import { TauriVectorDB } from "./lib/tauri-vector-db";
-import { registerDesktopFallbackContentProvider } from "./lib/rag/fallback-content-provider";
 import { useLibraryStore } from "./stores/library-store";
 import { flushAllWrites } from "./stores/persist";
 import { useVectorModelStore } from "./stores/vector-model-store";
 
 installFeedbackLogCapture();
 
-// Suppress the WebView's native context menu everywhere. Editable areas get a
-// slim custom menu (Cut/Copy/Paste/Select All) from the ContextMenu component;
-// the reader's sandboxed iframe is handled separately in
-// registerIframeEventHandlers. Without this, the OS/WebView2 default menu
-// (Inspect etc.) pops up over the app.
-document.addEventListener(
-  "contextmenu",
-  (event) => event.preventDefault(),
-  true,
-);
+// Suppress the WebView's native context menu in production builds; dev keeps
+// it so the native menu (Inspect Element etc.) stays available for debugging.
+// Editable areas get a slim custom menu (Undo/Cut/Copy/Paste/Select All) from
+// the ContextMenu component; the reader's sandboxed iframe is handled
+// separately in registerIframeEventHandlers. Without this, the OS/WebView2
+// default menu (Inspect etc.) pops up over the app.
+if (shouldSuppressNativeContextMenu) {
+  document.addEventListener("contextmenu", (event) => event.preventDefault(), true);
+}
 
 // Keep the WebView color scheme in sync with the app theme so book CSS that
 // relies on light-dark() / @media(prefers-color-scheme) follows the app theme
@@ -57,7 +57,8 @@ new MutationObserver(syncSystemTheme).observe(document.documentElement, {
 });
 
 const FEEDBACK_WORKER_FALLBACK = "https://feedback.readany.top";
-const feedbackWorkerUrl = import.meta.env.VITE_FEEDBACK_WORKER_URL?.trim() || FEEDBACK_WORKER_FALLBACK;
+const feedbackWorkerUrl =
+  import.meta.env.VITE_FEEDBACK_WORKER_URL?.trim() || FEEDBACK_WORKER_FALLBACK;
 setFeedbackWorkerUrl(feedbackWorkerUrl);
 
 // Register platform service before any database/core operations

--- a/packages/core/src/i18n/locales/en/common.json
+++ b/packages/core/src/i18n/locales/en/common.json
@@ -5,6 +5,8 @@
     "confirm": "Confirm",
     "save": "Save",
     "close": "Close",
+    "cut": "Cut",
+    "undo": "Undo",
     "copy": "Copy",
     "copied": "Copied",
     "remove": "Remove",
@@ -42,6 +44,7 @@
     "insertLink": "Insert link",
     "linkText": "Link text",
     "paste": "Paste",
+    "selectAll": "Select all",
     "rename": "Rename",
     "reset": "Reset",
     "writeYourThoughts": "Write your thoughts..."

--- a/packages/core/src/i18n/locales/es/common.json
+++ b/packages/core/src/i18n/locales/es/common.json
@@ -5,6 +5,8 @@
     "confirm": "Confirmar",
     "save": "Guardar",
     "close": "Cerrar",
+    "cut": "Cortar",
+    "undo": "Deshacer",
     "copy": "Copiar",
     "copied": "Copiado",
     "remove": "Eliminar",
@@ -42,6 +44,7 @@
     "insertLink": "Insertar enlace",
     "linkText": "Texto del enlace",
     "paste": "Pegar",
+    "selectAll": "Seleccionar todo",
     "rename": "Renombrar",
     "reset": "Restablecer",
     "writeYourThoughts": "Escribe tus ideas..."

--- a/packages/core/src/i18n/locales/fr/common.json
+++ b/packages/core/src/i18n/locales/fr/common.json
@@ -5,6 +5,8 @@
     "confirm": "Confirmer",
     "save": "Enregistrer",
     "close": "Fermer",
+    "cut": "Couper",
+    "undo": "Annuler",
     "copy": "Copier",
     "copied": "Copié",
     "remove": "Supprimer",
@@ -42,6 +44,7 @@
     "insertLink": "Insérer un lien",
     "linkText": "Texte du lien",
     "paste": "Coller",
+    "selectAll": "Tout sélectionner",
     "rename": "Renommer",
     "reset": "Réinitialiser",
     "writeYourThoughts": "Écrivez vos réflexions..."

--- a/packages/core/src/i18n/locales/ja/common.json
+++ b/packages/core/src/i18n/locales/ja/common.json
@@ -5,6 +5,8 @@
     "confirm": "確認",
     "save": "保存",
     "close": "閉じる",
+    "cut": "切り取り",
+    "undo": "元に戻す",
     "copy": "コピー",
     "copied": "コピーしました",
     "remove": "削除",
@@ -42,6 +44,7 @@
     "insertLink": "リンクを挿入",
     "linkText": "リンクテキスト",
     "paste": "貼り付け",
+    "selectAll": "すべて選択",
     "rename": "名前を変更",
     "reset": "リセット",
     "writeYourThoughts": "感想を書く..."

--- a/packages/core/src/i18n/locales/ko/common.json
+++ b/packages/core/src/i18n/locales/ko/common.json
@@ -5,6 +5,8 @@
     "confirm": "확인",
     "save": "저장",
     "close": "닫기",
+    "cut": "잘라내기",
+    "undo": "실행 취소",
     "copy": "복사",
     "copied": "복사됨",
     "remove": "제거",
@@ -42,6 +44,7 @@
     "insertLink": "링크 삽입",
     "linkText": "링크 텍스트",
     "paste": "붙여넣기",
+    "selectAll": "모두 선택",
     "rename": "이름 변경",
     "reset": "초기화",
     "writeYourThoughts": "생각을 적어보세요..."

--- a/packages/core/src/i18n/locales/zh-TW/common.json
+++ b/packages/core/src/i18n/locales/zh-TW/common.json
@@ -5,6 +5,8 @@
     "confirm": "確定",
     "save": "儲存",
     "close": "關閉",
+    "cut": "剪下",
+    "undo": "復原",
     "copy": "複製",
     "copied": "已複製",
     "remove": "刪除",
@@ -42,6 +44,7 @@
     "insertLink": "插入連結",
     "linkText": "連結文字",
     "paste": "貼上",
+    "selectAll": "全選",
     "rename": "重新命名",
     "reset": "復原",
     "writeYourThoughts": "寫下你的想法..."

--- a/packages/core/src/i18n/locales/zh/common.json
+++ b/packages/core/src/i18n/locales/zh/common.json
@@ -5,6 +5,8 @@
     "confirm": "确定",
     "save": "保存",
     "close": "关闭",
+    "cut": "剪切",
+    "undo": "撤销",
     "copy": "复制",
     "copied": "已复制",
     "remove": "删除",
@@ -42,6 +44,7 @@
     "insertLink": "插入链接",
     "linkText": "链接文字",
     "paste": "粘贴",
+    "selectAll": "全选",
     "rename": "重命名",
     "reset": "复原",
     "writeYourThoughts": "写下你的想法..."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@tauri-apps/plugin-dialog':
         specifier: ^2.6.0
         version: 2.6.0
@@ -3804,6 +3807,9 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
     engines: {node: '>= 10'}
@@ -3874,6 +3880,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.3':
+    resolution: {integrity: sha512-KnyoTs9gj1yEgDkSPUNjOIOHjJTr5wk8IWcYMOWxYTIJCip6QwlyPW8u2X+6bd6kHM4fAdZNpxoal0gy/TwJbg==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
@@ -7476,11 +7485,11 @@ packages:
   onnxruntime-common@1.21.0:
     resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
 
-  onnxruntime-common@1.24.3:
-    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
-
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
 
   onnxruntime-node@1.21.0:
     resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
@@ -7488,6 +7497,10 @@ packages:
 
   onnxruntime-react-native@1.24.3:
     resolution: {integrity: sha512-vMxFcnO1YDtT6auv719Zk0Zj/EXujqeEzSjTe5W7A915qaRrM4pRfXlI4ye/ExOwcTan7NYVZ/wpLX+YBU2aWQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: 19.1.0
+      react-native: '*'
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
@@ -8796,6 +8809,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -13449,6 +13463,8 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     optional: true
 
@@ -13495,6 +13511,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
@@ -18082,9 +18102,9 @@ snapshots:
 
   onnxruntime-common@1.21.0: {}
 
-  onnxruntime-common@1.24.3: {}
-
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
+
+  onnxruntime-common@1.24.3: {}
 
   onnxruntime-node@1.21.0:
     dependencies:


### PR DESCRIPTION
### 问题

桌面版（Tauri/WebView）各处都会弹出浏览器自带的右键菜单（检查元素、拼写检查、
翻译等与阅读器无关的项），干扰阅读和操作。此前 `contextmenu` 未做全局处理，
仅在个别组件（如侧栏）局部 `preventDefault`。

### 修复

1. **全局屏蔽原生右键菜单**（`main.tsx`）：`document.addEventListener("contextmenu",
   e => e.preventDefault(), true)`，覆盖主界面 / 目录 / 设置 / 弹窗等所有主文档区域。
2. **阅读器 iframe 屏蔽**（`iframe-event-handlers.ts`）：书内容渲染在 sandboxed
   foliate iframe 中，主文档监听进不去，因此在每个 section 的 iframe document 上
   注册 `contextmenu` 屏蔽（覆盖 epub 与 PDF）。
3. **右键不再误触发翻页**（`FoliateViewer.tsx`）：屏蔽菜单后，右键 `pointerup`
   会按点击位置触发原有翻页逻辑；现在 `handlePointerUp` 忽略 `button === 2`，
   右键仅用于菜单屏蔽，不做任何页面操作。
4. **可编辑区精简菜单**（新增 `ContextMenu.tsx`）：全局替换原生菜单，仅在
   input / textarea / contenteditable / select 上显示自定义菜单
   （撤销 / 剪切 / 复制 / 粘贴 / 全选），去掉"检查元素"等无关项。
   粘贴 / 复制优先用 `document.execCommand`（避免 WebView2 剪贴板权限对话框），
   检测到 execCommand 不可用时降级到 async Clipboard API。

### 行为

- 主界面 / 目录 / 设置 / 阅读器：右键无原生菜单。
- 输入框 / 文本域 / 编辑区：右键显示精简自定义菜单（撤销/剪切/复制/粘贴/全选）。
- 阅读器内右键：不弹菜单、不翻页。
- 侧栏等已有自定义右键（自带 preventDefault）：不受影响。

### 说明

- `document.execCommand` 虽标记 deprecated，但所有引擎（Chromium/WebView2、WebKit、
  Firefox）仍完整支持且无移除计划；它是自定义右键菜单中唯一免权限对话框的
  粘贴方式（async Clipboard API 每次弹权限提示）。已实现优雅降级。
- 表情符号 / 语音输入等系统级菜单项（Windows 依赖 Win+. / Win+H）未纳入精简
  菜单，需要平台特定 API 且仅 Windows 可用，故未实现。
- 移动端为触摸设备无右键菜单，无需处理。