### PR TITLE
fix(android): 打补丁让 @expo/cli 相对 --entry-file 按项目根解析（SDK 54 Windows + pnpm monorepo release 构建）

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     },
     "patchedDependencies": {
       "@langchain/core": "patches/@langchain__core.patch",
-      "react-native-track-player@4.1.2": "patches/react-native-track-player@4.1.2.patch"
+      "react-native-track-player@4.1.2": "patches/react-native-track-player@4.1.2.patch",
+      "@expo/cli@54.0.23": "patches/@expo__cli@54.0.23.patch"
     }
   },
   "packageManager": "pnpm@9.15.0"

--- a/patches/@expo__cli@54.0.23.patch
+++ b/patches/@expo__cli@54.0.23.patch
@@ -1,0 +1,32 @@
+diff --git a/build/src/utils/filePath.js b/build/src/utils/filePath.js
+index 68eed166a8061d9a2488a454aeaa13487416d53b..6ff1ae8b6a1a37c722aa0e71182d2835a5eca9a6 100644
+--- a/build/src/utils/filePath.js
++++ b/build/src/utils/filePath.js
+@@ -23,6 +23,13 @@ function _fs() {
+     };
+     return data;
+ }
++function _path() {
++    const data = /*#__PURE__*/ _interop_require_default(require("path"));
++    _path = function() {
++        return data;
++    };
++    return data;
++}
+ function _interop_require_default(obj) {
+     return obj && obj.__esModule ? obj : {
+         default: obj
+@@ -30,6 +37,13 @@ function _interop_require_default(obj) {
+ }
+ const REGEXP_REPLACE_SLASHES = /\\/g;
+ function resolveRealEntryFilePath(projectRoot, entryFile) {
++    // A relative --entry-file is relative to the project root (not the server
++    // root). Resolve it to an absolute path first so Metro gets a correct
++    // mainModuleName in pnpm monorepos on Windows. Mirrors the fix in
++    // expo/expo#44414 (SDK 55), not backported to SDK 54.
++    if (!_path().default.isAbsolute(entryFile)) {
++        entryFile = _path().default.resolve(process.cwd(), projectRoot, entryFile);
++    }
+     if (projectRoot.startsWith('/private/var') && entryFile.startsWith('/var')) {
+         return _fs().default.realpathSync(entryFile);
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   '@types/react': 19.1.17
 
 patchedDependencies:
+  '@expo/cli@54.0.23':
+    hash: xnnprts3wgwjemoo7wbqe2veuy
+    path: patches/@expo__cli@54.0.23.patch
   '@langchain/core':
     hash: fsq4dynshckwono4lsk3t4tbui
     path: patches/@langchain__core.patch
@@ -11025,7 +11028,7 @@ snapshots:
     dependencies:
       uuid: 8.3.2
 
-  '@expo/cli@54.0.23(expo@54.0.33(@babel/core@7.29.0)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(graphql@16.8.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))':
+  '@expo/cli@54.0.23(patch_hash=xnnprts3wgwjemoo7wbqe2veuy)(expo@54.0.33(@babel/core@7.29.0)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(graphql@16.8.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))':
     dependencies:
       '@0no-co/graphql.web': 1.2.0(graphql@16.8.1)
       '@expo/code-signing-certificates': 0.0.6
@@ -15798,7 +15801,7 @@ snapshots:
   expo@54.0.33(@babel/core@7.29.0)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.28.6
-      '@expo/cli': 54.0.23(expo@54.0.33(@babel/core@7.29.0)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(graphql@16.8.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      '@expo/cli': 54.0.23(patch_hash=xnnprts3wgwjemoo7wbqe2veuy)(expo@54.0.33(@babel/core@7.29.0)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(graphql@16.8.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
       '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
### 问题

在 **Windows + pnpm monorepo** 环境下，用 Expo SDK 54 构建 Android **release APK** 会失败。`gradle assembleRelease` 的 `createBundleReleaseJsAndAssets` 阶段必现报错：

    Error: Unable to resolve module ./index.js from E:\<repo-root>\.: 

Metro 把 **monorepo 根目录**当作解析基准，而不是 app 目录。原因是 react-native 的 gradle 插件在 **Windows 上传递相对路径**的 `--entry-file`（其 `File.cliPath()` 在 macOS/Linux 返回绝对路径、Windows 返回相对路径），而 SDK 54 的 `@expo/cli`（`resolveRealEntryFilePath`）**对相对路径原样返回**，没有按项目根解析成绝对路径。

macOS 上不触发（gradle 传绝对路径），所以上游在 macOS 构建正常、Windows 用户无法本地出包。

### 上游反馈

- 已向 expo 提交 issue（[expo/expo#49659](https://github.com/expo/expo/issues/49659)，附最小复现仓库 [expo-bug](https://github.com/k6G52m4Dz75W/expo-bug)）
- **被关闭**。expo 确认这是已知问题，已在 [expo/expo#44414](https://github.com/expo/expo/pull/44414)（SDK 55）修复，但属于**破坏性变更，不 backport 到 SDK 54**。因此 SDK 54 需要自行补丁。

### 修复

移植 expo/expo#44414 的核心改动：`resolveRealEntryFilePath` 对相对路径先基于 `projectRoot` 解析为绝对路径，再走原有 realpath 逻辑：

    if (!path.isAbsolute(entryFile)) {
      entryFile = path.resolve(process.cwd(), projectRoot, entryFile);
    }

通过 **pnpm patch**（`patches/@expo__cli@54.0.23.patch`）应用，`pnpm install` 自动重新应用，可持续维护。升级 SDK 55+ 后可移除。

### 验证

- `expo export:embed` 相对 entry-file：Bundled 成功（修复前 `Unable to resolve ./index.js from <repo-root>`）
- `gradle assembleRelease`：BUILD SUCCESSFUL，产出签名 APK
- 模拟器安装实测正常
- 相对与绝对 `--entry-file` 均能打包

### 备注

- 仅针对 expo SDK 54（`@expo/cli` 54.0.23）；SDK 55 已内置修复，无需此补丁
- SDK 52+ 的 monorepo 由 expo 自动处理；`metro.config.js` 中手动 `watchFolders`/`nodeModulesPaths` 属废弃写法（expo 官方建议清理），与本 PR 独立