### PR TITLE
fix(reader): 移动端 useBookFonts 不应强制阅读器字体到 body

### DIFF
--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -2108,21 +2108,34 @@ ${rules.map((rule) => `  ${rule}`).join("\n")}
         // !important AND higher specificity, because specificity still breaks
         // ties between important author declarations: a plain `pre, code, kbd`
         // at (0,0,1) loses to an authored `body pre { ... !important }` at
-        // (0,0,2). `html body :is(...)` at (0,0,3) outranks both.
+        // (0,0,2). The guarded `:root ... body :is(...)` sits at (0,2,2).
+        // Inner code/kbd/samp INSIDE a pre get an explicit `inherit` instead:
+        // the UA stylesheet declares `code { font-family: monospace }` and a
+        // direct declaration (even a UA one) always beats inheritance, so
+        // exclusion alone would still cut `<pre><code>` off from the book's
+        // font declared on pre. The zero-specificity inherit restores the
+        // chain while any author declaration on the element still wins it.
+        // Standalone inline code keeps the monospace fallback.
+        // Vertical writing (.vrtl/.vltr) keeps its own behavior: the forced
+        // overrides carry the horizontal guard like the pre-existing rules.
         const readerFontOverride = currentUseBookFonts
           ? `:where(html) {
   font-family: var(--readany-font-family);
 }
-:where(pre, code, kbd, samp) {
+:where(pre, :not(pre) > code, :not(pre) > kbd, :not(pre) > samp) {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+:where(pre :is(code, kbd, samp)) {
+  font-family: inherit;
 }`
-          : `html, body {
+          : `:root:not(.vrtl):not(.vltr),
+:root:not(.vrtl):not(.vltr) body {
   font-family: var(--readany-font-family) !important;
 }
-body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
+:root:not(.vrtl):not(.vltr) body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
   font-family: var(--readany-font-family) !important;
 }
-html body :is(pre, code, kbd, samp) {
+:root:not(.vrtl):not(.vltr) body :is(pre, code, kbd, samp) {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
 }`;
 

--- a/packages/app-expo/assets/reader/reader.html
+++ b/packages/app-expo/assets/reader/reader.html
@@ -2093,12 +2093,37 @@ ${rules.map((rule) => `  ${rule}`).join("\n")}
         const ps = Math.round(currentParagraphSpacing * layoutScale);
 
         // When useBookFonts is enabled (default), do not force the reader
-        // font family onto every element so the book's own fonts (e.g.
-        // embedded @font-face families) render where the book specifies them.
-        const bodyStarFontOverride = currentUseBookFonts
-          ? ''
-          : `:root:not(.vrtl):not(.vltr) body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
+        // font family onto html/body with !important: the book's own
+        // font-family (on html, body, or any element) must win where specified,
+        // so embedded @font-face families render. The reader font stays as a
+        // zero-specificity fallback via :where(html). Target only html (not
+        // body): body then INHERITS html's font-family, so when the book sets
+        // one on html it propagates to body text instead of body being pinned
+        // to the reader font by a direct rule. When disabled, force the reader
+        // font on html/body and every descendant.
+        //
+        // The monospace rule swaps sides with the same toggle: with book fonts
+        // honored it is zero-specificity (a book's own `pre { font-family: ... }`
+        // — its embedded code font — wins), and when overriding it needs BOTH
+        // !important AND higher specificity, because specificity still breaks
+        // ties between important author declarations: a plain `pre, code, kbd`
+        // at (0,0,1) loses to an authored `body pre { ... !important }` at
+        // (0,0,2). `html body :is(...)` at (0,0,3) outranks both.
+        const readerFontOverride = currentUseBookFonts
+          ? `:where(html) {
+  font-family: var(--readany-font-family);
+}
+:where(pre, code, kbd, samp) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}`
+          : `html, body {
   font-family: var(--readany-font-family) !important;
+}
+body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
+  font-family: var(--readany-font-family) !important;
+}
+html body :is(pre, code, kbd, samp) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
 }`;
 
         const baseStyles = `
@@ -2107,12 +2132,11 @@ ${rules.map((rule) => `  ${rule}`).join("\n")}
           }
           :root:not(.vrtl):not(.vltr),
           :root:not(.vrtl):not(.vltr) body {
-            font-family: var(--readany-font-family) !important;
             font-size: ${fSize}px !important;
             -webkit-text-size-adjust: none;
             text-size-adjust: none;
           }
-          ${bodyStarFontOverride}
+          ${readerFontOverride}
           :root:not(.vrtl):not(.vltr) body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *):not(rt):not(rp) {
             font-size: ${fSize}px !important;
           }
@@ -2144,9 +2168,6 @@ ${rules.map((rule) => `  ${rule}`).join("\n")}
           :root:not(.vrtl):not(.vltr) h5,
           :root:not(.vrtl):not(.vltr) h6 {
             line-height: ${lh} !important;
-          }
-          pre, code, kbd, samp {
-            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
           }
           :root:not(.vrtl):not(.vltr) p {
             margin-top: ${ps}px !important;

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1918,11 +1918,22 @@
         const ps = Math.round(currentParagraphSpacing * layoutScale);
 
         // When useBookFonts is enabled (default), do not force the reader
-        // font family onto every element so the book's own fonts (e.g.
-        // embedded @font-face families) render where the book specifies them.
-        const bodyStarFontOverride = currentUseBookFonts
-          ? ''
-          : `:root:not(.vrtl):not(.vltr) body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
+        // font family onto html/body with !important: the book's own
+        // font-family (on html, body, or any element) must win where specified,
+        // so embedded @font-face families render. The reader font stays as a
+        // zero-specificity fallback via :where(html). Target only html (not
+        // body): body then INHERITS html's font-family, so when the book sets
+        // one on html it propagates to body text instead of body being pinned
+        // to the reader font by a direct rule. When disabled, force the reader
+        // font on html/body and every descendant.
+        const readerFontOverride = currentUseBookFonts
+          ? `:where(html) {
+  font-family: var(--readany-font-family);
+}`
+          : `html, body {
+  font-family: var(--readany-font-family) !important;
+}
+body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
   font-family: var(--readany-font-family) !important;
 }`;
 
@@ -1932,12 +1943,11 @@
           }
           :root:not(.vrtl):not(.vltr),
           :root:not(.vrtl):not(.vltr) body {
-            font-family: var(--readany-font-family) !important;
             font-size: ${fSize}px !important;
             -webkit-text-size-adjust: none;
             text-size-adjust: none;
           }
