### PR TITLE
feat(reader): 页级笔记兜底 —— 不支持划词的格式（PDF 等）也能添加笔记

### DIFF
--- a/packages/app/src/components/notes/NotesPage.tsx
+++ b/packages/app/src/components/notes/NotesPage.tsx
@@ -33,6 +33,7 @@ import {
  */
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { pageNoteLabel } from "@/lib/reader/page-note";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -666,7 +667,7 @@ function NoteDetailCard({
             className="text-xs text-muted-foreground italic leading-relaxed cursor-pointer hover:text-primary transition-colors line-clamp-2"
             onClick={onNavigate}
           >
-            {t("reader.notebook.pageNoteBadge")}
+            {pageNoteLabel(highlight.cfi, t)}
           </p>
         )}
 
@@ -772,7 +773,7 @@ function HighlightDetailCard({ highlight, onDelete, onNavigate, t }: HighlightDe
             className="text-sm text-muted-foreground italic leading-relaxed cursor-pointer hover:text-primary transition-colors"
             onClick={onNavigate}
           >
-            {t("reader.notebook.pageNoteBadge")}
+            {pageNoteLabel(highlight.cfi, t)}
           </p>
         )}
 

--- a/packages/app/src/components/notes/NotesPage.tsx
+++ b/packages/app/src/components/notes/NotesPage.tsx
@@ -654,12 +654,21 @@ function NoteDetailCard({
     <div className="group rounded-lg border border-border/40 bg-card transition-colors hover:border-border/70">
       <div className="p-3">
         {/* Quoted highlight text */}
-        <p
-          className="text-xs text-muted-foreground/80 leading-relaxed cursor-pointer hover:text-primary transition-colors line-clamp-2"
-          onClick={onNavigate}
-        >
-          "{highlight.text}"
-        </p>
+        {highlight.text ? (
+          <p
+            className="text-xs text-muted-foreground/80 leading-relaxed cursor-pointer hover:text-primary transition-colors line-clamp-2"
+            onClick={onNavigate}
+          >
+            "{highlight.text}"
+          </p>
+        ) : (
+          <p
+            className="text-xs text-muted-foreground italic leading-relaxed cursor-pointer hover:text-primary transition-colors line-clamp-2"
+            onClick={onNavigate}
+          >
+            {t("reader.notebook.pageNoteBadge")}
+          </p>
+        )}
 
         {/* Note content */}
         {isEditing ? (
@@ -751,12 +760,21 @@ function HighlightDetailCard({ highlight, onDelete, onNavigate, t }: HighlightDe
       />
 
       <div className="pl-4 pr-3 py-3">
-        <p
-          className="text-sm text-foreground/90 leading-relaxed cursor-pointer hover:text-primary transition-colors"
-          onClick={onNavigate}
-        >
-          "{highlight.text}"
-        </p>
+        {highlight.text ? (
+          <p
+            className="text-sm text-foreground/90 leading-relaxed cursor-pointer hover:text-primary transition-colors"
+            onClick={onNavigate}
+          >
+            "{highlight.text}"
+          </p>
+        ) : (
+          <p
+            className="text-sm text-muted-foreground italic leading-relaxed cursor-pointer hover:text-primary transition-colors"
+            onClick={onNavigate}
+          >
+            {t("reader.notebook.pageNoteBadge")}
+          </p>
+        )}
 
         <div className="mt-2 flex items-center justify-between">
           <span className="text-[11px] text-muted-foreground/60">

--- a/packages/app/src/components/reader/NotebookPanel.tsx
+++ b/packages/app/src/components/reader/NotebookPanel.tsx
@@ -13,6 +13,7 @@ import {
   ChevronDown,
   ChevronRight,
   Edit3,
+  FileText,
   Highlighter,
   NotebookPen,
   Save,
@@ -30,6 +31,7 @@ import remarkGfm from "remark-gfm";
 interface NotebookPanelProps {
   bookId: string;
   onClose: () => void;
+  onAddPageNote?: () => void;
   onGoToCfi?: (cfi: string) => void;
   onAddAnnotation?: (cfi: string, color: string, note?: string) => void;
   onDeleteAnnotation?: (cfi: string) => void;
@@ -38,6 +40,7 @@ interface NotebookPanelProps {
 export function NotebookPanel({
   bookId,
   onClose,
+  onAddPageNote,
   onGoToCfi,
   onAddAnnotation,
   onDeleteAnnotation,
@@ -202,6 +205,15 @@ export function NotebookPanel({
       <div className="flex h-10 shrink-0 items-center justify-between border-b border-border/40 px-3">
         <span className="text-xs font-medium text-foreground">{t("notebook.title")}</span>
         <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={onAddPageNote}
+            disabled={!onAddPageNote}
+            title={t("notebook.addPageNote")}
+          >
+            <NotebookPen className="h-3.5 w-3.5" />
+          </button>
           <ExportDropdown onExport={handleExport} disabled={bookHighlights.length === 0} />
           <button
             type="button"
@@ -218,19 +230,38 @@ export function NotebookPanel({
         {/* Note Editor - shown when creating/editing */}
         {isEditing && (
           <div className="border-b border-border/40 p-3">
-            {/* Selected text preview */}
-            <div className="mb-3 rounded-md bg-muted/50 p-2">
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
-                <Highlighter className="h-3 w-3" />
-                <span>{t("notebook.selectedText")}</span>
+            {/* Context preview: selected text, or page info for page-level notes */}
+            {editingText ? (
+              <div className="mb-3 rounded-md bg-muted/50 p-2">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+                  <Highlighter className="h-3 w-3" />
+                  <span>{t("notebook.selectedText")}</span>
+                </div>
+                <p className="text-sm text-foreground line-clamp-3">"{editingText}"</p>
+                {(pendingNote?.chapterTitle || editingHighlight?.chapterTitle) && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {pendingNote?.chapterTitle || editingHighlight?.chapterTitle}
+                  </p>
+                )}
               </div>
-              <p className="text-sm text-foreground line-clamp-3">"{editingText}"</p>
-              {(pendingNote?.chapterTitle || editingHighlight?.chapterTitle) && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {pendingNote?.chapterTitle || editingHighlight?.chapterTitle}
+            ) : (
+              <div className="mb-3 rounded-md bg-muted/50 p-2">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+                  <FileText className="h-3 w-3" />
+                  <span>{t("notebook.pageNoteBadge")}</span>
+                </div>
+                <p className="text-sm text-foreground">
+                  {pendingNote?.page
+                    ? t("notebook.pageNotePage", { page: pendingNote.page })
+                    : t("notebook.pageNoteNoPage")}
                 </p>
-              )}
-            </div>
+                {(pendingNote?.chapterTitle || editingHighlight?.chapterTitle) && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {pendingNote?.chapterTitle || editingHighlight?.chapterTitle}
+                  </p>
+                )}
+              </div>
+            )}
 
             {/* Note input */}
             <MarkdownEditor
@@ -260,7 +291,15 @@ export function NotebookPanel({
                 <Button variant="ghost" size="sm" onClick={handleCancel}>
                   {t("common.cancel")}
                 </Button>
-                <Button size="sm" onClick={handleSave}>
+                {/* Page-level notes must carry content — an empty note would be
+                    an invisible row in the list. */}
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={Boolean(pendingNote && !pendingNote.text && !noteContent.trim())}
+                >
+                  <Save className="h-3.5 w-3.5 mr-1" />
+                  {t("common.save")}
                   <Save className="h-3.5 w-3.5 mr-1" />
                   {t("common.save")}
                 </Button>
@@ -381,7 +420,13 @@ function HighlightNoteItem({
           style={{ backgroundColor: HIGHLIGHT_COLOR_HEX[highlight.color] }}
         />
         <div className="flex-1 min-w-0">
-          <p className="text-sm text-foreground line-clamp-2">"{highlight.text}"</p>
+          {highlight.text ? (
+            <p className="text-sm text-foreground line-clamp-2">"{highlight.text}"</p>
+          ) : (
+            <p className="text-sm text-muted-foreground italic line-clamp-2">
+              {t("notebook.pageNoteBadge")}
+            </p>
+          )}
           {highlight.note && (
             <div className="mt-1.5 text-xs text-muted-foreground bg-muted/50 rounded px-2 py-1.5 prose prose-xs dark:prose-invert max-w-none break-words overflow-hidden [overflow-wrap:anywhere]">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{highlight.note}</ReactMarkdown>
@@ -440,7 +485,13 @@ function HighlightItem({ highlight, onClick, onAddNote, onDelete }: HighlightIte
         style={{ backgroundColor: HIGHLIGHT_COLOR_HEX[highlight.color] }}
       />
       <div className="flex-1 min-w-0">
-        <p className="text-sm text-foreground line-clamp-2">"{highlight.text}"</p>
+        {highlight.text ? (
+          <p className="text-sm text-foreground line-clamp-2">"{highlight.text}"</p>
+        ) : (
+          <p className="text-sm text-muted-foreground italic line-clamp-2">
+            {t("notebook.pageNoteBadge")}
+          </p>
+        )}
         {highlight.chapterTitle && (
           <p className="mt-1 text-xs text-muted-foreground/70">{highlight.chapterTitle}</p>
         )}

--- a/packages/app/src/components/reader/NotebookPanel.tsx
+++ b/packages/app/src/components/reader/NotebookPanel.tsx
@@ -15,6 +15,7 @@ import {
   Edit3,
   FileText,
   Highlighter,
+  Plus,
   NotebookPen,
   Save,
   Trash2,
@@ -26,6 +27,7 @@ import {
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
+import { pageNoteLabel } from "@/lib/reader/page-note";
 import remarkGfm from "remark-gfm";
 
 interface NotebookPanelProps {
@@ -212,7 +214,7 @@ export function NotebookPanel({
             disabled={!onAddPageNote}
             title={t("notebook.addPageNote")}
           >
-            <NotebookPen className="h-3.5 w-3.5" />
+            <Plus className="h-4 w-4" />
           </button>
           <ExportDropdown onExport={handleExport} disabled={bookHighlights.length === 0} />
           <button
@@ -298,8 +300,6 @@ export function NotebookPanel({
                   onClick={handleSave}
                   disabled={Boolean(pendingNote && !pendingNote.text && !noteContent.trim())}
                 >
-                  <Save className="h-3.5 w-3.5 mr-1" />
-                  {t("common.save")}
                   <Save className="h-3.5 w-3.5 mr-1" />
                   {t("common.save")}
                 </Button>
@@ -424,7 +424,7 @@ function HighlightNoteItem({
             <p className="text-sm text-foreground line-clamp-2">"{highlight.text}"</p>
           ) : (
             <p className="text-sm text-muted-foreground italic line-clamp-2">
-              {t("notebook.pageNoteBadge")}
+              {pageNoteLabel(highlight.cfi, t)}
             </p>
           )}
           {highlight.note && (
@@ -489,7 +489,7 @@ function HighlightItem({ highlight, onClick, onAddNote, onDelete }: HighlightIte
           <p className="text-sm text-foreground line-clamp-2">"{highlight.text}"</p>
         ) : (
           <p className="text-sm text-muted-foreground italic line-clamp-2">
-            {t("notebook.pageNoteBadge")}
+            {pageNoteLabel(highlight.cfi, t)}
           </p>
         )}
         {highlight.chapterTitle && (

--- a/packages/app/src/components/reader/ReaderView.tsx
+++ b/packages/app/src/components/reader/ReaderView.tsx
@@ -1673,6 +1673,19 @@ export function ReaderView({ bookId, tabId }: ReaderViewProps) {
     setSelection(null);
   }, [selection, bookId, highlights, readerTab?.chapterTitle]);
 
+  // Handle page-level note button — anchor a note to the current position so
+  // formats without usable text selection (e.g. PDF) can still take notes.
+  const handleAddPageNote = useCallback(() => {
+    const cfi = readerTab?.currentCfi;
+    if (!cfi) return;
+    useNotebookStore.getState().startNewNote({
+      text: "",
+      cfi,
+      chapterTitle: readerTab?.chapterTitle,
+      page: currentPage || undefined,
+    });
+  }, [readerTab?.currentCfi, readerTab?.chapterTitle, currentPage]);
+
   const handleCopy = useCallback(() => {
     if (selection?.text) navigator.clipboard.writeText(selection.text);
     setSelection(null);
@@ -2870,6 +2883,7 @@ export function ReaderView({ bookId, tabId }: ReaderViewProps) {
       {/* Notebook sidebar — LEFT side */}
       <NotebookSidebarWrapper
         bookId={bookId}
+        onAddPageNote={handleAddPageNote}
         onGoToCfi={navigateToCfi}
         onAddAnnotation={(cfi, color, note) => {
           foliateRef.current?.addAnnotation({
@@ -3214,6 +3228,7 @@ export function ReaderView({ bookId, tabId }: ReaderViewProps) {
 // Separate component to use notebook store hook
 function NotebookSidebarWrapper({
   bookId,
+  onAddPageNote,
   onGoToCfi,
   onAddAnnotation,
   onDeleteAnnotation,
@@ -3223,6 +3238,7 @@ function NotebookSidebarWrapper({
   onResizeEnd,
 }: {
   bookId: string;
+  onAddPageNote?: () => void;
   onGoToCfi: (cfi: string) => void;
   onAddAnnotation: (cfi: string, color: string, note?: string) => void;
   onDeleteAnnotation: (cfi: string) => void;
@@ -3250,6 +3266,7 @@ function NotebookSidebarWrapper({
       <NotebookPanel
         bookId={bookId}
         onClose={closeNotebook}
+        onAddPageNote={onAddPageNote}
         onGoToCfi={onGoToCfi}
         onAddAnnotation={onAddAnnotation}
         onDeleteAnnotation={onDeleteAnnotation}

--- a/packages/app/src/lib/reader/page-note.ts
+++ b/packages/app/src/lib/reader/page-note.ts
@@ -24,6 +24,6 @@ type LabelT = (key: string, options?: Record<string, unknown>) => string;
 export function pageNoteLabel(cfi: string, t: LabelT): string {
   const page = parseFakeCfiPage(cfi);
   return page
-    ? t("reader.notebook.pageNoteWithPage", { page })
-    : t("reader.notebook.pageNoteBadge");
+    ? t("notebook.pageNoteWithPage", { page })
+    : t("notebook.pageNoteBadge");
 }

--- a/packages/app/src/lib/reader/page-note.ts
+++ b/packages/app/src/lib/reader/page-note.ts
@@ -1,0 +1,29 @@
+/**
+ * Page-level note helpers.
+ *
+ * Page-level notes anchor to the current position. For fixed-layout books
+ * (PDF/CBZ) that position is a foliate "fake" section CFI — `epubcfi(/6/N)`
+ * where N = (pageIndex + 1) * 2 — so the page number can be recovered from
+ * the CFI for list labels. Reflowable books use real position CFIs, which
+ * carry no page number; their label falls back to the generic badge (the
+ * chapter title shown beneath provides the context).
+ */
+
+const FAKE_SECTION_CFI_RE = /^epubcfi\(\/6\/(\d+)\)$/;
+
+export function parseFakeCfiPage(cfi: string): number | null {
+  const match = FAKE_SECTION_CFI_RE.exec(cfi.trim());
+  if (!match) return null;
+  const page = Math.round(Number(match[1]) / 2);
+  return page > 0 ? page : null;
+}
+
+type LabelT = (key: string, options?: Record<string, unknown>) => string;
+
+/** List label for a page-level note: "第N页笔记" when the page is known. */
+export function pageNoteLabel(cfi: string, t: LabelT): string {
+  const page = parseFakeCfiPage(cfi);
+  return page
+    ? t("reader.notebook.pageNoteWithPage", { page })
+    : t("reader.notebook.pageNoteBadge");
+}

--- a/packages/core/src/i18n/locales/en/reader.json
+++ b/packages/core/src/i18n/locales/en/reader.json
@@ -113,6 +113,10 @@
     "emptyHint": "Select text in the book to highlight or add notes",
     "editNote": "Edit note",
     "addNoteBtn": "Add note",
+    "addPageNote": "Add page note",
+    "pageNoteBadge": "Page note",
+    "pageNotePage": "Page {{page}}",
+    "pageNoteNoPage": "Current position",
     "deleteHighlightBtn": "Delete highlight"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/en/reader.json
+++ b/packages/core/src/i18n/locales/en/reader.json
@@ -117,6 +117,7 @@
     "pageNoteBadge": "Page note",
     "pageNotePage": "Page {{page}}",
     "pageNoteNoPage": "Current position",
+    "pageNoteWithPage": "Note on page {{page}}",
     "deleteHighlightBtn": "Delete highlight"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/es/reader.json
+++ b/packages/core/src/i18n/locales/es/reader.json
@@ -113,6 +113,7 @@
     "pageNoteBadge": "Nota de página",
     "pageNotePage": "Página {{page}}",
     "pageNoteNoPage": "Posición actual",
+    "pageNoteWithPage": "Nota en la página {{page}}",
     "deleteHighlightBtn": "Eliminar subrayado"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/es/reader.json
+++ b/packages/core/src/i18n/locales/es/reader.json
@@ -109,6 +109,10 @@
     "emptyHint": "Selecciona texto en el libro para subrayar o agregar notas",
     "editNote": "Editar nota",
     "addNoteBtn": "Agregar nota",
+    "addPageNote": "Añadir nota de página",
+    "pageNoteBadge": "Nota de página",
+    "pageNotePage": "Página {{page}}",
+    "pageNoteNoPage": "Posición actual",
     "deleteHighlightBtn": "Eliminar subrayado"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/fr/reader.json
+++ b/packages/core/src/i18n/locales/fr/reader.json
@@ -113,6 +113,7 @@
     "pageNoteBadge": "Note de page",
     "pageNotePage": "Page {{page}}",
     "pageNoteNoPage": "Position actuelle",
+    "pageNoteWithPage": "Note page {{page}}",
     "deleteHighlightBtn": "Supprimer le surlignage"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/fr/reader.json
+++ b/packages/core/src/i18n/locales/fr/reader.json
@@ -109,6 +109,10 @@
     "emptyHint": "Sélectionnez du texte dans le livre pour surligner ou ajouter des notes",
     "editNote": "Modifier la note",
     "addNoteBtn": "Ajouter une note",
+    "addPageNote": "Ajouter une note de page",
+    "pageNoteBadge": "Note de page",
+    "pageNotePage": "Page {{page}}",
+    "pageNoteNoPage": "Position actuelle",
     "deleteHighlightBtn": "Supprimer le surlignage"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/ja/reader.json
+++ b/packages/core/src/i18n/locales/ja/reader.json
@@ -113,6 +113,7 @@
     "pageNoteBadge": "ページメモ",
     "pageNotePage": "{{page}} ページ",
     "pageNoteNoPage": "現在位置",
+    "pageNoteWithPage": "{{page}} ページのメモ",
     "deleteHighlightBtn": "ハイライトを削除"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/ja/reader.json
+++ b/packages/core/src/i18n/locales/ja/reader.json
@@ -109,6 +109,10 @@
     "emptyHint": "本のテキストを選択してハイライトやノートを追加",
     "editNote": "ノートを編集",
     "addNoteBtn": "ノートを追加",
+    "addPageNote": "ページメモを追加",
+    "pageNoteBadge": "ページメモ",
+    "pageNotePage": "{{page}} ページ",
+    "pageNoteNoPage": "現在位置",
     "deleteHighlightBtn": "ハイライトを削除"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/ko/reader.json
+++ b/packages/core/src/i18n/locales/ko/reader.json
@@ -113,6 +113,7 @@
     "pageNoteBadge": "페이지 메모",
     "pageNotePage": "{{page}}쪽",
     "pageNoteNoPage": "현재 위치",
+    "pageNoteWithPage": "{{page}}쪽 메모",
     "deleteHighlightBtn": "하이라이트 삭제"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/ko/reader.json
+++ b/packages/core/src/i18n/locales/ko/reader.json
@@ -109,6 +109,10 @@
     "emptyHint": "책에서 텍스트를 선택하여 하이라이트하거나 노트를 추가하세요",
     "editNote": "노트 편집",
     "addNoteBtn": "노트 추가",
+    "addPageNote": "페이지 메모 추가",
+    "pageNoteBadge": "페이지 메모",
+    "pageNotePage": "{{page}}쪽",
+    "pageNoteNoPage": "현재 위치",
     "deleteHighlightBtn": "하이라이트 삭제"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/zh-TW/reader.json
+++ b/packages/core/src/i18n/locales/zh-TW/reader.json
@@ -109,6 +109,10 @@
     "emptyHint": "選取書中文字進行醒目標示或新增筆記",
     "editNote": "編輯筆記",
     "addNoteBtn": "新增筆記",
+    "addPageNote": "新增頁級筆記",
+    "pageNoteBadge": "頁級筆記",
+    "pageNotePage": "第 {{page}} 頁",
+    "pageNoteNoPage": "當前位置",
     "deleteHighlightBtn": "刪除醒目標示"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/zh-TW/reader.json
+++ b/packages/core/src/i18n/locales/zh-TW/reader.json
@@ -113,6 +113,7 @@
     "pageNoteBadge": "頁級筆記",
     "pageNotePage": "第 {{page}} 頁",
     "pageNoteNoPage": "當前位置",
+    "pageNoteWithPage": "第 {{page}} 頁筆記",
     "deleteHighlightBtn": "刪除醒目標示"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/zh/reader.json
+++ b/packages/core/src/i18n/locales/zh/reader.json
@@ -113,6 +113,10 @@
     "emptyHint": "选择书中文本进行高亮或添加笔记",
     "editNote": "编辑笔记",
     "addNoteBtn": "添加笔记",
+    "addPageNote": "添加页级笔记",
+    "pageNoteBadge": "页级笔记",
+    "pageNotePage": "第 {{page}} 页",
+    "pageNoteNoPage": "当前位置",
     "deleteHighlightBtn": "删除高亮"
   },
   "editor": {

--- a/packages/core/src/i18n/locales/zh/reader.json
+++ b/packages/core/src/i18n/locales/zh/reader.json
@@ -117,6 +117,7 @@
     "pageNoteBadge": "页级笔记",
     "pageNotePage": "第 {{page}} 页",
     "pageNoteNoPage": "当前位置",
+    "pageNoteWithPage": "第 {{page}} 页笔记",
     "deleteHighlightBtn": "删除高亮"
   },
   "editor": {

--- a/packages/core/src/stores/notebook-store.ts
+++ b/packages/core/src/stores/notebook-store.ts
@@ -5,8 +5,10 @@ import { create } from "zustand";
 import type { Highlight } from "../types";
 
 export interface PendingNote {
-  /** Selected text to annotate */
+  /** Selected text to annotate (empty string = page-level note) */
   text: string;
+  /** Page number for page-level notes (fixed-layout books) */
+  page?: number;
   /** CFI location */
   cfi: string;
   /** Chapter title for context */


### PR DESCRIPTION
## 问题

添加笔记的现有入口只有"划词"：选中文字 → 弹出菜单 → 高亮/添加笔记。但部分格式不支持这个流程——**PDF 的选择弹窗中高亮/笔记按钮被禁用**（`SelectionPopover` 中 `disabled: isPdf` 的格式门槛），扫描版 PDF 更是没有文字层可选。结果：这类格式的书籍**完全无法添加笔记**。

## 方案：页级笔记兜底

在**阅读器的笔记本面板**头部新增"添加页级笔记"按钮（所有格式可见）：

- 点击后打开内联笔记编辑器，**锚定当前阅读位置**（当前页/当前 CFI）；
- 保存后列表显示"**第 N 页笔记**"（N 为记录时的页码），**点击笔记跳回记录时的页面**；
- EPUB 同样支持（锚定为当前位置 CFI，点击跳回对应位置）。

<img width="1002" height="762" alt="image" src="https://github.com/user-attachments/assets/df17831f-0ea4-432b-b0f3-11c1308406ba" />


## 实现要点

1. **零数据库 / 零同步格式改动**：复用现有"高亮 + note"存储（`highlights` 表，本就在同步范围内）。页级笔记 = `text` 为空串、`cfi` 为当前位置的 Highlight 行；
2. **页码显示**：PDF 等固定版式的定位是 foliate 的 fake CFI（`epubcfi(/6/N)`，N=(页码)×2），可**反向解析出页码**用于列表标题（`第 N 页笔记`）；EPUB 等流式格式的 CFI 不含页码，回退显示通用占位（下方的章节名提供上下文）；
3. **编辑器上下文适配**：页级笔记创建时隐藏"选中文本"预览，改为显示"页级笔记 · 第 N 页 · 章节名"；空内容的页级笔记**禁止保存**（避免产生列表中不可见的空行）；
4. **列表渲染兜底**：`highlight.text` 为空的条目在笔记本面板和首页笔记页显示斜体占位（"页级笔记" / "第 N 页笔记"），不再渲染空引号；
5. 选择弹窗的 `isPdf` 门槛**保持不变**（PDF 划词路径质量不稳，本 PR 不放开；页级按钮是兜底入口）。

## 验证

- core 全量 584 个单元测试通过，改动文件 lint 零错误，tsc 通过；
- 真机验证：EPUB 与 PDF 分别创建页级笔记 → 列表显示"第 N 页笔记" → 点击跳回记录时的页面（PDF 跳页、EPUB 跳位置）→ 首页笔记页占位渲染与跳转正常。

## 已知小瑕疵

导出笔记时，页级笔记的"引用文本"渲染为空引号（导出器尚未对空 text 做占位处理），后续可在导出器过滤。


**注：本次代码修改和PR信息由AI生成**
