### PR TITLE
fix(desktop): Windows 触屏设备上标签页无法关闭（全应用 hover 样式失效）

### DIFF
--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod db;
+mod pointer_caps;
 mod readany_cli;
 mod storage;
 mod sync;
@@ -10,6 +11,9 @@ use vector::VectorDBState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Must happen before the first WebView2 environment is created.
+    pointer_caps::apply_webview_pointer_capabilities();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             if let Some(window) = app.get_webview_window("main") {

--- a/packages/app/src-tauri/src/pointer_caps.rs
+++ b/packages/app/src-tauri/src/pointer_caps.rs
@@ -1,0 +1,122 @@
+//! WebView2 pointer-capability correction for Windows touchscreen machines.
+//!
+//! Chromium's device enumeration on some Windows touchscreen devices (e.g.
+//! Surface) registers only the touch digitizer, so CSS media queries report
+//! `(hover: none)` and `(pointer: coarse)` even while a mouse is in use —
+//! which keeps every Tailwind `hover:` / `group-hover:` utility (including
+//! the tab close button) permanently disabled. The same applies to
+//! `(any-hover)` / `(any-pointer)`, so no CSS-side query can recover.
+//!
+//! When a fine pointer (mouse or precision touchpad) is present we override
+//! the renderer's report via blink-settings so the media queries match the
+//! hardware. Must run before the first WebView2 environment is created.
+
+const BLINK_SETTINGS_ARGS: &str =
+    "--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4";
+
+#[cfg(target_os = "windows")]
+pub fn apply_webview_pointer_capabilities() {
+    if !has_fine_pointer() {
+        return;
+    }
+
+    const KEY: &str = "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS";
+    let mut value = std::env::var(KEY).unwrap_or_default();
+    if !value.is_empty() {
+        value.push(' ');
+    }
+    value.push_str(BLINK_SETTINGS_ARGS);
+    std::env::set_var(KEY, value);
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn apply_webview_pointer_capabilities() {}
+
+/// True when Windows reports a mouse or a precision touchpad.
+///
+/// Touchscreen digitizers deliberately do NOT count: Chromium treats the
+/// primary pointer as touch there, which is exactly the report we correct.
+#[cfg(target_os = "windows")]
+fn has_fine_pointer() -> bool {
+    use std::alloc::{alloc, dealloc, Layout};
+
+    // Minimal FFI for user32 raw-input enumeration; avoids a new dependency.
+    #[link(name = "user32")]
+    extern "system" {
+        fn GetRawInputDeviceList(
+            list: *mut RawInputDeviceList,
+            count: *mut u32,
+            size: u32,
+        ) -> u32;
+        fn GetRawInputDeviceInfoW(
+            device: isize,
+            command: u32,
+            data: *mut u8,
+            size: *mut u32,
+        ) -> u32;
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct RawInputDeviceList {
+        h_device: isize,
+        dw_type: u32,
+    }
+
+    const RIM_TYPEMOUSE: u32 = 0;
+    const RIM_TYPEHID: u32 = 2;
+    const RIDI_DEVICEINFO: u32 = 0x2000_0007;
+    // HID usage-page / usage pairs from HID_USAGE_PAGE_DIGITIZER.
+    const USAGE_PAGE_DIGITIZER: u16 = 0x000D;
+    const USAGE_TOUCH_PAD: u16 = 0x0005;
+
+    unsafe {
+        let mut count: u32 = 0;
+        if GetRawInputDeviceList(std::ptr::null_mut(), &mut count, std::mem::size_of::<RawInputDeviceList>() as u32)
+            == u32::MAX
+        {
+            return false;
+        }
+        if count == 0 {
+            return false;
+        }
+        let layout = Layout::array::<RawInputDeviceList>(count as usize).expect("device list layout");
+        let list = alloc(layout) as *mut RawInputDeviceList;
+        if list.is_null() {
+            return false;
+        }
+        let fetched = GetRawInputDeviceList(list, &mut count, std::mem::size_of::<RawInputDeviceList>() as u32);
+
+        let mut fine = false;
+        if fetched != u32::MAX {
+            for i in 0..fetched as usize {
+                let device = *list.add(i);
+                if device.dw_type == RIM_TYPEMOUSE {
+                    fine = true;
+                    break;
+                }
+                if device.dw_type != RIM_TYPEHID {
+                    continue;
+                }
+                // RID_DEVICE_INFO: cbSize@0, dwType@4, then the HID union
+                // member: vendorId@8, productId@10, versionNumber@12,
+                // usagePage@14, usage@16 (all USHORT).
+                let mut info = [0u8; 32];
+                let mut info_size = info.len() as u32;
+                if GetRawInputDeviceInfoW(device.h_device, RIDI_DEVICEINFO, info.as_mut_ptr(), &mut info_size)
+                    != u32::MAX
+                {
+                    let usage_page = u16::from_ne_bytes([info[14], info[15]]);
+                    let usage = u16::from_ne_bytes([info[16], info[17]]);
+                    if usage_page == USAGE_PAGE_DIGITIZER && usage == USAGE_TOUCH_PAD {
+                        fine = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        dealloc(list as *mut u8, layout);
+        fine
+    }
+}

--- a/packages/app/src/components/layout/TabBar.tsx
+++ b/packages/app/src/components/layout/TabBar.tsx
@@ -11,6 +11,7 @@ import { useReaderStore } from "@/stores/reader-store";
 import { useSyncStore } from "@/stores/sync-store";
 import { BookOpen, FilePenLine, Home, MessageSquare, NotebookPen, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 const TAB_ICONS: Record<string, React.ElementType> = {
   home: Home,
@@ -131,6 +132,7 @@ function TabItem({
   onClose: () => void;
 }) {
   const Icon = TAB_ICONS[tab.type] ?? BookOpen;
+  const { t } = useTranslation();
 
   return (
     <div
@@ -147,7 +149,10 @@ function TabItem({
       <span className="max-w-[120px] truncate">{tab.title}</span>
       <button
         type="button"
-        className="ml-0.5 hidden h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-neutral-200/80 hover:text-foreground group-hover:flex"
+        title={t("tabs.close")}
+        // Always visible on the active tab — hover-gated elsewhere. Hover-only
+        // UI is unusable on devices whose webview reports (hover: none).
+        className={`ml-0.5 ${isActive ? "flex" : "hidden group-hover:flex"} h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-neutral-200/80 hover:text-foreground`}
         data-no-window-drag
         onClick={(e) => { e.stopPropagation(); onClose(); }}
       >

--- a/packages/core/src/i18n/locales/en/common.json
+++ b/packages/core/src/i18n/locales/en/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "Delete this group? Books will not be deleted."
   },
   "tabs": {
+    "close": "Close tab",
     "library": "Library",
     "ai": "AI",
     "notes": "Notes",

--- a/packages/core/src/i18n/locales/es/common.json
+++ b/packages/core/src/i18n/locales/es/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "¿Eliminar este grupo? Los libros no se eliminarán."
   },
   "tabs": {
+    "close": "Cerrar pestaña",
     "library": "Biblioteca",
     "ai": "IA",
     "notes": "Notas",

--- a/packages/core/src/i18n/locales/fr/common.json
+++ b/packages/core/src/i18n/locales/fr/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "Supprimer ce groupe ? Les livres ne seront pas supprimés."
   },
   "tabs": {
+    "close": "Fermer l'onglet",
     "library": "Bibliothèque",
     "ai": "IA",
     "notes": "Notes",

--- a/packages/core/src/i18n/locales/ja/common.json
+++ b/packages/core/src/i18n/locales/ja/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "このグループを削除しますか？書籍は削除されません。"
   },
   "tabs": {
+    "close": "タブを閉じる",
     "library": "ライブラリ",
     "ai": "AI",
     "notes": "ノート",

--- a/packages/core/src/i18n/locales/ko/common.json
+++ b/packages/core/src/i18n/locales/ko/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "이 그룹을 삭제하시겠습니까? 책은 삭제되지 않습니다."
   },
   "tabs": {
+    "close": "탭 닫기",
     "library": "서재",
     "ai": "AI",
     "notes": "노트",

--- a/packages/core/src/i18n/locales/zh-TW/common.json
+++ b/packages/core/src/i18n/locales/zh-TW/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "確定刪除此分組？書籍不會被刪除。"
   },
   "tabs": {
+    "close": "關閉標籤頁",
     "library": "書庫",
     "ai": "AI",
     "notes": "筆記",

--- a/packages/core/src/i18n/locales/zh/common.json
+++ b/packages/core/src/i18n/locales/zh/common.json
@@ -63,6 +63,7 @@
     "deleteGroupConfirm": "确定删除此分组？书籍不会被删除。"
   },
   "tabs": {
+    "close": "关闭标签页",
     "library": "书库",
     "ai": "AI",
     "notes": "笔记",


### PR DESCRIPTION
## 问题

Windows 触屏设备（如 Surface）上，打开多本书后顶部标签页没有关闭按钮，无法关闭指定的标签页。

tab 关闭按钮原实现为 `hidden group-hover:flex`（悬停显示），但在这类设备上它**永远不会出现**。进一步排查发现影响不止于此——**全应用的 hover 交互**（按钮悬停变色、悬停显现的控件等）在这类设备上全部失效，tab 关闭按钮只是唯一造成功能损失的入口。

## 根因

1. Tailwind v4 将所有 `hover:` / `group-hover:` 工具类编译进 `@media (hover: hover)`（已在构建产物 CSS 中确认）。
2. Chromium/WebView2 在带触摸屏的 Windows 设备上，指针设备枚举只上报触屏数字化仪。实测本应用 WebView 的媒体查询矩阵：

   | 查询 | 结果 |
   |---|---|
   | `(hover: hover)` / `(any-hover: hover)` | false / **false** |
   | `(pointer: fine)` / `(any-pointer: fine)` | false / **false** |
   | `(pointer: coarse)` / `maxTouchPoints` | true / 10 |

   连 `any-hover` / `any-pointer: fine` 都是 false——鼠标在 WebView 的设备能力报告里完全不存在（即使正在使用鼠标），因此换用任何 CSS 写法（包括 `any-*` 查询）都无法恢复。鼠标事件本身（JS mousemove、`:hover` 状态）是正常的，坏的只是能力上报这一层。

## 修复

1. **根因修复**（`src-tauri`，仅 Windows，无新增依赖，commit 1）：启动时通过 Win32 Raw Input API 枚举指针设备，检测到**鼠标或精确触摸板**时，通过 `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` 追加 `--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4`，修正 WebView 的指针能力上报。
   - 不修改任何 CSS；
   - 无鼠标的纯触屏设备保持原行为；
   - 触屏能力保留（实测 `maxTouchPoints` 仍为 10，不影响双指手势）。
2. **交互补强**（`TabBar.tsx`，commit 2）：激活 tab 的关闭按钮**常显**（不再依赖 hover），非激活 tab 保留悬停显示；按钮补充多语言 tooltip（`tabs.close`，en/zh/zh-TW/ja/ko/fr/es 七种语言）。

## 验证

- 修复前实测媒体查询：`hover:hover=false, any-hover:hover=false, pointer:fine=false, any-pointer:fine=false`；修复后全部正确翻转。
- 通过 CDP 向页面注入与 TabItem 结构相同的探针并派发鼠标事件：修复前悬停时按钮 `display` 仍为 `none`；修复后正确翻转为 `flex`（CSS 一行未改）。
- 真机（Surface + 鼠标）验证：多本书打开时关闭按钮悬停可见、激活 tab 常显、可正常关闭指定 tab。
- `cargo check`、`tsc` 通过；改动的 lint 告警均为存量问题（HEAD 上即存在）。


<img width="2560" height="142" alt="image" src="https://github.com/user-attachments/assets/f2d33a87-52a6-4701-8f5d-712cfcfdea85" />
<img width="2560" height="90" alt="image" src="https://github.com/user-attachments/assets/c8e47ef6-a7e6-4619-a917-3ffe906ee1e2" />



**注：本次代码修复和PR信息的提交由AI生成**