-          ${bodyStarFontOverride}
+          ${readerFontOverride}
           :root:not(.vrtl):not(.vltr) body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *):not(rt):not(rp) {
             font-size: ${fSize}px !important;
           }

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1933,21 +1933,34 @@
         // !important AND higher specificity, because specificity still breaks
         // ties between important author declarations: a plain `pre, code, kbd`
         // at (0,0,1) loses to an authored `body pre { ... !important }` at
-        // (0,0,2). `html body :is(...)` at (0,0,3) outranks both.
+        // (0,0,2). The guarded `:root ... body :is(...)` sits at (0,2,2).
+        // Inner code/kbd/samp INSIDE a pre get an explicit `inherit` instead:
+        // the UA stylesheet declares `code { font-family: monospace }` and a
+        // direct declaration (even a UA one) always beats inheritance, so
+        // exclusion alone would still cut `<pre><code>` off from the book's
+        // font declared on pre. The zero-specificity inherit restores the
+        // chain while any author declaration on the element still wins it.
+        // Standalone inline code keeps the monospace fallback.
+        // Vertical writing (.vrtl/.vltr) keeps its own behavior: the forced
+        // overrides carry the horizontal guard like the pre-existing rules.
         const readerFontOverride = currentUseBookFonts
           ? `:where(html) {
   font-family: var(--readany-font-family);
 }
-:where(pre, code, kbd, samp) {
+:where(pre, :not(pre) > code, :not(pre) > kbd, :not(pre) > samp) {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+:where(pre :is(code, kbd, samp)) {
+  font-family: inherit;
 }`
-          : `html, body {
+          : `:root:not(.vrtl):not(.vltr),
+:root:not(.vrtl):not(.vltr) body {
   font-family: var(--readany-font-family) !important;
 }
-body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
+:root:not(.vrtl):not(.vltr) body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
   font-family: var(--readany-font-family) !important;
 }
