### PR TITLE
fix(reader): make PDF edge taps page-turn on first click

### DIFF
--- a/packages/app/src/components/reader/ReaderView.tsx
+++ b/packages/app/src/components/reader/ReaderView.tsx
@@ -308,18 +308,6 @@ function useAutoHideControls(
           rightNavStart,
         });
 
-        if (isFixedLayout && !isVisible) {
-          console.log("[ReaderTap][reader:action]", {
-            bookKey,
-            source,
-            action: "show-controls",
-            fraction,
-            isDoublePage,
-          });
-          showAndScheduleHide();
-          return;
-        }
-
         if (isScrollMode) {
           toggleControls();
           return;
@@ -372,7 +360,6 @@ function useAutoHideControls(
     isDoublePage,
     isScrollMode,
     isFixedLayout,
-    isVisible,
   ]);
 
   // Mouse enter/leave handlers for toolbar area


### PR DESCRIPTION
 ## 问题现象

    桌面端阅读 PDF 格式书籍时，点击屏幕左右区域无法直接翻页：第一次点击只弹出工具栏菜单，必须再点第二次才会翻页。

    - 仅 PDF 复现（PDF 属于 fixed-layout 固定版面书籍，CBZ 同理）
    - EPUB 正常，点击左右区域直接翻页

    期望行为：点击左右区域翻页、点击中间区域显示/隐藏菜单，且第一次点击就生效。

 ## 根因定位

    问题出在 packages/app/src/components/reader/ReaderView.tsx 的 useAutoHideControls 中，消息处理回调里针对固定版面书籍的一段提前返回：

    js
    if (isFixedLayout && !isVisible) {
      showAndScheduleHide();
      return;
    }


    这段逻辑位于点击分区判定之前。工具栏在 2 秒后自动隐藏，所以 isVisible 平时为 false，导致：

    1. 第一次点击左右区域 → 命中该分支 → 只调用 showAndScheduleHide() 显示菜单后 return，根本没有走到 onPrev / onNext，页面不翻。这正是"先显示菜单"的来源。
    2. 第二次点击 → 此时 isVisible 已为 true，该分支不再命中 → 流程才落到下面的左右/中间分区逻辑 → 翻页成功。

    EPUB 不受影响，因为 EPUB 的 isFixedLayout 为 false，从一开始就不会进入这个分支，点击分区逻辑正常执行。

    即：这段为固定版面加的特殊分支短路了后续的点击分区逻辑，使得 PDF 的首次点击语义与 EPUB 不一致。

    ## 修复方案

    删除该提前返回分支，让 PDF/CBZ 与 EPUB 共用同一套点击分区逻辑（左侧区域上一页、右侧区域下一页、中间区域切换菜单），首次点击即生效。

    同时移除该 effect 依赖数组中已不再被使用的 isVisible 依赖项。

    改动范围：单文件，纯删除，13 行。

    diff
    -        if (isFixedLayout && !isVisible) {
    -          console.log("[ReaderTap][reader:action]", {
    -            bookKey,
    -            source,
    -            action: "show-controls",
    -            fraction,
    -            isDoublePage,
    -          });
    -          showAndScheduleHide();
    -          return;
    -        }
    -
             if (isScrollMode) {
    @@ -372,7 +360,6 @@ function useAutoHideControls(
         isDoublePage,
         isScrollMode,
         isFixedLayout,
    -    isVisible,
       ]);


   ## 影响面与风险

    - 该分支是唯一依赖 isFixedLayout && !isVisible 的提前返回，仓库内无其他逻辑依赖它，删除后无副作用。
    - 修复后 PDF 的交互与其他格式一致；菜单仍可通过点击中间区域或鼠标移入工具栏区域显示，未削弱原有能力。
    - 未改动 EPUB、CBZ 之外的任何路径行为。

   ## 验证

    - pnpm run test：80 个文件、584 个用例全部通过
    - pnpm run build：构建成功（仅存量 chunk 体积提示，非本次改动引入）
    - tsc --noEmit -p packages/app/tsconfig.json：exit 0
    - Lint：与基线一致，无新增问题（改动文件在改动前后均为 19 个存量错误；仓库级 lint 在 HEAD 时即为红，本次改动未使其增加）


**注：本次代码修改和PR信息由AI生成**