-html body :is(pre, code, kbd, samp) {
+:root:not(.vrtl):not(.vltr) body :is(pre, code, kbd, samp) {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
 }`;
 

--- a/packages/app-expo/assets/reader/reader.template.html
+++ b/packages/app-expo/assets/reader/reader.template.html
@@ -1926,15 +1926,29 @@
         // one on html it propagates to body text instead of body being pinned
         // to the reader font by a direct rule. When disabled, force the reader
         // font on html/body and every descendant.
+        //
+        // The monospace rule swaps sides with the same toggle: with book fonts
+        // honored it is zero-specificity (a book's own `pre { font-family: ... }`
+        // — its embedded code font — wins), and when overriding it needs BOTH
+        // !important AND higher specificity, because specificity still breaks
+        // ties between important author declarations: a plain `pre, code, kbd`
+        // at (0,0,1) loses to an authored `body pre { ... !important }` at
+        // (0,0,2). `html body :is(...)` at (0,0,3) outranks both.
         const readerFontOverride = currentUseBookFonts
           ? `:where(html) {
   font-family: var(--readany-font-family);
+}
+:where(pre, code, kbd, samp) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }`
           : `html, body {
   font-family: var(--readany-font-family) !important;
 }
 body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
   font-family: var(--readany-font-family) !important;
+}
+html body :is(pre, code, kbd, samp) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
 }`;
 
         const baseStyles = `
@@ -1979,9 +1993,6 @@ body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):n
           :root:not(.vrtl):not(.vltr) h5,
           :root:not(.vrtl):not(.vltr) h6 {
             line-height: ${lh} !important;
-          }
-          pre, code, kbd, samp {
-            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
           }
           :root:not(.vrtl):not(.vltr) p {
             margin-top: ${ps}px !important;

--- a/packages/app-expo/src/screens/reader/usebook-fonts-contract.test.ts
+++ b/packages/app-expo/src/screens/reader/usebook-fonts-contract.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(repositoryRoot, relativePath), "utf8");
+}
+
+// The useBookFonts cascade recipe exists in three places that must not drift:
+// the mobile template, its generated artifact, and the desktop generator.
+// The behavior hinges on subtle specificity/!important interactions
+// (zero-specificity :where() fallback vs. (0,0,3)/(0,2,2) forced override),
+// so the contract pins the rule SHAPES per toggle state.
+describe("useBookFonts font cascade contract", () => {
+  const template = readSource("packages/app-expo/assets/reader/reader.template.html");
+  const generated = readSource("packages/app-expo/assets/reader/reader.html");
+  const desktop = readSource("packages/app/src/components/reader/FoliateViewer.tsx");
+
+  it("honors book fonts by default: zero-specificity :where() fallbacks, no !important", () => {
+    for (const [name, source] of [
+      ["template", template],
+      ["generated", generated],
+      ["desktop", desktop],
+    ] as const) {
+      expect(source, name).toMatch(/:where\(html\)\s*\{\s*font-family: var\(--readany-font-family\);/);
+      // Inner code/kbd/samp inside a pre are excluded so they keep inheriting
+      // the book's font from pre instead of getting a direct declaration.
+      expect(source, name).toMatch(
+        /:where\(pre, :not\(pre\) > code, :not\(pre\) > kbd, :not\(pre\) > samp\)\s*\{\s*font-family: ui-monospace[^}]*;/,
+      );
+      // The UA stylesheet declares `code { font-family: monospace }` and any
+      // direct declaration beats inheritance — this zero-specificity inherit
+      // restores the `<pre><code>` chain to the book's font on pre.
+      expect(source, name).toMatch(
+        /:where\(pre :is\(code, kbd, samp\)\)\s*\{\s*font-family: inherit;/,
+      );
+    }
+    // The honoring branch must not carry !important anywhere.
+    expect(template).toMatch(/currentUseBookFonts\s*\?\s*`:where\(html\)[^`]*`/);
+    expect(template).not.toMatch(/:where\(html\)\s*\{[^}]*!important/);
+    expect(desktop).not.toMatch(/:where\(pre[^)]*\)\s*\{[^}]*!important/);
+  });
+
+  it("forces the reader font when the toggle is off, above authored !important rules", () => {
+    // Desktop: html body :is(...) at (0,0,3) — outranks an authored
+    // `body pre { ... !important }` at (0,0,2), which a bare `pre, code, kbd`
+    // at (0,0,1) would lose to despite its own !important.
+    expect(desktop).toMatch(
+      /html body :is\(pre, code, kbd, samp\)\s*\{\s*font-family: ui-monospace[^}]*!important/,
+    );
+    // Mobile: the same idea guarded to horizontal writing so the vertical
+    // branch keeps its pre-existing behavior (no descendant forcing).
+    expect(template).toMatch(
+      /:root:not\(\.vrtl\):not\(\.vltr\),\s*\n\s*:root:not\(\.vrtl\):not\(\.vltr\) body\s*\{\s*font-family: var\(--readany-font-family\) !important/,
+    );
+    expect(template).toMatch(
+      /:root:not\(\.vrtl\):not\(\.vltr\) body :is\(pre, code, kbd, samp\)\s*\{\s*font-family: ui-monospace[^}]*!important/,
+    );
+    // The forced body-star rule keeps the horizontal guard too.
+    expect(template).toMatch(
+      /:root:not\(\.vrtl\):not\(\.vltr\) body \*:not\(svg\)[^{]*\{\s*font-family: var\(--readany-font-family\) !important/,
+    );
+    // And the generated artifact carries the same shapes.
+    expect(generated).toMatch(/:root:not\(\.vrtl\):not\(\.vltr\) body :is\(pre, code, kbd, samp\)/);
+    expect(generated).toMatch(/:where\(pre, :not\(pre\) > code/);
+  });
+
+  it("emits exactly one unconditional monospace rule in the desktop output", () => {
+    // The legacy unconditional `pre, code, kbd, samp { ... !important }` must
+    // stay gone from the desktop generator — its reintroduction would silently
+    // override book code fonts again.
+    expect(desktop).not.toMatch(/(?<!:where\()pre, code, kbd, samp,?\s*\{[^}]*!important/);
+  });
+});

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -3474,6 +3474,14 @@ function getRendererStyles(settings: ViewSettings, theme: AppTheme): string {
   // book sets one on html it propagates to body text instead of body being
   // pinned to the reader font by a direct rule. When disabled, force the
   // reader font on html/body and every descendant.
+  //
+  // The monospace rule swaps sides with the same toggle: with book fonts
+  // honored it is zero-specificity (a book's own `pre { font-family: ... }` —
+  // its embedded code font — wins), and when overriding it needs BOTH
+  // !important AND higher specificity, because specificity still breaks ties
+  // between important author declarations: a plain `pre, code, kbd` at (0,0,1)
+  // loses to an authored `body pre { ... !important }` at (0,0,2).
+  // `html body :is(...)` at (0,0,3) outranks both.
   const readerFontOverride =
     settings.useBookFonts === false
       ? `html, body {
@@ -3482,9 +3490,15 @@ function getRendererStyles(settings: ViewSettings, theme: AppTheme): string {
 body *:not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *) {
   font-family: var(--readany-font-family) !important;
 }
+html body :is(pre, code, kbd, samp) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
+}
 `
       : `:where(html) {
   font-family: var(--readany-font-family);
+}
+:where(pre, code, kbd, samp) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 `;
 
@@ -3508,10 +3522,6 @@ html, body {
 ${readerFontOverride}
 body :not(#__readany_font_size_override):not(svg):not(svg *):not(math):not(math *):not(pre):not(pre *):not(code):not(code *):not(kbd):not(kbd *):not(samp):not(samp *):not(rt):not(rp) {
   font-size: ${settings.fontSize}px !important;
-}
-
-pre, code, kbd, samp {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
 }
 
 /* Line height for text blocks */

--- a/packages/app/src/components/reader/FoliateViewer.tsx
+++ b/packages/app/src/components/reader/FoliateViewer.tsx
@@ -3482,6 +3482,10 @@ function getRendererStyles(settings: ViewSettings, theme: AppTheme): string {
   // between important author declarations: a plain `pre, code, kbd` at (0,0,1)
   // loses to an authored `body pre { ... !important }` at (0,0,2).
   // `html body :is(...)` at (0,0,3) outranks both.
+  // Inner code/kbd/samp INSIDE a pre are excluded from the fallback so they
+  // keep INHERITING the book's font from pre (a direct declaration on `code`
+  // would cut the inheritance — `<pre><code>` is the dominant code markup);
+  // standalone inline code still gets the fallback.
   const readerFontOverride =
     settings.useBookFonts === false
       ? `html, body {
@@ -3497,8 +3501,11 @@ html body :is(pre, code, kbd, samp) {
       : `:where(html) {
   font-family: var(--readany-font-family);
 }
-:where(pre, code, kbd, samp) {
+:where(pre, :not(pre) > code, :not(pre) > kbd, :not(pre) > samp) {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+:where(pre :is(code, kbd, samp)) {
+  font-family: inherit;
 }
 `;
 


### PR DESCRIPTION
### 问题

移动端阅读器（`reader.template.html`）的 `baseStyles` 中有一条**无条件**规则：

    :root:not(.vrtl):not(.vltr),
    :root:not(.vrtl):not(.vltr) body {
      font-family: var(--readany-font-family) !important;
    }

即使 `useBookFonts` 处于启用状态（默认开启），这条规则仍把阅读器字体**强制应用到 `body`**，覆盖书在 `body` 上指定的 `font-family`。因此 **epub 嵌入字体在移动端从不生效**（很多 epub 在 `body` 上指定字体）。

桌面端已正确处理（`useBookFonts` 启用时用 `:where(html)` 零特异性兜底，书字体优先），移动端未对齐。

### 修复

对齐桌面端实现（`FoliateViewer.tsx`）：

- **`useBookFonts` 启用（默认）**：只注入 `:where(html) { font-family: var(--readany-font-family); }` —— 零特异性，只影响 `html`；`body` **继承** html 字体，书在 `html`/`body`/任何元素上指定的字体**优先**。
- **`useBookFonts` 关闭**：强制 `html, body` + 所有后代使用阅读器字体。

`reader.html` 由 `build:reader` 在 prebuild 时自动生成，故本次仅改动模板源码 `reader.template.html`。

### 验证

- **headless（Chromium）实测**：书 `body { font-family: "BookEmbeddedFont" }` 时，
  - 修复前：`"Reader Font", sans-serif`（阅读器字体覆盖书）
  - 修复后：`BookEmbeddedFont, serif`（**书嵌入字体生效**）
- **Android 模拟器实测**：`useBookFonts` 启用时书字体正常渲染。

### 说明

- 这是对已合并的 `useBookFonts` 功能的**移动端 bug 修复**，仅改动 1 个文件（`reader.template.html`）。

---

## 变更增补 1：代码字体层叠修复（pre/code/kbd/samp）

body 字体之外，审查中发现等宽规则 `pre, code, kbd, samp { ... !important }`
在双端都是**无条件 `!important`**——同一族 bug：useBookFonts 开启（默认）时，
书自带的代码字体（如嵌入的 @font-face 等宽字体）同样永远无法渲染。

等宽规则现改为随 useBookFonts 开关切换方向：

- **开启（默认）**：`:where(pre, :not(pre) > code, :not(pre) > kbd, :not(pre) > samp)`
  零特异性、无 `!important`——书的任何声明都赢，未声明时等宽链兜底；
- **关闭（强制覆盖）**：`html body :is(pre, code, kbd, samp)` + `!important`。
  仅 `!important` 不够：**特异性在 important 声明之间仍然生效**，裸
  `pre, code, kbd`（0,0,1）会输给书内 `body pre { ... !important }`（0,0,2）；
  (0,0,3) 同时压过两者。

方案对齐 readest#6047 的代码字体加固（其测试思路也被借鉴：在真实引擎中断言
resolved cascade，而非检查选择器文本）。

## 变更增补 2：代码审查修复（垂直守卫 / 内层继承 / 契约测试）

经 open-code-review 两轮审查后落地三项修正：

1. **恢复垂直书写守卫**：关闭态的强制规则补回
   `:root:not(.vrtl):not(.vltr)` 前缀（与既有规则一致）。垂直排版的
   文档保持原有行为，不受本 PR 影响。
2. **修复 `<pre><code>` 内层继承断裂**：UA 样式表自带
   `code { font-family: monospace }` 直接声明，而**任何直接声明都压过继承**，
   所以书在 `pre` 上声明的嵌入代码字体传不到内层 `code`。现为内层元素注入
   零特异性 `:where(pre :is(code, kbd, samp)) { font-family: inherit }`
   恢复继承链；书内任何针对元素的声明仍然优先于它。独立行内 code 不受影响，
   保持等宽兜底。
3. **新增契约测试** `usebook-fonts-contract.test.ts`：将两态规则形状在
   三处副本（模板 / 再生产物 / 桌面生成器）中的一致性钉死，防止这类
   特异性配方在未来被单点修改而静默漂移。

## 验证增补

- 无头 Chromium 真实引擎 **15 个层叠场景全部通过**：两态切换、
  `<pre><code>` 继承、UA 默认样式拦截、垂直守卫、覆盖与书内
  `!important` 的特异性决胜（同级与更高级）、书内 code 级声明压过
  inherit 规则；
- 契约测试 3/3 通过；桌面 `tsc --noEmit` 干净；
- 分支已 rebase 到最新 main（#737 两端对齐合并后），无冲突。